### PR TITLE
GitHub content error refactor

### DIFF
--- a/open-authoring/OpenAuthoringError.ts
+++ b/open-authoring/OpenAuthoringError.ts
@@ -1,8 +1,0 @@
-export default class OpenAuthoringError extends Error {
-    code: number
-    constructor(message, code) {
-        super(message)
-        this.message = message
-        this.code = code
-    }
-}

--- a/open-authoring/github-error/OpenAuthoringErrorModal.tsx
+++ b/open-authoring/github-error/OpenAuthoringErrorModal.tsx
@@ -1,9 +1,13 @@
 import { ActionableModalOptions, ActionableModal } from '../../components/ui'
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState } from 'react'
 import { useCMS } from 'tinacms'
-import OpenAuthoringError from '../OpenAuthoringError'
 import { useOpenAuthoring } from '../open-authoring/OpenAuthoringProvider'
 import { getModalProps } from './github-interpeter'
+
+interface OpenAuthoringError extends Error {
+  status: number
+  message: string
+}
 
 interface Props {
   error: OpenAuthoringError

--- a/open-authoring/github-error/github-interpeter.ts
+++ b/open-authoring/github-error/github-interpeter.ts
@@ -18,7 +18,7 @@ export const getModalProps = async (
     action: stopEditing,
   }
 
-  switch (error.code) {
+  switch (error.status) {
     case 401: {
       // Unauthorized
       return {
@@ -58,7 +58,7 @@ export const getModalProps = async (
   }
 
   return {
-    title: `Error  ${error.code}`,
+    title: `Error  ${error.status}`,
     message: error.message,
     actions: [cancelEditModeAction, reauthenticateAction],
   }

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -19,8 +19,8 @@ import OpenAuthoringSiteForm from '../../components/layout/OpenAuthoringSiteForm
 const fg = require('fast-glob')
 import { useOpenAuthoring } from '../../open-authoring/open-authoring/OpenAuthoringProvider'
 import { Button } from '../../components/ui/Button'
-import OpenAuthoringError from '../../open-authoring/OpenAuthoringError'
 import Error from 'next/error'
+import { GithubError } from '../../utils/github/GithubError'
 
 function BlogTemplate({
   markdownFile,
@@ -120,7 +120,7 @@ export const getStaticProps: GetStaticProps = async function({
     accessToken,
   } = getGithubDataFromPreviewProps(previewData)
 
-  let previewError: OpenAuthoringError = null
+  let previewError: GithubError = null
   let file = {}
   try {
     file = await getMarkdownFile(
@@ -129,9 +129,9 @@ export const getStaticProps: GetStaticProps = async function({
       accessToken
     )
   } catch (e) {
-    if (e instanceof OpenAuthoringError) {
+    if (e instanceof GithubError) {
       previewError = { ...e } //workaround since we cant return error as JSON
-    } else if (e.code === 'ENOENT') {
+    } else if (e.status === 'ENOENT') {
       return { props: {} } // will render the 404 error
     } else {
       throw e

--- a/pages/community.tsx
+++ b/pages/community.tsx
@@ -23,7 +23,7 @@ import { getJsonFile } from '../utils/getJsonFile'
 import { getGithubDataFromPreviewProps } from '../utils/github/sourceProviderConnection'
 import { useGithubJsonForm } from '../utils/github/useGithubJsonForm'
 import OpenAuthoringSiteForm from '../components/layout/OpenAuthoringSiteForm'
-import OpenAuthoringError from '../open-authoring/OpenAuthoringError'
+import { GithubError } from '../utils/github/GithubError'
 
 function CommunityPage({
   community,
@@ -168,7 +168,7 @@ export const getStaticProps: GetStaticProps = async function({
   } = getGithubDataFromPreviewProps(previewData)
   const { default: metadata } = await import('../content/siteConfig.json')
 
-  let previewError: OpenAuthoringError = null
+  let previewError: GithubError = null
   let communityData = {}
   try {
     communityData = await getJsonFile(
@@ -177,7 +177,7 @@ export const getStaticProps: GetStaticProps = async function({
       accessToken
     )
   } catch (e) {
-    if (e instanceof OpenAuthoringError) {
+    if (e instanceof GithubError) {
       previewError = { ...e } //workaround since we cant return error as JSON
     } else {
       throw e

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -21,7 +21,7 @@ import { TinaIcon } from '../../components/logo'
 import { useGithubMarkdownForm } from '../../utils/github/useGithubMarkdownForm'
 import { getDocProps } from '../../utils/docs/getDocProps'
 import OpenAuthoringSiteForm from '../../components/layout/OpenAuthoringSiteForm'
-import OpenAuthoringError from '../../open-authoring/OpenAuthoringError'
+import { GithubError } from '../../utils/github/GithubError'
 
 function DocTemplate(props) {
   // Registers Tina Form
@@ -105,7 +105,7 @@ export const getStaticProps: GetStaticProps = async function(props) {
   try {
     return getDocProps(props, slug)
   } catch (e) {
-    if (e instanceof OpenAuthoringError) {
+    if (e instanceof GithubError) {
       return {
         props: {
           previewError: { ...e }, //workaround since we cant return error as JSON

--- a/pages/docs/index.tsx
+++ b/pages/docs/index.tsx
@@ -1,13 +1,13 @@
 import DocTemplate from './[...slug]'
 import { getDocProps } from '../../utils/docs/getDocProps'
 import { GetStaticProps } from 'next'
-import OpenAuthoringError from '../../open-authoring/OpenAuthoringError'
+import { GithubError } from '../../utils/github/GithubError'
 
 export const getStaticProps: GetStaticProps = async function(props) {
   try {
     return await getDocProps(props, 'index')
   } catch (e) {
-    if (e instanceof OpenAuthoringError) {
+    if (e instanceof GithubError) {
       return {
         props: {
           previewError: { ...e }, //workaround since we cant return error as JSON

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -28,7 +28,7 @@ import { useGithubJsonForm } from '../utils/github/useGithubJsonForm'
 import { getJsonFile } from '../utils/getJsonFile'
 import { getGithubDataFromPreviewProps } from '../utils/github/sourceProviderConnection'
 import OpenAuthoringSiteForm from '../components/layout/OpenAuthoringSiteForm'
-import OpenAuthoringError from '../open-authoring/OpenAuthoringError'
+import { GithubError } from '../utils/github/GithubError'
 
 const HomePage = (props: any) => {
   const [formData, form] = useGithubJsonForm(
@@ -217,7 +217,7 @@ export const getStaticProps: GetStaticProps = async function({
     sourceProviderConnection,
     accessToken,
   } = getGithubDataFromPreviewProps(previewData)
-  let previewError: OpenAuthoringError = null
+  let previewError: GithubError = null
   let homeData = {}
   try {
     homeData = await getJsonFile(
@@ -226,7 +226,7 @@ export const getStaticProps: GetStaticProps = async function({
       accessToken
     )
   } catch (e) {
-    if (e instanceof OpenAuthoringError) {
+    if (e instanceof GithubError) {
       previewError = { ...e } //workaround since we cant return error as JSON
     } else {
       throw e

--- a/pages/teams.tsx
+++ b/pages/teams.tsx
@@ -14,7 +14,7 @@ import { getGithubDataFromPreviewProps } from '../utils/github/sourceProviderCon
 import OpenAuthoringSiteForm from '../components/layout/OpenAuthoringSiteForm'
 import { InlineBlocks } from 'react-tinacms-inline'
 import { useGithubJsonForm } from '../utils/github/useGithubJsonForm'
-import OpenAuthoringError from '../open-authoring/OpenAuthoringError'
+import { GithubError } from '../utils/github/GithubError'
 
 const formOptions = {
   label: 'Teams',
@@ -121,7 +121,7 @@ export const getStaticProps: GetStaticProps = async function({
     accessToken,
   } = getGithubDataFromPreviewProps(previewData)
 
-  let previewError: OpenAuthoringError = null
+  let previewError: GithubError = null
   let teamsData = {}
   try {
     teamsData = await getJsonFile(
@@ -130,7 +130,7 @@ export const getStaticProps: GetStaticProps = async function({
       accessToken
     )
   } catch (e) {
-    if (e instanceof OpenAuthoringError) {
+    if (e instanceof GithubError) {
       previewError = { ...e } //workaround since we cant return error as JSON
     } else {
       throw e

--- a/utils/github/GithubError.ts
+++ b/utils/github/GithubError.ts
@@ -1,0 +1,8 @@
+export class GithubError extends Error {
+  status: number
+  constructor(message, status) {
+    super(message)
+    this.message = message
+    this.status = status
+  }
+}

--- a/utils/github/getContent.ts
+++ b/utils/github/getContent.ts
@@ -1,5 +1,4 @@
 const axios = require('axios')
-const qs = require('qs')
 
 export const getContent = async (
   repoFullName,
@@ -14,10 +13,4 @@ export const getContent = async (
       Authorization: 'token ' + accessToken,
     },
   })
-    .then(resp => {
-      return resp
-    })
-    .catch(err => {
-      return err // TODO - this should be caught outside of this scope
-    })
 }

--- a/utils/github/getDecodedData.ts
+++ b/utils/github/getDecodedData.ts
@@ -1,5 +1,5 @@
 import { getContent } from './getContent'
-import OpenAuthoringError from '../../open-authoring/OpenAuthoringError'
+import { GithubError } from './GithubError'
 const atob = require('atob')
 
 const b64DecodeUnicode = str => {
@@ -23,7 +23,7 @@ const getDecodedData = async (repoFullName, headBranch, path, accessToken) => {
     ;({ data } = await getContent(repoFullName, headBranch, path, accessToken))
   } catch (e) {
     const errorStatus = e.response?.status || 500
-    throw new OpenAuthoringError('Failed to get data.', errorStatus)
+    throw new GithubError('Failed to get data.', errorStatus)
   }
 
   return { ...data, content: b64DecodeUnicode(data.content) }

--- a/utils/github/getDecodedData.ts
+++ b/utils/github/getDecodedData.ts
@@ -17,15 +17,12 @@ const b64DecodeUnicode = str => {
 // TODO - this name kinda sucks,
 // Throw a formatted error on 404, and decode github data properly
 const getDecodedData = async (repoFullName, headBranch, path, accessToken) => {
-  const { data, ...response } = await getContent(
-    repoFullName,
-    headBranch,
-    path,
-    accessToken
-  )
+  let data = null
 
-  const errorStatus = response?.response?.status || 200
-  if (errorStatus < 200 || errorStatus > 299) {
+  try {
+    ;({ data } = await getContent(repoFullName, headBranch, path, accessToken))
+  } catch (e) {
+    const errorStatus = e.response?.status || 500
     throw new OpenAuthoringError('Failed to get data.', errorStatus)
   }
 

--- a/utils/github/getFiles.ts
+++ b/utils/github/getFiles.ts
@@ -1,19 +1,25 @@
 import { getContent } from './getContent'
 import { SourceProviderConnection } from './sourceProviderConnection'
+import OpenAuthoringError from '../../open-authoring/OpenAuthoringError'
 
 export const getFiles = async (
   filePath: string,
   sourceProviderConnection: SourceProviderConnection,
   accessToken: string
 ) => {
-  const response = await getContent(
-    sourceProviderConnection.forkFullName,
-    sourceProviderConnection.headBranch || 'master',
-    filePath,
-    accessToken
-  )
+  let data
 
-  return response.data
-    .filter(file => file.type === 'file')
-    .map(file => file.path)
+  try {
+    ;({ data } = await getContent(
+      sourceProviderConnection.forkFullName,
+      sourceProviderConnection.headBranch || 'master',
+      filePath,
+      accessToken
+    ))
+  } catch (e) {
+    const errorStatus = e.response?.status || 500
+    throw new OpenAuthoringError('Failed to get data.', errorStatus)
+  }
+
+  return data.filter(file => file.type === 'file').map(file => file.path)
 }

--- a/utils/github/getFiles.ts
+++ b/utils/github/getFiles.ts
@@ -1,6 +1,6 @@
 import { getContent } from './getContent'
 import { SourceProviderConnection } from './sourceProviderConnection'
-import OpenAuthoringError from '../../open-authoring/OpenAuthoringError'
+import { GithubError } from './GithubError'
 
 export const getFiles = async (
   filePath: string,
@@ -18,7 +18,7 @@ export const getFiles = async (
     ))
   } catch (e) {
     const errorStatus = e.response?.status || 500
-    throw new OpenAuthoringError('Failed to get data.', errorStatus)
+    throw new GithubError('Failed to get data.', errorStatus)
   }
 
   return data.filter(file => file.type === 'file').map(file => file.path)

--- a/utils/github/useGithubFileForm.ts
+++ b/utils/github/useGithubFileForm.ts
@@ -3,7 +3,7 @@ import { Options } from 'next-tinacms-markdown'
 import { useCMS, useLocalForm } from 'tinacms'
 import { getForkName } from '../../open-authoring/open-authoring/repository'
 import { FORM_ERROR } from 'final-form'
-import OpenAuthoringError from '../../open-authoring/OpenAuthoringError'
+import { GithubError } from './GithubError'
 
 export const useGithubFileForm = <T = any>(
   file: GitFile<T>,
@@ -37,7 +37,7 @@ export const useGithubFileForm = <T = any>(
           setSha(response.content.sha)
         })
         .catch(e => {
-          return { [FORM_ERROR]: new OpenAuthoringError(e.message, e.status) }
+          return { [FORM_ERROR]: e }
         })
     },
   })

--- a/utils/plugins/MarkdownCreatorPlugin.ts
+++ b/utils/plugins/MarkdownCreatorPlugin.ts
@@ -2,7 +2,6 @@ import { toMarkdownString } from 'next-tinacms-markdown'
 import { CMS, Field, AddContentPlugin } from 'tinacms'
 import { GithubOptions } from '../github/useGitFileSha'
 import { FORM_ERROR } from 'final-form'
-import OpenAuthoringError from '../../open-authoring/OpenAuthoringError'
 import { getCachedFormData, setCachedFormData } from '../formCache'
 
 type MaybePromise<T> = Promise<T> | T
@@ -102,7 +101,7 @@ export class MarkdownCreatorPlugin<FormShape = any, FrontmatterShape = any>
         }
       })
       .catch(e => {
-        return { [FORM_ERROR]: new OpenAuthoringError(e.message, e.status) }
+        return { [FORM_ERROR]: e }
       })
   }
 }

--- a/utils/plugins/github-api/GithubApi.ts
+++ b/utils/plugins/github-api/GithubApi.ts
@@ -1,5 +1,4 @@
 import { b64EncodeUnicode } from './base64'
-import GithubError from './GithubError'
 
 export class GithubApi {
   proxy: string
@@ -126,5 +125,14 @@ export class GithubApi {
       method: 'POST',
       body: JSON.stringify(data),
     })
+  }
+}
+
+class GithubError extends Error {
+  status: number
+  constructor(message, status) {
+    super(message)
+    this.message = message
+    this.status = status
   }
 }

--- a/utils/plugins/github-api/GithubError.ts
+++ b/utils/plugins/github-api/GithubError.ts
@@ -1,8 +1,0 @@
-export default class GithubError extends Error {
-    status: number
-    constructor(message, status) {
-        super(message)
-        this.message = message
-        this.status = status
-    }
-}


### PR DESCRIPTION
- Replace "OpenAuthoring" error with "GithubError".
- in [getContent](https://github.com/tinacms/tinacms.org/compare/github-content-error-refactor?expand=1#diff-ae9280b5816ca3c82ebdd87dddcb4c6b), we were returning error with response instead of bubbling the error up. 
- In [a few cases](https://github.com/tinacms/tinacms.org/compare/github-content-error-refactor?expand=1#diff-c379cba35ed0c09a44ea341b3ef071c4L40), we were catching error, and creating a new error with same format