### PR TITLE
Toolbar Refactor

### DIFF
--- a/components/cms/Toolbar.tsx
+++ b/components/cms/Toolbar.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { useCMS, useSubscribable, Form, FieldMeta } from 'tinacms'
+import { useCMS, useSubscribable, Form, FieldMeta, Plugin } from 'tinacms'
 import { Button, color } from '@tinacms/styles'
 import { CreateContentMenu } from './CreateContent'
 import styled, { css } from 'styled-components'
@@ -22,9 +22,14 @@ const useFormState = (form: Form | null, subscription: any): any => {
   return state
 }
 
+interface ToolbarWidgetPlugin extends Plugin {
+  weight: number
+  component(): React.ReactElement
+}
+
 export const Toolbar = styled(({ ...styleProps }) => {
   const cms = useCMS()
-  const widgets = cms.plugins.getType('toolbar:widget')
+  const widgets = cms.plugins.getType<ToolbarWidgetPlugin>('toolbar:widget')
 
   const forms = cms.forms
   const form = cms.forms.all().length ? cms.forms.all()[0] : null
@@ -47,9 +52,12 @@ export const Toolbar = styled(({ ...styleProps }) => {
           <CreateContentMenu />
         </Create>
         <Github>
-          {widgets.all().map((git: any) => (
-            <git.component key={git.name} />
-          ))}
+          {widgets
+            .all()
+            .sort((a, b) => a.weight - b.weight)
+            .map(widget => (
+              <widget.component key={widget.name} />
+            ))}
         </Github>
         {formState && (
           <>

--- a/components/cms/Toolbar.tsx
+++ b/components/cms/Toolbar.tsx
@@ -33,9 +33,10 @@ export const Toolbar = styled(({ ...styleProps }) => {
   useSubscribable(forms)
   useSubscribable(widgets)
 
-  const hasToolbarWidgets = widgets.all().length
+  // TODO: Find a more accurate solution then this.
+  const inEditMode = widgets.all().length
 
-  if (!hasToolbarWidgets) {
+  if (!inEditMode) {
     return null
   }
   return (
@@ -50,12 +51,12 @@ export const Toolbar = styled(({ ...styleProps }) => {
             <git.component key={git.name} />
           ))}
         </Github>
-        <Status>
-          {form && formState && <FormStatus dirty={!formState.pristine} />}
-        </Status>
-        <Actions>
-          {form && formState && (
-            <>
+        {formState && (
+          <>
+            <Status>
+              <FormStatus dirty={!formState.pristine} />}
+            </Status>
+            <Actions>
               <ToolbarButton disabled={formState.pristine} onClick={form.reset}>
                 <UndoIconSvg />
                 <DesktopLabel> Discard</DesktopLabel>
@@ -73,9 +74,9 @@ export const Toolbar = styled(({ ...styleProps }) => {
                   </>
                 )}
               </SaveButton>
-            </>
-          )}
-        </Actions>
+            </Actions>
+          </>
+        )}
       </div>
     </>
   )

--- a/components/cms/Toolbar.tsx
+++ b/components/cms/Toolbar.tsx
@@ -30,16 +30,14 @@ export const Toolbar = styled(({ ...styleProps }) => {
           <CreateContentMenu />
         </Create>
         <Github>
-          {git.all().length > 0 &&
-            git.all().map((git: any) => <git.component key={git.name} />)}
+          {git.all().map((git: any) => (
+            <git.component key={git.name} />
+          ))}
         </Github>
         <Status>
-          {status.all().length > 0 &&
-            status
-              .all()
-              .map((status: any) => (
-                <status.component key={status.name} {...status.props} />
-              ))}
+          {status.all().map((status: any) => (
+            <status.component key={status.name} {...status.props} />
+          ))}
         </Status>
         <Actions>
           {form &&

--- a/components/cms/Toolbar.tsx
+++ b/components/cms/Toolbar.tsx
@@ -16,7 +16,7 @@ const useFormState = (form: Form | null, subscription: any): any => {
   const [state, setState] = useState<any>()
   useEffect(() => {
     if (!form) return
-    form.subscribe(setState, subscription)
+    return form.subscribe(setState, subscription)
   }, [form])
 
   return state
@@ -60,7 +60,7 @@ export const Toolbar = styled(({ ...styleProps }) => {
               <widget.component key={widget.name} {...widget.props} />
             ))}
         </WidgetsContainer>
-        {formState && (
+        {form && formState && (
           <>
             <Status>
               <FormStatus dirty={!formState.pristine} />

--- a/components/cms/Toolbar.tsx
+++ b/components/cms/Toolbar.tsx
@@ -10,12 +10,15 @@ export const Toolbar = styled(({ ...styleProps }) => {
   const git = cms.plugins.getType('toolbar:git')
   const actions = cms.plugins.getType('toolbar:form-actions')
 
+  const forms = cms.forms
+  const form = cms.forms.all().length ? cms.forms.all()[0] : null
+
+  useSubscribable(forms)
   useSubscribable(status)
   useSubscribable(git)
-  useSubscribable(actions)
 
-  const hasToolbarStuff =
-    git.all().length + status.all().length + actions.all().length > 0
+  const hasToolbarStuff = git.all().length || status.all().length
+
   if (!hasToolbarStuff) {
     return null
   }
@@ -39,7 +42,7 @@ export const Toolbar = styled(({ ...styleProps }) => {
               ))}
         </Status>
         <Actions>
-          {actions.all().length > 0 &&
+          {form &&
             actions
               .all()
               .map((action: any) => <action.component key={action.name} />)}

--- a/components/cms/Toolbar.tsx
+++ b/components/cms/Toolbar.tsx
@@ -34,7 +34,11 @@ export const Toolbar = styled(({ ...styleProps }) => {
 
   const forms = cms.forms
   const form = cms.forms.all().length ? cms.forms.all()[0] : null
-  const formState = useFormState(form, { pristine: true, submitting: true })
+  // TODO: This doesn't return the correct value initially
+  const formState = useFormState(form, {
+    pristine: true,
+    submitting: true,
+  })
 
   useSubscribable(forms)
   useSubscribable(widgets)
@@ -45,6 +49,15 @@ export const Toolbar = styled(({ ...styleProps }) => {
   if (!inEditMode) {
     return null
   }
+  // TODO: Form#reset should always exist
+  const reset = form && (form.reset || (() => form.finalForm.reset()))
+  const submit = form && form.submit
+  const disabled = !form
+
+  // TODO: There's got to be a better way to get formState
+  const pristine = disabled ? true : formState && formState.pristine
+  const submitting = disabled ? false : !!(formState && formState.submitting)
+
   return (
     <>
       <ToolbarPlaceholder />
@@ -60,32 +73,28 @@ export const Toolbar = styled(({ ...styleProps }) => {
               <widget.component key={widget.name} {...widget.props} />
             ))}
         </WidgetsContainer>
-        {form && formState && (
-          <>
-            <Status>
-              <FormStatus dirty={!formState.pristine} />
-            </Status>
-            <Actions>
-              <ToolbarButton disabled={formState.pristine} onClick={form.reset}>
-                <UndoIconSvg />
-                <DesktopLabel> Discard</DesktopLabel>
-              </ToolbarButton>
-              <SaveButton
-                primary
-                onClick={form.submit}
-                busy={formState.submitting}
-                disabled={formState.pristine}
-              >
-                {formState.submitting && <LoadingDots />}
-                {!formState.submitting && (
-                  <>
-                    Save <DesktopLabel>&nbsp;Page</DesktopLabel>
-                  </>
-                )}
-              </SaveButton>
-            </Actions>
-          </>
-        )}
+        <Status>
+          <FormStatus dirty={!pristine} />
+        </Status>
+        <Actions>
+          <ToolbarButton disabled={disabled || pristine} onClick={reset}>
+            <UndoIconSvg />
+            <DesktopLabel> Discard</DesktopLabel>
+          </ToolbarButton>
+          <SaveButton
+            primary
+            onClick={submit}
+            busy={submitting}
+            disabled={disabled || pristine}
+          >
+            {submitting && <LoadingDots />}
+            {!submitting && (
+              <>
+                Save <DesktopLabel>&nbsp;Page</DesktopLabel>
+              </>
+            )}
+          </SaveButton>
+        </Actions>
       </div>
     </>
   )

--- a/components/cms/Toolbar.tsx
+++ b/components/cms/Toolbar.tsx
@@ -63,7 +63,7 @@ export const Toolbar = styled(({ ...styleProps }) => {
         {formState && (
           <>
             <Status>
-              <FormStatus dirty={!formState.pristine} />}
+              <FormStatus dirty={!formState.pristine} />
             </Status>
             <Actions>
               <ToolbarButton disabled={formState.pristine} onClick={form.reset}>

--- a/components/cms/Toolbar.tsx
+++ b/components/cms/Toolbar.tsx
@@ -52,14 +52,14 @@ export const Toolbar = styled(({ ...styleProps }) => {
         <Create>
           <CreateContentMenu />
         </Create>
-        <Github>
+        <WidgetsContainer>
           {widgets
             .all()
             .sort((a, b) => a.weight - b.weight)
             .map(widget => (
               <widget.component key={widget.name} {...widget.props} />
             ))}
-        </Github>
+        </WidgetsContainer>
         {formState && (
           <>
             <Status>
@@ -112,7 +112,7 @@ export const Toolbar = styled(({ ...styleProps }) => {
   }
 `
 
-const Github = styled.div`
+const WidgetsContainer = styled.div`
   display: flex;
   align-items: center;
   justify-self: end;

--- a/components/cms/Toolbar.tsx
+++ b/components/cms/Toolbar.tsx
@@ -1,17 +1,35 @@
-import React from 'react'
-import { useCMS, useSubscribable } from 'tinacms'
+import React, { useState, useEffect } from 'react'
+import { useCMS, useSubscribable, Form } from 'tinacms'
 import { Button } from '@tinacms/styles'
 import { CreateContentMenu } from './CreateContent'
 import styled from 'styled-components'
+import { ToolbarButton } from '../ui/inline/ToolbarButton'
+import UndoIconSvg from '../../public/svg/undo-icon.svg'
+import { DesktopLabel } from '../ui/inline/DesktopLabel'
+import { LoadingDots } from '../ui/LoadingDots'
+
+const SaveButton = styled(ToolbarButton)`
+  padding: 0 2rem;
+`
+
+const useFormState = (form: Form | null, subscription: any): any => {
+  const [state, setState] = useState<any>()
+  useEffect(() => {
+    if (!form) return
+    form.subscribe(setState, subscription)
+  }, [form])
+
+  return state
+}
 
 export const Toolbar = styled(({ ...styleProps }) => {
   const cms = useCMS()
   const status = cms.plugins.getType('toolbar:status')
   const git = cms.plugins.getType('toolbar:git')
-  const actions = cms.plugins.getType('toolbar:form-actions')
 
   const forms = cms.forms
   const form = cms.forms.all().length ? cms.forms.all()[0] : null
+  const formState = useFormState(form, { pristine: true, submitting: true })
 
   useSubscribable(forms)
   useSubscribable(status)
@@ -40,10 +58,27 @@ export const Toolbar = styled(({ ...styleProps }) => {
           ))}
         </Status>
         <Actions>
-          {form &&
-            actions
-              .all()
-              .map((action: any) => <action.component key={action.name} />)}
+          {form && formState && (
+            <>
+              <ToolbarButton disabled={formState.pristine} onClick={form.reset}>
+                <UndoIconSvg />
+                <DesktopLabel> Discard</DesktopLabel>
+              </ToolbarButton>
+              <SaveButton
+                primary
+                onClick={form.submit}
+                busy={formState.submitting}
+                disabled={formState.pristine}
+              >
+                {formState.submitting && <LoadingDots />}
+                {!formState.submitting && (
+                  <>
+                    Save <DesktopLabel>&nbsp;Page</DesktopLabel>
+                  </>
+                )}
+              </SaveButton>
+            </>
+          )}
         </Actions>
       </div>
     </>

--- a/components/cms/Toolbar.tsx
+++ b/components/cms/Toolbar.tsx
@@ -24,18 +24,18 @@ const useFormState = (form: Form | null, subscription: any): any => {
 
 export const Toolbar = styled(({ ...styleProps }) => {
   const cms = useCMS()
-  const git = cms.plugins.getType('toolbar:git')
+  const widgets = cms.plugins.getType('toolbar:widget')
 
   const forms = cms.forms
   const form = cms.forms.all().length ? cms.forms.all()[0] : null
   const formState = useFormState(form, { pristine: true, submitting: true })
 
   useSubscribable(forms)
-  useSubscribable(git)
+  useSubscribable(widgets)
 
-  const hasToolbarStuff = git.all().length
+  const hasToolbarWidgets = widgets.all().length
 
-  if (!hasToolbarStuff) {
+  if (!hasToolbarWidgets) {
     return null
   }
   return (
@@ -46,7 +46,7 @@ export const Toolbar = styled(({ ...styleProps }) => {
           <CreateContentMenu />
         </Create>
         <Github>
-          {git.all().map((git: any) => (
+          {widgets.all().map((git: any) => (
             <git.component key={git.name} />
           ))}
         </Github>

--- a/components/cms/Toolbar.tsx
+++ b/components/cms/Toolbar.tsx
@@ -22,8 +22,9 @@ const useFormState = (form: Form | null, subscription: any): any => {
   return state
 }
 
-interface ToolbarWidgetPlugin extends Plugin {
+interface ToolbarWidgetPlugin<Props = any> extends Plugin {
   weight: number
+  props?: Props
   component(): React.ReactElement
 }
 
@@ -56,7 +57,7 @@ export const Toolbar = styled(({ ...styleProps }) => {
             .all()
             .sort((a, b) => a.weight - b.weight)
             .map(widget => (
-              <widget.component key={widget.name} />
+              <widget.component key={widget.name} {...widget.props} />
             ))}
         </Github>
         {formState && (

--- a/components/cms/Toolbar.tsx
+++ b/components/cms/Toolbar.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react'
-import { useCMS, useSubscribable, Form } from 'tinacms'
-import { Button } from '@tinacms/styles'
+import { useCMS, useSubscribable, Form, FieldMeta } from 'tinacms'
+import { Button, color } from '@tinacms/styles'
 import { CreateContentMenu } from './CreateContent'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { ToolbarButton } from '../ui/inline/ToolbarButton'
 import UndoIconSvg from '../../public/svg/undo-icon.svg'
 import { DesktopLabel } from '../ui/inline/DesktopLabel'
@@ -56,6 +56,7 @@ export const Toolbar = styled(({ ...styleProps }) => {
           {status.all().map((status: any) => (
             <status.component key={status.name} {...status.props} />
           ))}
+          {form && formState && <FormStatus dirty={!formState.pristine} />}
         </Status>
         <Actions>
           {form && formState && (
@@ -180,4 +181,52 @@ const ToolbarPlaceholder = styled.div`
   display: block;
   width: 100%;
   height: 62px;
+`
+
+const FormStatus = ({ dirty }) => {
+  return (
+    <FieldMeta name={'Form Status'}>
+      {dirty ? (
+        <StatusMessage>
+          <StatusLight warning /> <DesktopLabel>Unsaved changes</DesktopLabel>
+        </StatusMessage>
+      ) : (
+        <StatusMessage>
+          <StatusLight /> <DesktopLabel>No changes</DesktopLabel>
+        </StatusMessage>
+      )}
+    </FieldMeta>
+  )
+}
+
+interface StatusLightProps {
+  warning?: boolean
+}
+
+const StatusLight = styled.span<StatusLightProps>`
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 8px;
+  margin-top: -1px;
+  background-color: #3cad3a;
+  border: 1px solid #249a21;
+  margin-right: 5px;
+  opacity: 0.5;
+
+  ${p =>
+    p.warning &&
+    css`
+      background-color: #e9d050;
+      border: 1px solid #d3ba38;
+      opacity: 1;
+    `};
+`
+
+const StatusMessage = styled.p`
+  font-size: 16px;
+  display: flex;
+  align-items: center;
+  color: ${color.grey(6)};
+  padding-right: 4px;
 `

--- a/components/cms/Toolbar.tsx
+++ b/components/cms/Toolbar.tsx
@@ -24,7 +24,6 @@ const useFormState = (form: Form | null, subscription: any): any => {
 
 export const Toolbar = styled(({ ...styleProps }) => {
   const cms = useCMS()
-  const status = cms.plugins.getType('toolbar:status')
   const git = cms.plugins.getType('toolbar:git')
 
   const forms = cms.forms
@@ -32,10 +31,9 @@ export const Toolbar = styled(({ ...styleProps }) => {
   const formState = useFormState(form, { pristine: true, submitting: true })
 
   useSubscribable(forms)
-  useSubscribable(status)
   useSubscribable(git)
 
-  const hasToolbarStuff = git.all().length || status.all().length
+  const hasToolbarStuff = git.all().length
 
   if (!hasToolbarStuff) {
     return null
@@ -53,9 +51,6 @@ export const Toolbar = styled(({ ...styleProps }) => {
           ))}
         </Github>
         <Status>
-          {status.all().map((status: any) => (
-            <status.component key={status.name} {...status.props} />
-          ))}
           {form && formState && <FormStatus dirty={!formState.pristine} />}
         </Status>
         <Actions>

--- a/open-authoring/PRPlugin.tsx
+++ b/open-authoring/PRPlugin.tsx
@@ -17,13 +17,10 @@ export const PRPlugin = (
   __type: 'toolbar:widget',
   name: 'create-pr',
   weight: 5,
-  component: () => {
-    return (
-      <PullRequestButton
-        baseRepoFullName={baseRepoFullName}
-        forkRepoFullName={forkRepoFullName}
-      />
-    )
+  component: PullRequestButton,
+  props: {
+    baseRepoFullName,
+    forkRepoFullName,
   },
 })
 

--- a/open-authoring/PRPlugin.tsx
+++ b/open-authoring/PRPlugin.tsx
@@ -14,7 +14,7 @@ export const PRPlugin = (
   baseRepoFullName: string,
   forkRepoFullName: string
 ) => ({
-  __type: 'toolbar:git',
+  __type: 'toolbar:widget',
   name: 'create-pr',
   component: () => {
     return (

--- a/open-authoring/PRPlugin.tsx
+++ b/open-authoring/PRPlugin.tsx
@@ -16,6 +16,7 @@ export const PRPlugin = (
 ) => ({
   __type: 'toolbar:widget',
   name: 'create-pr',
+  weight: 5,
   component: () => {
     return (
       <PullRequestButton

--- a/open-authoring/useOpenAuthoringToolbarPlugins.tsx
+++ b/open-authoring/useOpenAuthoringToolbarPlugins.tsx
@@ -26,6 +26,7 @@ export const useOpenAuthoringToolbarPlugins = (
       {
         __type: 'toolbar:widget',
         name: 'current-fork',
+        weight: 1,
         component: () => {
           return (
             <FieldMeta name={'Fork'}>

--- a/open-authoring/useOpenAuthoringToolbarPlugins.tsx
+++ b/open-authoring/useOpenAuthoringToolbarPlugins.tsx
@@ -27,15 +27,8 @@ export const useOpenAuthoringToolbarPlugins = (
         __type: 'toolbar:widget',
         name: 'current-fork',
         weight: 1,
-        component: () => {
-          return (
-            <FieldMeta name={'Fork'}>
-              <MetaLink target="_blank" href={`https://github.com/${forkName}`}>
-                {forkName}
-              </MetaLink>
-            </FieldMeta>
-          )
-        },
+        props: { forkName },
+        component: ForkInfo,
       },
       // TODO
       PRPlugin(process.env.REPO_FULL_NAME, forkName),
@@ -63,3 +56,13 @@ const MetaLink = styled.a`
   font-size: 16px;
   color: ${color.primary('dark')};
 `
+
+const ForkInfo = ({ forkName }) => {
+  return (
+    <FieldMeta name={'Fork'}>
+      <MetaLink target="_blank" href={`https://github.com/${forkName}`}>
+        {forkName}
+      </MetaLink>
+    </FieldMeta>
+  )
+}

--- a/open-authoring/useOpenAuthoringToolbarPlugins.tsx
+++ b/open-authoring/useOpenAuthoringToolbarPlugins.tsx
@@ -44,48 +44,6 @@ export const useOpenAuthoringToolbarPlugins = (
       // TODO
       PRPlugin(process.env.REPO_FULL_NAME, forkName),
       {
-        __type: 'toolbar:form-actions',
-        name: 'base-form-actions',
-        component: () => (
-          <>
-            {formState.dirty ? (
-              <>
-                <ToolbarButton
-                  onClick={() => {
-                    form.finalForm.reset()
-                  }}
-                >
-                  <UndoIconSvg />
-                  <DesktopLabel> Discard</DesktopLabel>
-                </ToolbarButton>
-                <SaveButton
-                  primary
-                  onClick={form.submit}
-                  busy={formState.submitting}
-                >
-                  {formState.submitting && <LoadingDots />}
-                  {!formState.submitting && (
-                    <>
-                      Save <DesktopLabel>&nbsp;Page</DesktopLabel>
-                    </>
-                  )}
-                </SaveButton>
-              </>
-            ) : (
-              <>
-                <ToolbarButton onClick={form.reset} disabled>
-                  <UndoIconSvg />
-                  <DesktopLabel> Discard</DesktopLabel>
-                </ToolbarButton>
-                <SaveButton primary onClick={form.submit} disabled>
-                  Save <DesktopLabel>&nbsp;Page</DesktopLabel>
-                </SaveButton>
-              </>
-            )}
-          </>
-        ),
-      },
-      {
         __type: 'toolbar:status',
         name: 'form-state-dirty',
         props: {

--- a/open-authoring/useOpenAuthoringToolbarPlugins.tsx
+++ b/open-authoring/useOpenAuthoringToolbarPlugins.tsx
@@ -25,7 +25,7 @@ export const useOpenAuthoringToolbarPlugins = (
     const forkName = getForkName()
     const plugins = [
       {
-        __type: 'toolbar:git',
+        __type: 'toolbar:widget',
         name: 'current-fork',
         component: () => {
           return (

--- a/open-authoring/useOpenAuthoringToolbarPlugins.tsx
+++ b/open-authoring/useOpenAuthoringToolbarPlugins.tsx
@@ -1,12 +1,8 @@
 import { Form, useCMS, FieldMeta } from 'tinacms'
 import { useEffect, useState } from 'react'
-import { ToolbarButton } from '../components/ui/inline/ToolbarButton'
-import { DesktopLabel } from '../components/ui/inline/DesktopLabel'
 import { PRPlugin } from './PRPlugin'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 import { color } from '@tinacms/styles'
-import UndoIconSvg from '../public/svg/undo-icon.svg'
-import { LoadingDots } from '../components/ui/LoadingDots'
 import { getForkName } from './utils/repository'
 
 const useFormState = (form, subscription) => {
@@ -43,14 +39,6 @@ export const useOpenAuthoringToolbarPlugins = (
       },
       // TODO
       PRPlugin(process.env.REPO_FULL_NAME, forkName),
-      {
-        __type: 'toolbar:status',
-        name: 'form-state-dirty',
-        props: {
-          dirty: formState.dirty,
-        },
-        component: FormStatus,
-      },
     ] as any
 
     const removePlugins = () => {
@@ -67,10 +55,6 @@ export const useOpenAuthoringToolbarPlugins = (
   }, [editMode, form, formState])
 }
 
-interface StatusLightProps {
-  warning?: boolean
-}
-
 const MetaLink = styled.a`
   display: block;
   max-width: 250px;
@@ -79,50 +63,3 @@ const MetaLink = styled.a`
   font-size: 16px;
   color: ${color.primary('dark')};
 `
-
-const SaveButton = styled(ToolbarButton)`
-  padding: 0 2rem;
-`
-const StatusLight = styled.span<StatusLightProps>`
-  display: inline-block;
-  width: 8px;
-  height: 8px;
-  border-radius: 8px;
-  margin-top: -1px;
-  background-color: #3cad3a;
-  border: 1px solid #249a21;
-  margin-right: 5px;
-  opacity: 0.5;
-
-  ${p =>
-    p.warning &&
-    css`
-      background-color: #e9d050;
-      border: 1px solid #d3ba38;
-      opacity: 1;
-    `};
-`
-
-const StatusMessage = styled.p`
-  font-size: 16px;
-  display: flex;
-  align-items: center;
-  color: ${color.grey(6)};
-  padding-right: 4px;
-`
-
-const FormStatus = ({ dirty }) => {
-  return (
-    <FieldMeta name={'Form Status'}>
-      {dirty ? (
-        <StatusMessage>
-          <StatusLight warning /> <DesktopLabel>Unsaved changes</DesktopLabel>
-        </StatusMessage>
-      ) : (
-        <StatusMessage>
-          <StatusLight /> <DesktopLabel>No changes</DesktopLabel>
-        </StatusMessage>
-      )}
-    </FieldMeta>
-  )
-}

--- a/open-authoring/useOpenAuthoringToolbarPlugins.tsx
+++ b/open-authoring/useOpenAuthoringToolbarPlugins.tsx
@@ -19,7 +19,6 @@ export const useOpenAuthoringToolbarPlugins = (
   editMode: boolean
 ) => {
   const cms = useCMS()
-  const formState = useFormState(form, { dirty: true, submitting: true })
 
   useEffect(() => {
     const forkName = getForkName()
@@ -52,7 +51,7 @@ export const useOpenAuthoringToolbarPlugins = (
     }
 
     return removePlugins
-  }, [editMode, form, formState])
+  }, [editMode, form])
 }
 
 const MetaLink = styled.a`


### PR DESCRIPTION
This PR implements the changes described in [RFC 0005](https://github.com/tinacms/rfcs/blob/master/0005-toolbar-widget.md)

* The `toolbar:form-action` and `toolbar:status` plugins have been removed. Those components are always rendered now. This is the same way it works in the Sidebar.
* The `toolbar:git` plugin has been replaced with a more generic `toolbar:widget`. 
  * These widgets are ordered by `weight`.
  * Any `props` defined on the widget are passed to the component.