### PR TITLE
Reorder copy: put Next.js stuff before Gatsby stuff

### DIFF
--- a/content/docs/getting-started/introduction.md
+++ b/content/docs/getting-started/introduction.md
@@ -4,7 +4,6 @@ id: introduction
 prev: null
 next: /docs/getting-started/how-tina-works
 ---
-
 Tina is a **lightweight but powerful toolkit** for creating a content editing interface with JavaScript components. Tina surfaces superpowers for developers to create an intuitive UI for real-time content editing, built directly into their website.
 
 ## The Next Generation of Content Management
@@ -15,9 +14,9 @@ Tina is optimized for next-gen JAMstack tools. It is written in JavaScript and e
 
 Tina currently supports React-based frameworks, including:
 
-- Create-React-App
-- Gatsby
-- NextJS
+* Create-React-App
+* Gatsby
+* NextJS
 
 ## Get Started
 
@@ -27,24 +26,24 @@ If you want to get started with some code right away, check out the [Gatsby Quic
 
 If you want to dive deep, start by learning more about [how Tina works](/docs/getting-started/how-tina-works) and get familiar with some core concepts.
 
+## For Next.js
+
+* [Next.js + Tina Overview](/docs/nextjs/overview) — Get started with the documentation
+* Read an in-depth tutorial on [Using TinaCMS with Next.js](/blog/using-tinacms-with-nextjs/)
+* Check out this sample [Next.js Markdown Blog](https://github.com/kendallstrautman/brevifolia-next-tinacms) with Tina configured for reference.
+
 ## For Gatsby
 
-- [Quickstart](/docs/gatsby/quickstart) with a Tina Starter to hit the ground running.
-- [Manual Setup](/docs/gatsby/manual-setup) for adding Tina to an existing Gatsby site.
+* [Quickstart](/docs/gatsby/quickstart) with a Tina Starter to hit the ground running.
+* [Manual Setup](/docs/gatsby/manual-setup) for adding Tina to an existing Gatsby site.
 
 **Gatsby Starters**
 
-- [Gatsby Blog Starter](https://github.com/tinacms/gatsby-starter-tinacms) with Tina — The classic Gatsby starter, but Tinified.
-- [Tina Grande](https://github.com/tinacms/tina-starter-grande) — A more advanced starter to showcase the power of Tina.
-- [Tina Brevifolia](https://github.com/kendallstrautman/brevifolia-gatsby-tinacms) — A Markdown-based blog with minimalist design and Tina for editing.
+* [Gatsby Blog Starter](https://github.com/tinacms/gatsby-starter-tinacms) with Tina — The classic Gatsby starter, but Tinified.
+* [Tina Grande](https://github.com/tinacms/tina-starter-grande) — A more advanced starter to showcase the power of Tina.
+* [Tina Brevifolia](https://github.com/kendallstrautman/brevifolia-gatsby-tinacms) — A Markdown-based blog with minimalist design and Tina for editing.
 
 Want to add your starter? Make a [PR](/docs/contributing/guidelines) to add your Tina site to this list.
-
-## For Next.js
-
-- [Next.js + Tina Overview](/docs/nextjs/overview) — Get started with the documentation
-- Read an in-depth tutorial on [Using TinaCMS with Next.js](/blog/using-tinacms-with-nextjs/)
-- Check out this sample [Next.js Markdown Blog](https://github.com/kendallstrautman/brevifolia-next-tinacms) with Tina configured for reference.
 
 ## Get Involved
 

--- a/content/docs/getting-started/introduction.md
+++ b/content/docs/getting-started/introduction.md
@@ -39,7 +39,7 @@ If you want to dive deep, start by learning more about [how Tina works](/docs/ge
 
 **Gatsby Starters**
 
-* [Gatsby Blog Starter](https://github.com/tinacms/gatsby-starter-tinacms) with Tina — The classic Gatsby starter, but Tinified.
+* [Gatsby Blog Starter](https://github.com/tinacms/gatsby-starter-tinacms) with Tina — The classic Gatsby starter, but Tinafied.
 * [Tina Grande](https://github.com/tinacms/tina-starter-grande) — A more advanced starter to showcase the power of Tina.
 * [Tina Brevifolia](https://github.com/kendallstrautman/brevifolia-gatsby-tinacms) — A Markdown-based blog with minimalist design and Tina for editing.
 


### PR DESCRIPTION
Next.js support is currently better than Gatsby's so I reordered the content copy