### PR TITLE
Improve docs dropdown behavior

### DIFF
--- a/components/ui/DocsNav.tsx
+++ b/components/ui/DocsNav.tsx
@@ -29,29 +29,35 @@ export const NavSection = (section: NavSection) => {
     setExpanded(menuIsActive(section, currentPath))
   }, [currentPath])
 
+  const hasChildren = section.items && section.items.length > 0
+
   return (
     <NavItem key={section.slug} open={highlighted}>
-      <NavItemHeader>
-        {section.slug ? (
+      <NavItemHeader onClick={() => setExpanded(!expanded)}>
+        {section.slug && !hasChildren ? (
           <DynamicLink href={section.slug} passHref>
             <NavSectionTitle as="a" open={highlighted}>
               {section.title}
             </NavSectionTitle>
           </DynamicLink>
         ) : (
-          <NavSectionTitle
-            open={highlighted}
-            onClick={() => setExpanded(!expanded)}
-          >
-            {section.title}
-          </NavSectionTitle>
+          <NavSectionTitle open={highlighted}>{section.title}</NavSectionTitle>
         )}
-        {section.items && section.items.length > 0 && <RightArrowSvg />}
+        {hasChildren && <RightArrowSvg />}
       </NavItemHeader>
-      {section.items && section.items.length > 0 && (
+      {hasChildren && (
         <SubNav>
+          {section.slug && (
+            <NavSection
+              key={`${section.id}-overview`}
+              id={section.id}
+              slug={section.slug}
+              title="Overview"
+              items={null}
+            />
+          )}
           {(section.items || []).map(item => (
-            <NavSection key={section.id} {...item} />
+            <NavSection key={`${section.id}-${item.id}`} {...item} />
           ))}
         </SubNav>
       )}

--- a/components/ui/DocsNav.tsx
+++ b/components/ui/DocsNav.tsx
@@ -18,30 +18,32 @@ export const NavSection = (section: NavSection) => {
   const router = useRouter()
   const currentPath = router.asPath
   const isCurrentPage = useMemo(() => {
-    if (section.slug && currentPath.includes(section.slug)) {
+    if (section.slug && currentPath === section.slug) {
       return true
     }
   }, [section.slug, currentPath])
   const [expanded, setExpanded] = useState(menuIsActive(section, currentPath))
-  const highlighted = isCurrentPage || expanded
 
   useEffect(() => {
     setExpanded(menuIsActive(section, currentPath))
   }, [currentPath])
 
   const hasChildren = section.items && section.items.length > 0
+  const highlighted = isCurrentPage || (hasChildren && expanded)
 
   return (
     <NavItem key={section.slug} open={expanded}>
       <NavItemHeader onClick={() => setExpanded(!expanded)}>
         {section.slug && !hasChildren ? (
           <DynamicLink href={section.slug} passHref>
-            <NavSectionTitle as="a" open={expanded}>
+            <NavSectionTitle as="a" highlighted={highlighted}>
               {section.title}
             </NavSectionTitle>
           </DynamicLink>
         ) : (
-          <NavSectionTitle open={highlighted}>{section.title}</NavSectionTitle>
+          <NavSectionTitle highlighted={highlighted}>
+            {section.title}
+          </NavSectionTitle>
         )}
         {hasChildren && <RightArrowSvg />}
       </NavItemHeader>
@@ -66,11 +68,14 @@ export const NavSection = (section: NavSection) => {
 }
 
 const menuIsActive = (section: NavSection, currentPath: string) => {
+  if (section.slug && currentPath.includes(section.slug)) {
+    return true
+  }
   return (
     section.items &&
-    section.items.reduce((isActive, section) => {
-      if (section.slug && currentPath.includes(section.slug)) {
-        return true
+    section.items.reduce((isActive, subsection) => {
+      if (subsection.slug && currentPath.includes(subsection.slug)) {
+        return subsection.slug !== section.slug
       }
       return isActive
     }, false)
@@ -184,7 +189,7 @@ const NavItemHeader = styled.div`
 `
 
 interface NavSectionTitleProps {
-  open: boolean
+  highlighted: boolean
 }
 
 const NavSectionTitle = styled.span<NavSectionTitleProps>`
@@ -200,7 +205,7 @@ const NavSectionTitle = styled.span<NavSectionTitleProps>`
   }
 
   ${props =>
-    props.open &&
+    props.highlighted &&
     css`
       color: var(--color-primary);
     `};

--- a/components/ui/DocsNav.tsx
+++ b/components/ui/DocsNav.tsx
@@ -32,11 +32,11 @@ export const NavSection = (section: NavSection) => {
   const hasChildren = section.items && section.items.length > 0
 
   return (
-    <NavItem key={section.slug} open={highlighted}>
+    <NavItem key={section.slug} open={expanded}>
       <NavItemHeader onClick={() => setExpanded(!expanded)}>
         {section.slug && !hasChildren ? (
           <DynamicLink href={section.slug} passHref>
-            <NavSectionTitle as="a" open={highlighted}>
+            <NavSectionTitle as="a" open={expanded}>
               {section.title}
             </NavSectionTitle>
           </DynamicLink>


### PR DESCRIPTION
- adds an "Overview" link as first child if nav item has both a slug and children, so parent item can be used exclusively to toggle nav
- fixes highlight logic so highlights remain correct
- fixes expand logic so parent menus can be collapsed even if currently viewing a child page