### PR TITLE
Fix custom fields examples

### DIFF
--- a/content/docs/fields/custom-fields.md
+++ b/content/docs/fields/custom-fields.md
@@ -93,10 +93,10 @@ cms.fields.add({
   Component({ input, meta, field }) {
     return (
       <div>
-        <label htmFor={input.name}>{field.label || field.name}</label>
+        <label htmlFor={input.name}>{field.label || field.name}</label>
         <div>{field.description}</div>
         <input type="email" {...input} />
-        <div class="field-error">{meta.error}</div>
+        <div className="field-error">{meta.error}</div>
       </div>
     )
   },

--- a/content/docs/gatsby/custom-fields.md
+++ b/content/docs/gatsby/custom-fields.md
@@ -32,10 +32,10 @@ import React from 'react'
 export function EmailField({ input, meta, field }) {
   return (
     <div>
-      <label htmFor={input.name}>{field.label || field.name}</label>
+      <label htmlFor={input.name}>{field.label || field.name}</label>
       <div>{field.description}</div>
       <input type="email" {...input} />
-      <div class="field-error">{meta.error}</div>
+      <div className="field-error">{meta.error}</div>
     </div>
   )
 }


### PR DESCRIPTION
`class` prop on a div should be `className`
`htmFor` prop on a div should be `htmlFor`