### PR TITLE
refactor: extract AsyncButton, use for PR button

### DIFF
--- a/open-authoring/open-authoring/AsyncButton.tsx
+++ b/open-authoring/open-authoring/AsyncButton.tsx
@@ -1,0 +1,31 @@
+import { useCallback, useState } from 'react'
+import { LoadingDots } from '@tinacms/react-forms'
+import { Button } from '@tinacms/styles'
+
+interface ButtonProps {
+  name: string
+  action(): Promise<void>
+  primary: boolean
+}
+
+export const AsyncButton = ({ name, primary, action }: ButtonProps) => {
+  const [submitting, setSubmitting] = useState(false)
+
+  const onClick = useCallback(async () => {
+    setSubmitting(true)
+    await action()
+    setSubmitting(false)
+  }, [action, setSubmitting])
+
+  return (
+    <Button
+      primary={primary}
+      onClick={onClick}
+      busy={submitting}
+      disabled={submitting}
+    >
+      {submitting && <LoadingDots />}
+      {!submitting && name}
+    </Button>
+  )
+}

--- a/open-authoring/open-authoring/OpenAuthoringAuthModal.tsx
+++ b/open-authoring/open-authoring/OpenAuthoringAuthModal.tsx
@@ -8,8 +8,8 @@ import {
   ModalBody,
   ModalActions,
 } from 'tinacms'
-import { TinaReset, Button as TinaButton } from '@tinacms/styles'
-import { LoadingDots } from '@tinacms/react-forms'
+import { TinaReset } from '@tinacms/styles'
+import { AsyncButton } from './AsyncButton'
 
 const OpenAuthoringAuthModal = ({
   onUpdateAuthState,
@@ -81,33 +81,6 @@ const OpenAuthoringAuthModal = ({
         </ModalPopup>
       </Modal>
     </TinaReset>
-  )
-}
-
-interface ButtonProps {
-  name: string
-  action(): Promise<void>
-  primary: boolean
-}
-const AsyncButton = ({ name, primary, action }: ButtonProps) => {
-  const [submitting, setSubmitting] = useState(false)
-
-  const onClick = useCallback(async () => {
-    setSubmitting(true)
-    await action()
-    setSubmitting(false)
-  }, [action, setSubmitting])
-
-  return (
-    <TinaButton
-      primary={primary}
-      onClick={onClick}
-      busy={submitting}
-      disabled={submitting}
-    >
-      {submitting && <LoadingDots />}
-      {!submitting && name}
-    </TinaButton>
   )
 }
 

--- a/open-authoring/toolbar-plugins/pull-request/PRModal.tsx
+++ b/open-authoring/toolbar-plugins/pull-request/PRModal.tsx
@@ -4,6 +4,7 @@ import { ModalBody, ModalActions, FieldMeta, useCMS } from 'tinacms'
 import styled from 'styled-components'
 import React, { useEffect, useState } from 'react'
 import { getHeadBranch } from '../../open-authoring/repository'
+import { AsyncButton } from '../../open-authoring/AsyncButton'
 
 const BASE_BRANCH = process.env.BASE_BRANCH
 
@@ -35,8 +36,8 @@ export const PRModal = ({ forkRepoFullName, baseRepoFullName }: Props) => {
       })
   }
 
-  const createPR = () => {
-    cms.api.github
+  const createPR = async () => {
+    await cms.api.github
       .createPR(
         forkRepoFullName,
         getHeadBranch(),
@@ -124,9 +125,7 @@ export const PRModal = ({ forkRepoFullName, baseRepoFullName }: Props) => {
       </PrModalBody>
       <ModalActions>
         {!fetchedPR.id && (
-          <TinaButton primary onClick={createPR}>
-            Create Pull Request
-          </TinaButton>
+          <AsyncButton primary name="Create Pull Request" action={createPR} />
         )}
         {fetchedPR && fetchedPR.html_url && (
           <>


### PR DESCRIPTION
This uses the AsyncButton for the 'Create PR' button so it gets a loading state / disabled after it's pressed.

Fixes #300