### PR TITLE
RFC for linking monorepo and app

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,5 @@
 const withSvgr = require('next-svgr')
+const path = require('path')
 require('dotenv').config()
 
 const dummyMailchimpEndpoint =
@@ -15,13 +16,24 @@ module.exports = withSvgr({
     GTM_ID: process.env.GTM_ID,
     GITHUB_CLIENT_ID: process.env.GITHUB_CLIENT_ID,
     REPO_FULL_NAME: process.env.REPO_FULL_NAME,
-    BASE_BRANCH: process.env.BASE_BRANCH
+    BASE_BRANCH: process.env.BASE_BRANCH,
   },
   exportTrailingSlash: true,
   exportPathMap: async function() {
     return {}
   },
   webpack(config) {
+    config.resolve.alias['react'] = path.resolve('./node_modules/react')
+    config.resolve.alias['react-dom'] = path.resolve('./node_modules/react-dom')
+    config.resolve.alias['styled'] = path.resolve('./node_modules/styled')
+    config.resolve.alias['@tinacms'] = path.resolve(
+      '../tinacms/packages/@tinacms'
+    )
+    config.resolve.alias['tinacms'] = path.resolve(
+      '../tinacms/packages/tinacms'
+    )
+    console.log(config.resolve.alias)
+
     config.module.rules.push({
       test: /\.md$/,
       use: 'raw-loader',

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,6 @@
 const withSvgr = require('next-svgr')
 const path = require('path')
+const fs = require('fs')
 require('dotenv').config()
 
 const dummyMailchimpEndpoint =
@@ -22,17 +23,24 @@ module.exports = withSvgr({
   exportPathMap: async function() {
     return {}
   },
-  webpack(config) {
-    config.resolve.alias['react'] = path.resolve('./node_modules/react')
-    config.resolve.alias['react-dom'] = path.resolve('./node_modules/react-dom')
-    config.resolve.alias['styled'] = path.resolve('./node_modules/styled')
-    config.resolve.alias['@tinacms'] = path.resolve(
-      '../tinacms/packages/@tinacms'
-    )
-    config.resolve.alias['tinacms'] = path.resolve(
-      '../tinacms/packages/tinacms'
-    )
-    console.log(config.resolve.alias)
+  webpack(config, { dev }) {
+    if (dev) {
+      // const pathToTina = '../tinacms'
+      const pathToTinaPackages = '../tinacms/packages'
+      config.resolve.alias['react'] = path.resolve('./node_modules/react')
+      config.resolve.alias['react-dom'] = path.resolve(
+        './node_modules/react-dom'
+      )
+      config.resolve.alias['styled'] = path.resolve('./node_modules/styled')
+      fs.readdir(pathToTinaPackages, (err, files) => {
+        console.log(files)
+        files.forEach(packageBase => {
+          config.resolve.alias[packageBase] = path.resolve(
+            `${pathToTinaPackages}/${packageBase}`
+          )
+        })
+      })
+    }
 
     config.module.rules.push({
       test: /\.md$/,


### PR DESCRIPTION
Pulled up some notes I mentioned earlier and got this working for the most part. I ran into an issue when trying to match **all** tina packages but I think it's some config tweaks needed (see below about potential issues) - but it works well enough to put it up here for discussion.

To see the simplest form of this working in action:
```js
  // in tinacms.org next.config.js
  webpack(config) {
    config.resolve.alias['react'] = path.resolve('./node_modules/react')
    config.resolve.alias['react-dom'] = path.resolve('./node_modules/react-dom')
    config.resolve.alias['styled'] = path.resolve('./node_modules/styled')
    config.resolve.alias['@tinacms/styles'] = path.resolve(
      '../tinacms/packages/@tinacms/styles' // just trying this with the styles package
    )

    // keep the rest as-is
  },
```
* Run the `watch` command in the monorepo
* Run the `dev` command in the next.js repo
* Change a style in the `@tinacms/styles` repo and wait - the next.js process should pick up the change and refresh

We can probably provide a webpack plugin which takes a single argument of either the relative or absolute path to the monorepo and sets up the aliases - from there we know which singleton packages tina is relying on so things like `react` and `styled-components` need to be aliased - probably will want to keep a manifest somewhere that indicates which packages should be aliased. 

Webpack will pick up any changes and refresh the next.js app for you. You’ll have to be running watch on the monorepo and you may need to do `npm run build` before `npm run watch` - this is because the consuming app (tinacms.org) has a webpack config which look for files according to each package's `package.json` and `npm run watch` won't build those files unless you've saved (it seems) - so a package that is depended on by another package won't be built yet. But after you've built once you can work with `npm run watch` after that.

### What it does
I consider this a hack

If you point to a directory the alias will match anything after that directory and follow instructions from any `package.json` it finds in there, so `'../tinacms/packages/@tinacms/styles'` will only match the styles package - so it's key needs to reflect that:

    config.resolve.alias['@tinacms/styles'] = path.resolve(
      '../tinacms/packages/@tinacms/styles'
    )

However you can do broader matches - and some form of this is likely what we'll want

    config.resolve.alias['@tinacms'] = path.resolve(
      '../tinacms/packages/@tinacms'
    )
    config.resolve.alias['tinacms'] = path.resolve(
      '../tinacms/packages/tinacms'
    )


A config like this would tell webpack that when they find a package that starts with `@tinacms/<my-package-name>` look for it in `../tinacms/packages/@tinacms/<my-package-name>`

Note that we also have to alias any packages will rely on a single instance to work:

    config.resolve.alias['react'] = path.resolve('./node_modules/react')
    config.resolve.alias['react-dom'] = path.resolve('./node_modules/react-dom')
    config.resolve.alias['styled'] = path.resolve('./node_modules/styled')

This ensures that any reference to `react` will follow this path and not one from the monorepo's `node_modules` directory.

## Potential issues
Any references to files in an adjacent `node_modules` directory may break - for example if we reference react by doing `require('./node_modules/react`) - that's likely to break since node won't be able to find it - this is probably ok for the most part since that's an antipattern that we should fix. I ran into this from this [react-core](https://github.com/tinacms/tinacms/blob/c479d8cac9098795da25980c7fb6d9e732c59d12/packages/@tinacms/react-core) package 

This will work regardless of what is in your app's `package.json` - so if you don't have any tina packages in your `packages.json` the alias won't know any better and builds will likely continue to work - this can lead to inconsistencies, especially if you have a stale version in dependencies but are expecting the latest version (which is what you'd likely be working)

You'll want to be sure not to have this turned on in `production` mode as the relative tina monorepo won't be there.