### PR TITLE
Fix capitalisation of import

### DIFF
--- a/content/docs/inline-blocks/block-textarea.md
+++ b/content/docs/inline-blocks/block-textarea.md
@@ -18,7 +18,7 @@ Inline `BlockTextarea` represents a multiline text input. It should be used for 
 Below is an example of how `BlockTextarea` may be used in a [Block Component](/docs/inline-blocks#block-component) definition.
 
 ```jsx
-import { BlocksControls, BlockTextArea } from 'react-tinacms-inline'
+import { BlocksControls, BlockTextarea } from 'react-tinacms-inline'
 
 // Example 'SupportCopy' Block
 export function SupportCopy({ index }) {


### PR DESCRIPTION
The name of the import is `BlockTextarea` not `BlockTextArea`