### PR TITLE
handles invalid auth (e.g. revoked app access)

### DIFF
--- a/open-authoring/OpenAuthoringModalContainer.tsx
+++ b/open-authoring/OpenAuthoringModalContainer.tsx
@@ -33,6 +33,7 @@ export const OpenAuthoringModalContainer = ({ previewError }: Props) => {
   useEffect(() => {
     if (previewError) {
       openAuthoring.updateAuthChecks() //recheck if we need to open auth window as result of error
+      fetch(`/api/reset-preview`) // clear preview cookies
     }
   }, [previewError])
 

--- a/utils/github/getDecodedData.ts
+++ b/utils/github/getDecodedData.ts
@@ -11,11 +11,21 @@ const getDecodedData = async (repoFullName, headBranch, path, accessToken) => {
     path,
     accessToken
   )
-
-  if ((response?.response?.status || 0) == 404) {
-    throw new ContentNotFoundError(
-      'Content not found. Your fork may have been deleted.'
-    )
+  
+  const errorStatus = response?.response?.status || 200
+  if (errorStatus != 200) {
+    switch (errorStatus) {
+      case 404: {
+        throw new ContentNotFoundError(
+          'Content not found. Your fork may have been deleted.'
+        )
+      }
+      case 401: {
+        throw new ContentNotFoundError(
+          'Authentication invalid. You will need to re-authenticate.'
+        )
+      }
+    }
   }
 
   return { ...data, content: b64DecodeUnicode(data.content) }


### PR DESCRIPTION
- handles 401 unauthorized get content error
- when an error is flagged in the modal it clears the preview cookies so that on refresh if the user doesn't follow the flow it kicks em back to a normal viewing mode (also makes it easy to add a cancel auth button in the future (just refresh page)).