### PR TITLE
Github env is only required in serverless functions, and not at build…

### DIFF
--- a/now.json
+++ b/now.json
@@ -10,7 +10,6 @@
   "build": {
     "env": {
       "GITHUB_CLIENT_ID": "942232a549642aea2bbf",
-      "GITHUB_CLIENT_SECRET": "@github_client_secret",
       "REPO_FULL_NAME": "tinacms/tinacms.org",
       "USE_CONTENT_API": "true",
       "BASE_BRANCH": "master",


### PR DESCRIPTION
Github env is only required in serverless functions, and not at build-time. Once removed, we can safely authorize pull requests that are failing due to: "Need authorization to deploy": https://github.com/tinacms/tinacms.org/pull/249

For Zeit env details, see: https://zeit.co/docs/v2/serverless-functions/env-and-secrets#providing-environment-variables