### PR TITLE
Shortcode updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Source code for the tinacms.org website.
 
 This site supports shortcodes in markdown content via [remark-shortcodes](https://github.com/djm/remark-shortcodes).
 
-Shortcodes must be written as React components. To add a shortcode, export it from `utils/shortcodes.ts`.
+Shortcodes must be written as React components. To add a shortcode, export it from `utils/shortcodes.tsx`.
 
 ```jsx
 export function MyShortcode({ textContent }) {

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-Tina 🤝 Next.js
+# TinaCMS.org
+
+Source code for the tinacms.org website.
+
+## Shortcodes
+
+This site supports shortcodes in markdown content via [remark-shortcodes](https://github.com/djm/remark-shortcodes).
+
+Shortcodes must be written as React components. To add a shortcode, export it from `utils/shortcodes.ts`.
+
+```jsx
+export function MyShortcode({ textContent }) {
+  return <div>{textContent}</div>
+}
+```
+
+Call the shortcode in your content by writing the name of the component encased in double curly braces. Key-value pairs included in the shortcode will be passed to your component as props.
+
+```
+{{ MyShortcode textContent="Example shortcode" }}
+```
+
+### Shortcode Limitations
+
+Shortcodes must be standalone elements; "wrapping" shortcodes will not work.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Source code for the tinacms.org website.
 
 ## Shortcodes
 
-This site supports shortcodes in markdown content via [remark-shortcodes](https://github.com/djm/remark-shortcodes).
+This site supports shortcodes in Markdown content via [remark-shortcodes](https://github.com/djm/remark-shortcodes).
 
 Shortcodes must be written as React components. To add a shortcode, export it from `utils/shortcodes.tsx`.
 

--- a/components/layout/MarkdownContent.tsx
+++ b/components/layout/MarkdownContent.tsx
@@ -94,7 +94,7 @@ export function MarkdownContent({
         heading: WithHeadings,
         shortcode: ShortcodeRenderer,
       }}
-      plugins={[[shortcodes]]}
+      plugins={[[shortcodes, { startBlock: '{{', endBlock: '}}' }]]}
     />
   )
 }

--- a/content/docs/cms/alerts.md
+++ b/content/docs/cms/alerts.md
@@ -12,16 +12,16 @@ Display an alert by calling one of the **alert level methods** on the CMS object
 cms.alerts.info('This is an alert')
 ```
 
-[[ AlertTest type="info" message="This is an alert"]]
+{{ AlertTest type="info" message="This is an alert"}}
 
 ## Alert Levels
 
 The CMS supports four alert levels: `success`, `info`, `warn`, and `error`. Each alert level is its own method on `cms.alerts`; call the corresponding method with your message to trigger the appropriate alert.
 
-[[ AlertTest type="success" message="This is a 'success' alert" buttonText="Success"]]
-[[ AlertTest type="info" message="This is an 'info' alert" buttonText="Info"]]
-[[ AlertTest type="warn" message="This is a 'warn' alert" buttonText="Warn"]]
-[[ AlertTest type="error" message="This is an 'error' alert" buttonText="Error"]]
+{{ AlertTest type="success" message="This is a 'success' alert" buttonText="Success"}}
+{{ AlertTest type="info" message="This is an 'info' alert" buttonText="Info"}}
+{{ AlertTest type="warn" message="This is a 'warn' alert" buttonText="Warn"}}
+{{ AlertTest type="error" message="This is an 'error' alert" buttonText="Error"}}
 
 ## Alert Timeout
 
@@ -31,7 +31,7 @@ You can also optionally pass in a _timeout_ argument that specifies the message 
 cms.alerts.info('This alert will hang around a little longer', 5000)
 ```
 
-[[ AlertTest type="info" message="This alert will hang around a little longer", timeout="5000"]]
+{{ AlertTest type="info" message="This alert will hang around a little longer", timeout="5000"}}
 
 ## Usage Example
 


### PR DESCRIPTION
- change syntax from default `[[ Shortcode ]]` to Jekyll-style `{{ Shortcode }}` so they aren't escaped by the WYSIWYG
- update readme to explain shortcodes