### PR TITLE
docs: add blurb stating workaround for editing on the base

### DIFF
--- a/content/docs/nextjs/github-public-repo.md
+++ b/content/docs/nextjs/github-public-repo.md
@@ -269,6 +269,8 @@ export const getStaticProps: GetStaticProps = async function({
 }
 ```
 
+> We are currently working on making it possible to make commits directly on the base repository. Until then, to test editing on your own site you will need to test with a separate Github account.
+
 ## Using GitHub Forms
 
 Any forms that we have on our site can be created with the `useGithubJsonForm` or `useGithubMarkdownForm` helpers. These helpers will fetch and post data through the GitHub API via the `GithubClient` we registered in `_app.tsx`.


### PR DESCRIPTION
Add a blurb stating workaround for editing a site in which you own.

fixes #357 