### PR TITLE
Documentation: Update example code on Gatsby manual setup page.

### DIFF
--- a/content/docs/gatsby/manual-setup.md
+++ b/content/docs/gatsby/manual-setup.md
@@ -44,7 +44,7 @@ module.exports = {
       resolve: 'gatsby-plugin-tinacms',
       options: {
         sidebar: {
-          // hidden: process.env.NODE_ENV === "production",
+          hidden: process.env.NODE_ENV === "production",
           position: "displace",
         },
         plugins: [

--- a/content/docs/gatsby/manual-setup.md
+++ b/content/docs/gatsby/manual-setup.md
@@ -43,6 +43,10 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-tinacms',
       options: {
+        sidebar: {
+          // hidden: process.env.NODE_ENV === "production",
+          position: "displace",
+        },
         plugins: [
           // We'll add some Tinacms plugins in the next step.
         ],


### PR DESCRIPTION
This adds one more config item to the existing code sample on the [Gatsby manual setup](https://tinacms.org/docs/gatsby/manual-setup) page, which appears to be required.

When following the current documentation, adding the `gatsby-plugin-tinacms` plugin to your `gatsby-config.js` results in this error: 

`Unhandled Rejection (TypeError): Cannot read property 'position' of undefined`

Adding plugin options for sidebar position will fix this and meet the description of this first step of manual setup.

I've commented the `hidden` key out since it's not required for things to work, but might make sense to keep since it hints at how you'd probably want this configured for a real project.

Hope this helps!




