### PR TITLE
Error cleanup

### DIFF
--- a/components/layout/OpenAuthoringSiteForm.tsx
+++ b/components/layout/OpenAuthoringSiteForm.tsx
@@ -19,7 +19,6 @@ import { useLocalStorageCache } from '../../utils/plugins/useLocalStorageCache'
 
 interface Props extends InlineFormProps {
   editMode: boolean
-  error?: OpenAuthoringError
   children: any
   path: string
 }
@@ -33,13 +32,7 @@ const useFormState = (form, subscription) => {
   return state
 }
 
-const OpenAuthoringSiteForm = ({
-  form,
-  editMode,
-  error,
-  path,
-  children,
-}: Props) => {
+const OpenAuthoringSiteForm = ({ form, editMode, path, children }: Props) => {
   const [interpretedError, setInterpretedError] = useState(null)
   const cms = useCMS()
   const formState = useFormState(form, { dirty: true, submitting: true })
@@ -172,14 +165,6 @@ const OpenAuthoringSiteForm = ({
 
     return undecorateSaveListener
   }, [form])
-
-  useEffect(() => {
-    ;(async () => {
-      if (error) {
-        updateUIWithError(error)
-      }
-    })()
-  }, [error])
 
   return (
     <InlineForm

--- a/open-authoring/OpenAuthoringModalContainer.tsx
+++ b/open-authoring/OpenAuthoringModalContainer.tsx
@@ -13,7 +13,7 @@ interface Props {
   openAuthoringErrorUI?: OpenAuthoringContextualErrorUI
 }
 
-export const OpenAuthoringModalContainer = ({ ...props }: Props) => {
+export const OpenAuthoringModalContainer = (props: Props) => {
   const [authPopupDisplayed, setAuthPopupDisplayed] = useState(false)
   const [openAuthoringErrorUI, setOpenAuthoringErrorUI] = useState(
     props.openAuthoringErrorUI
@@ -61,7 +61,6 @@ export const OpenAuthoringModalContainer = ({ ...props }: Props) => {
 
   useEffect(() => {
     if (openAuthoringErrorUI) {
-      setOpenAuthoringErrorUI(openAuthoringErrorUI)
       openAuthoring.updateAuthChecks() //recheck if we need to open auth window as result of error
     }
   }, [openAuthoringErrorUI])

--- a/open-authoring/OpenAuthoringModalContainer.tsx
+++ b/open-authoring/OpenAuthoringModalContainer.tsx
@@ -3,7 +3,6 @@ import { ActionableModal } from '../components/ui'
 import { startAuthFlow } from './authFlow'
 import { useOpenAuthoring } from '../components/layout/OpenAuthoring'
 import OpenAuthoringContextualErrorUI from './OpenAuthoringContextualErrorUI'
-import getErrorUIFrom from './error-interpreter'
 
 /*
 TODO:
@@ -12,13 +11,9 @@ Otherwise it's a bit weird to sometimes interpret it outside this contet, and so
 */
 interface Props {
   openAuthoringErrorUI?: OpenAuthoringContextualErrorUI
-  openAuthoringError?
 }
 
-export const OpenAuthoringModalContainer = ({
-  openAuthoringError,
-  ...props
-}: Props) => {
+export const OpenAuthoringModalContainer = ({ ...props }: Props) => {
   const [authPopupDisplayed, setAuthPopupDisplayed] = useState(false)
   const [openAuthoringErrorUI, setOpenAuthoringErrorUI] = useState(
     props.openAuthoringErrorUI
@@ -36,17 +31,6 @@ export const OpenAuthoringModalContainer = ({
     )
     setAuthPopupDisplayed(false)
   }
-
-  useEffect(() => {
-    ;(async () => {
-      if (openAuthoringError) {
-        const contextualError = await getErrorUIFrom(openAuthoringError)
-        if (contextualError.asModal) {
-          setOpenAuthoringErrorUI(contextualError)
-        }
-      }
-    })()
-  }, [openAuthoringError])
 
   useEffect(() => {
     if (window.location.href.includes('autoAuth')) {

--- a/open-authoring/OpenAuthoringModalContainer.tsx
+++ b/open-authoring/OpenAuthoringModalContainer.tsx
@@ -13,6 +13,13 @@ interface Props {
   openAuthoringErrorUI?: OpenAuthoringContextualErrorUI
 }
 
+/*
+  TODO - This modal container is responsible for multiple things:
+  - authPopup on initial load,
+  - responding to & interpreting errors
+
+  It should probably be more of a dummy modal component, and move that logic elsewhere
+*/
 export const OpenAuthoringModalContainer = (props: Props) => {
   const [authPopupDisplayed, setAuthPopupDisplayed] = useState(false)
   const [openAuthoringErrorUI, setOpenAuthoringErrorUI] = useState(

--- a/open-authoring/error-interpreter/index.ts
+++ b/open-authoring/error-interpreter/index.ts
@@ -1,48 +1,57 @@
-import OpenAuthoringError from "../OpenAuthoringError"
-import OpenAuthoringContextualErrorUI from "../OpenAuthoringContextualErrorUI"
-import { enterAuthFlow, refresh } from "./actions"
-import interpretClientError from "./client-side"
-import interpretServerError from "./server-side"
+import OpenAuthoringError from '../OpenAuthoringError'
+import OpenAuthoringContextualErrorUI from '../OpenAuthoringContextualErrorUI'
+import { enterAuthFlow, refresh } from './actions'
+import interpretClientError from './client-side'
+import interpretServerError from './server-side'
 
-export default async function getErrorUIFrom(error: OpenAuthoringError) : Promise<OpenAuthoringContextualErrorUI> {
-    if (!error || !error.code) {
-        console.warn("Error Interpreter: called without an error")
-        const message = error?.message || "An error occured."
-        return new OpenAuthoringContextualErrorUI(
-            true, // should it be presented as a modal? (if not present a toast)
-            "Error", // title
-            message, // message (the only thing a toast will present)
-            [{ 
-                message: "Continue",
-                action: enterAuthFlow
-            },
-            { 
-                message: "Cancel",
-                action: refresh
-            }] // Action buttons
-        )
-    }
-    
-    switch (parseInt(error.code.toString()[0])) {
-        case 4: {
-            return await interpretClientError(error)
-        }
-        case 5: {
-            return interpretServerError(error)
-        }
-    }
-    console.warn("Error Interpreter: Could not interpret error " + error.code)
+export default async function getErrorUIFrom(
+  error: OpenAuthoringError
+): Promise<OpenAuthoringContextualErrorUI> {
+  if (!error || !error.code) {
+    console.warn('Error Interpreter: called without an error')
+
+    console.log(error)
+
+    const message = error?.message || 'An error occured.'
     return new OpenAuthoringContextualErrorUI(
-        true,
-        "Error " + error.code,
-        error.message,
-        [{ 
-            message: "Continue",
-            action: enterAuthFlow
+      true, // should it be presented as a modal? (if not present a toast)
+      'Error', // title
+      message, // message (the only thing a toast will present)
+      [
+        {
+          message: 'Continue',
+          action: enterAuthFlow,
         },
-        { 
-            message: "Cancel",
-            action: refresh
-        }]
+        {
+          message: 'Cancel',
+          action: refresh,
+        },
+      ] // Action buttons
     )
+  }
+
+  switch (parseInt(error.code.toString()[0])) {
+    case 4: {
+      return await interpretClientError(error)
+    }
+    case 5: {
+      return interpretServerError(error)
+    }
+  }
+  console.warn('Error Interpreter: Could not interpret error ' + error.code)
+  return new OpenAuthoringContextualErrorUI(
+    true,
+    'Error ' + error.code,
+    error.message,
+    [
+      {
+        message: 'Continue',
+        action: enterAuthFlow,
+      },
+      {
+        message: 'Cancel',
+        action: refresh,
+      },
+    ]
+  )
 }

--- a/open-authoring/withErrorModal.tsx
+++ b/open-authoring/withErrorModal.tsx
@@ -1,9 +1,26 @@
 import { OpenAuthoringModalContainer } from './OpenAuthoringModalContainer'
+import { useEffect, useState } from 'react'
+import getErrorUIFrom from './error-interpreter'
 
 export const withErrorModal = BaseComponent => (props: { previewError }) => {
+  const [openAuthoringErrorUI, setOpenAuthoringErrorUI] = useState(null)
+
+  useEffect(() => {
+    ;(async () => {
+      if (props.previewError) {
+        const contextualError = await getErrorUIFrom(props.previewError)
+        if (contextualError.asModal) {
+          setOpenAuthoringErrorUI(contextualError)
+        }
+      }
+    })()
+  }, [props.previewError])
+
   if (props.previewError) {
     return (
-      <OpenAuthoringModalContainer openAuthoringError={props.previewError} />
+      <OpenAuthoringModalContainer
+        openAuthoringErrorUI={openAuthoringErrorUI}
+      />
     )
   } else {
     return <BaseComponent {...props} />

--- a/open-authoring/withErrorModal.tsx
+++ b/open-authoring/withErrorModal.tsx
@@ -1,0 +1,11 @@
+import { OpenAuthoringModalContainer } from './OpenAuthoringModalContainer'
+
+export const withErrorModal = BaseComponent => (props: { previewError }) => {
+  if (props.previewError) {
+    return (
+      <OpenAuthoringModalContainer openAuthoringError={props.previewError} />
+    )
+  } else {
+    return <BaseComponent {...props} />
+  }
+}

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -21,8 +21,9 @@ import { exitEditMode, enterEditMode } from '../../open-authoring/authFlow'
 import { useOpenAuthoring } from '../../components/layout/OpenAuthoring'
 import { Button } from '../../components/ui/Button'
 import OpenAuthoringError from '../../open-authoring/OpenAuthoringError'
+import { withErrorModal } from '../../open-authoring/withErrorModal'
 
-export default function BlogTemplate({
+function BlogTemplate({
   markdownFile,
   sourceProviderConnection,
   siteConfig,
@@ -98,6 +99,8 @@ export default function BlogTemplate({
     </OpenAuthoringSiteForm>
   )
 }
+
+export default withErrorModal(BlogTemplate)
 
 /*
  ** DATA FETCHING --------------------------------------------------

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -47,7 +47,6 @@ function BlogTemplate({
       form={form}
       path={markdownFile.fileRelativePath}
       editMode={editMode}
-      error={previewError}
     >
       <Layout
         sourceProviderConnection={sourceProviderConnection}

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -140,7 +140,7 @@ export const getStaticProps: GetStaticProps = async function({
     props: {
       sourceProviderConnection,
       editMode: !!preview,
-      previewError: previewError,
+      previewError,
       siteConfig: {
         title: siteConfig.title,
       },

--- a/pages/blog/page/[page_index].tsx
+++ b/pages/blog/page/[page_index].tsx
@@ -17,7 +17,7 @@ import getMarkdownData from '../../../utils/github/getMarkdownData'
 import { useCMS } from 'tinacms'
 import OpenAuthoringSiteForm from '../../../components/layout/OpenAuthoringSiteForm'
 import { useForm } from 'tinacms'
-import { OpenAuthoringModalContainer } from '../../../open-authoring/OpenAuthoringModalContainer'
+import { withErrorModal } from '../../../open-authoring/withErrorModal'
 const Index = props => {
   const { currentPage, numPages } = props
 
@@ -108,17 +108,17 @@ export const getStaticProps: GetStaticProps = async function({
   // @ts-ignore page_index should always be a single string
   const page = parseInt((ctx.params && ctx.params.page_index) || '1')
 
-  const files = await getFiles(
-    'content/blog',
-    sourceProviderConnection,
-    accessToken
-  )
-
-  const getPost = async file => {
-    return (await getMarkdownData(file, sourceProviderConnection, accessToken))
-      .data
-  }
   try {
+    const files = await getFiles(
+      'content/blog',
+      sourceProviderConnection,
+      accessToken
+    )
+    const getPost = async file => {
+      return (
+        await getMarkdownData(file, sourceProviderConnection, accessToken)
+      ).data
+    }
     const posts = await Promise.all(
       // TODO - potentially making a lot of requests here
       files.map(async file => {
@@ -160,13 +160,13 @@ export const getStaticProps: GetStaticProps = async function({
   } catch (e) {
     return {
       props: {
-        error: e,
+        previewError: { ...e }, //workaround since we cant return error as JSON
       },
     }
   }
 }
 
-export default Index
+export default withErrorModal(Index)
 
 /**
  *  STYLES -----------------------------------------------------

--- a/pages/community.tsx
+++ b/pages/community.tsx
@@ -11,11 +11,7 @@ import {
   RichTextWrapper,
   MarkdownContent,
 } from '../components/layout'
-import {
-  InlineWysiwyg,
-  InlineTextareaField,
-  InlineTextField,
-} from '../components/ui/inline'
+import { InlineWysiwyg, InlineTextareaField } from '../components/ui/inline'
 import { Button, ButtonGroup } from '../components/ui'
 import { EmailForm } from '../components/forms'
 import TwitterIconSvg from '../public/svg/twitter-icon.svg'
@@ -27,10 +23,10 @@ import getJsonData from '../utils/github/getJsonData'
 import { getGithubDataFromPreviewProps } from '../utils/github/sourceProviderConnection'
 import { useLocalGithubJsonForm } from '../utils/github/useLocalGithubJsonForm'
 import OpenAuthoringSiteForm from '../components/layout/OpenAuthoringSiteForm'
-import ContentNotFoundError from '../utils/github/ContentNotFoundError'
 import OpenAuthoringError from '../open-authoring/OpenAuthoringError'
+import { withErrorModal } from '../open-authoring/withErrorModal'
 
-export default function CommunityPage({
+function CommunityPage({
   community,
   metadata,
   sourceProviderConnection,
@@ -50,7 +46,6 @@ export default function CommunityPage({
       form={form}
       path={community.fileRelativePath}
       editMode={editMode}
-      error={previewError}
     >
       <Layout
         sourceProviderConnection={sourceProviderConnection}
@@ -158,6 +153,8 @@ export default function CommunityPage({
     </OpenAuthoringSiteForm>
   )
 }
+
+export default withErrorModal(CommunityPage)
 
 /*
  ** DATA FETCHING -----------------------------------------------

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -21,8 +21,9 @@ import { TinaIcon } from '../../components/logo'
 import { useLocalGithubMarkdownForm } from '../../utils/github/useLocalGithubMarkdownForm'
 import { getDocProps } from '../../utils/docs/getDocProps'
 import OpenAuthoringSiteForm from '../../components/layout/OpenAuthoringSiteForm'
+import { withErrorModal } from '../../open-authoring/withErrorModal'
 
-export default function DocTemplate(props) {
+function DocTemplate(props) {
   // Registers Tina Form
   const [data, form] = useLocalGithubMarkdownForm(
     props.markdownFile,
@@ -40,7 +41,7 @@ export default function DocTemplate(props) {
       form={form}
       path={props.markdownFile.fileRelativePath}
       editMode={props.editMode}
-      error={props.error}
+      error={props.previewError}
     >
       <DocsLayout isEditing={props.editMode}>
         <NextSeo
@@ -91,6 +92,8 @@ export default function DocTemplate(props) {
   )
 }
 
+export default withErrorModal(DocTemplate)
+
 /*
  * DATA FETCHING ------------------------------------------------------
  */
@@ -105,7 +108,7 @@ export const getStaticProps: GetStaticProps = async function(props) {
   } catch (e) {
     return {
       props: {
-        error: e,
+        previewError: e,
       },
     }
   }

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -107,7 +107,7 @@ export const getStaticProps: GetStaticProps = async function(props) {
   } catch (e) {
     return {
       props: {
-        previewError: e,
+        previewError: { ...e }, //workaround since we cant return error as JSON
       },
     }
   }

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -41,7 +41,6 @@ function DocTemplate(props) {
       form={form}
       path={props.markdownFile.fileRelativePath}
       editMode={props.editMode}
-      error={props.previewError}
     >
       <DocsLayout isEditing={props.editMode}>
         <NextSeo

--- a/pages/docs/index.tsx
+++ b/pages/docs/index.tsx
@@ -1,8 +1,5 @@
 import DocTemplate from './[...slug]'
-import matter from 'gray-matter'
-import { readFile } from '../../utils/readFile'
 import { getDocProps } from '../../utils/docs/getDocProps'
-import ContentNotFoundError from '../../utils/github/ContentNotFoundError'
 import { GetStaticProps } from 'next'
 
 export const getStaticProps: GetStaticProps = async function(props) {

--- a/pages/docs/index.tsx
+++ b/pages/docs/index.tsx
@@ -8,7 +8,7 @@ export const getStaticProps: GetStaticProps = async function(props) {
   } catch (e) {
     return {
       props: {
-        previewError: e.message,
+        previewError: { ...e }, //workaround since we cant return error as JSON
       },
     }
   }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -30,6 +30,7 @@ import { getGithubDataFromPreviewProps } from '../utils/github/sourceProviderCon
 import ContentNotFoundError from '../utils/github/ContentNotFoundError'
 import OpenAuthoringSiteForm from '../components/layout/OpenAuthoringSiteForm'
 import OpenAuthoringError from '../open-authoring/OpenAuthoringError'
+import { withErrorModal } from '../open-authoring/withErrorModal'
 
 const HomePage = (props: any) => {
   const [formData, form] = useLocalGithubJsonForm(
@@ -116,7 +117,6 @@ const HomePage = (props: any) => {
       form={form}
       path={props.home.fileRelativePath}
       editMode={props.editMode}
-      error={props.previewError}
     >
       <Layout
         sourceProviderConnection={props.sourceProviderConnection}
@@ -210,7 +210,7 @@ export <b>WithTina</b>( <b>Component</b> );
   )
 }
 
-export default HomePage
+export default withErrorModal(HomePage)
 
 export const getStaticProps: GetStaticProps = async function({
   preview,

--- a/pages/teams.tsx
+++ b/pages/teams.tsx
@@ -16,6 +16,7 @@ import { InlineBlocks } from 'react-tinacms-inline'
 import { useLocalGithubJsonForm } from '../utils/github/useLocalGithubJsonForm'
 import ContentNotFoundError from '../utils/github/ContentNotFoundError'
 import OpenAuthoringError from '../open-authoring/OpenAuthoringError'
+import { withErrorModal } from '../open-authoring/withErrorModal'
 
 const formOptions = {
   label: 'Teams',
@@ -50,7 +51,7 @@ const formOptions = {
   ],
 }
 
-export default function TeamsPage(props) {
+function TeamsPage(props) {
   // Adds Tina Form
   const [data, form] = useLocalGithubJsonForm(
     props.teams,
@@ -64,7 +65,6 @@ export default function TeamsPage(props) {
       form={form}
       path={props.teams.fileRelativePath}
       editMode={props.editMode}
-      error={props.previewError}
     >
       <TeamsLayout
         sourceProviderConnection={props.sourceProviderConnection}
@@ -108,6 +108,8 @@ export default function TeamsPage(props) {
     </OpenAuthoringSiteForm>
   )
 }
+
+export default withErrorModal(TeamsPage)
 
 /*
  ** DATA FETCHING --------------------------------------------------


### PR DESCRIPTION
Move some of the error interpretting logic from the SiteForm to a ErrorModal HOC.
Now we don't have to pass errors from the initial content-load through several DOM elements (which caused issues when we didn't have a fallback state).
Also, OpenAuthoringModalContainer now only takes in an ErrorUI component