### PR TITLE
fix(errors): fix issue where errors not parsed as JSON

### DIFF
--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -126,7 +126,7 @@ export const getStaticProps: GetStaticProps = async function({
     )
   } catch (e) {
     if (e instanceof OpenAuthoringError) {
-      previewError = e
+      previewError = { ...e } //workaround since we cant return error as JSON
     } else {
       throw e
     }

--- a/pages/blog/page/[page_index].tsx
+++ b/pages/blog/page/[page_index].tsx
@@ -107,51 +107,59 @@ export const getStaticProps: GetStaticProps = async function({
   // @ts-ignore page_index should always be a single string
   const page = parseInt((ctx.params && ctx.params.page_index) || '1')
 
-  const files = await getFiles(
-    'content/blog',
-    sourceProviderConnection,
-    accessToken
-  )
-
-  const posts = await Promise.all(
-    // TODO - potentially making a lot of requests here
-    files.map(async file => {
-      const post = (
-        await getMarkdownData(file, sourceProviderConnection, accessToken)
-      ).data
-
-      // create slug from filename
-      const slug = file
-        .replace(/^.*[\\\/]/, '')
-        .split('.')
-        .slice(0, -1)
-        .join('.')
-
-      const excerpt = await formatExcerpt(post.markdownBody)
-
-      return {
-        data: { ...post.frontmatter, slug },
-        content: excerpt,
-      }
-    })
-  )
-
-  // for pagination and ordering
-  const numPages = Math.ceil(posts.length / POSTS_PER_PAGE)
-  const pageIndex = page - 1
-  const orderedPosts = orderPosts(posts).slice(
-    pageIndex * POSTS_PER_PAGE,
-    (pageIndex + 1) * POSTS_PER_PAGE
-  )
-
-  return {
-    props: {
-      posts: orderedPosts,
-      numPages: numPages,
-      currentPage: page,
-      editMode: !!preview,
+  try {
+    const files = await getFiles(
+      'content/blog',
       sourceProviderConnection,
-    },
+      accessToken
+    )
+
+    const posts = await Promise.all(
+      // TODO - potentially making a lot of requests here
+      files.map(async file => {
+        const post = (
+          await getMarkdownData(file, sourceProviderConnection, accessToken)
+        ).data
+
+        // create slug from filename
+        const slug = file
+          .replace(/^.*[\\\/]/, '')
+          .split('.')
+          .slice(0, -1)
+          .join('.')
+
+        const excerpt = await formatExcerpt(post.markdownBody)
+
+        return {
+          data: { ...post.frontmatter, slug },
+          content: excerpt,
+        }
+      })
+    )
+
+    // for pagination and ordering
+    const numPages = Math.ceil(posts.length / POSTS_PER_PAGE)
+    const pageIndex = page - 1
+    const orderedPosts = orderPosts(posts).slice(
+      pageIndex * POSTS_PER_PAGE,
+      (pageIndex + 1) * POSTS_PER_PAGE
+    )
+
+    return {
+      props: {
+        posts: orderedPosts,
+        numPages: numPages,
+        currentPage: page,
+        editMode: !!preview,
+        sourceProviderConnection,
+      },
+    }
+  } catch (e) {
+    return {
+      props: {
+        previewError: { ...e }, //workaround since we cant return error as JSON
+      },
+    }
   }
 }
 

--- a/pages/community.tsx
+++ b/pages/community.tsx
@@ -183,7 +183,7 @@ export const getStaticProps: GetStaticProps = async function({
     )
   } catch (e) {
     if (e instanceof OpenAuthoringError) {
-      previewError = e
+      previewError = { ...e } //workaround since we cant return error as JSON
     } else {
       throw e
     }

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -43,7 +43,7 @@ export default function DocTemplate(props) {
       form={form}
       path={props.markdownFile.fileRelativePath}
       editMode={props.editMode}
-      error={props.error}
+      error={props.previewError}
     >
       <DocsLayout isEditing={props.editMode}>
         <NextSeo
@@ -110,7 +110,7 @@ export const getStaticProps: GetStaticProps = async function(props) {
     if (e instanceof OpenAuthoringError) {
       return {
         props: {
-          error: e,
+          previewError: { ...e }, //workaround since we cant return error as JSON
         },
       }
     } else {

--- a/pages/docs/index.tsx
+++ b/pages/docs/index.tsx
@@ -12,7 +12,7 @@ export const getStaticProps: GetStaticProps = async function(props) {
     if (e instanceof ContentNotFoundError) {
       return {
         props: {
-          previewError: e.message,
+          previewError: { ...e }, //workaround since we cant return error as JSON
         },
       }
     } else {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -230,7 +230,7 @@ export const getStaticProps: GetStaticProps = async function({
     )
   } catch (e) {
     if (e instanceof OpenAuthoringError) {
-      previewError = e
+      previewError = { ...e } //workaround since we cant return error as JSON
     } else {
       throw e
     }

--- a/pages/teams.tsx
+++ b/pages/teams.tsx
@@ -132,7 +132,7 @@ export const getStaticProps: GetStaticProps = async function({
     )
   } catch (e) {
     if (e instanceof OpenAuthoringError) {
-      previewError = e
+      previewError = { ...e } //workaround since we cant return error as JSON
     } else {
       throw e
     }


### PR DESCRIPTION
This error surface with the upgrade to Next 9.3.0. Causes the Error modals to not be rendered in preview-mode