### PR TITLE
Adjust Docs Nav Submenu Item Font

### DIFF
--- a/components/layout/DocsTextWrapper.tsx
+++ b/components/layout/DocsTextWrapper.tsx
@@ -7,4 +7,5 @@ import DocsRichText from '../styles/DocsRichText'
 
 export const DocsTextWrapper = React.memo(styled.div`
   ${DocsRichText}
+  min-height: 68vh;
 `)

--- a/components/ui/DocsNav.tsx
+++ b/components/ui/DocsNav.tsx
@@ -13,6 +13,7 @@ interface NavSection {
   title: string
   items: NavSection[]
   collapsible?: boolean
+  isTunerFont?: boolean
   returnLink?: {
     url: string
     label: string
@@ -47,12 +48,19 @@ export const NavSection = (section: NavSection) => {
         <NavItemHeader onClick={() => collapsible && setExpanded(!expanded)}>
           {section.slug && !hasChildren ? (
             <DynamicLink href={section.slug} passHref>
-              <NavSectionTitle as="a" highlighted={highlighted}>
+              <NavSectionTitle
+                as="a"
+                highlighted={highlighted}
+                isTunerFont={section.isTunerFont}
+              >
                 {section.title}
               </NavSectionTitle>
             </DynamicLink>
           ) : (
-            <NavSectionTitle highlighted={highlighted}>
+            <NavSectionTitle
+              highlighted={highlighted}
+              isTunerFont={section.isTunerFont || true}
+            >
               {section.title}
             </NavSectionTitle>
           )}
@@ -126,7 +134,6 @@ export const DocsNav = styled(({ open, navItems, ...styleProps }) => {
     </div>
   )
 })`
-  font-family: var(--font-tuner);
   list-style-type: none;
   background-color: var(--color-light);
   overflow-x: hidden;
@@ -211,6 +218,7 @@ const NavItemHeader = styled.div`
 
 interface NavSectionTitleProps {
   highlighted: boolean
+  isTunerFont?: boolean
 }
 
 const NavSectionTitle = styled.span<NavSectionTitleProps>`
@@ -224,6 +232,12 @@ const NavSectionTitle = styled.span<NavSectionTitleProps>`
   &:focus {
     color: var(--color-primary);
   }
+
+  ${props =>
+    props.isTunerFont &&
+    css`
+      font-family: var(--font-tuner);
+    `}
 
   ${props =>
     props.highlighted &&

--- a/content/guides/index.md
+++ b/content/guides/index.md
@@ -2,4 +2,4 @@
 title: TinaCMS Guides
 ---
 
-Lorem ipsum dolor sit amet
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in.

--- a/content/toc-doc.json
+++ b/content/toc-doc.json
@@ -50,7 +50,8 @@
   {
     "title": "Forms",
     "id": "forms",
-    "slug": "/docs/forms"
+    "slug": "/docs/forms",
+    "isTunerFont": "true"
   },
   {
     "title": "Fields",
@@ -132,7 +133,8 @@
   {
     "title": "Media",
     "id": "media",
-    "slug": "/docs/media"
+    "slug": "/docs/media",
+    "isTunerFont": "true"
   },
   {
     "title": "Inline Editing",


### PR DESCRIPTION
- Makes the sub-level nav items in both the docs and guides navs be 'Inter'. I found the Tuner font very difficult to read at this level.
- Adds a min-height on the Docs Text. Since we have so few guides atm, it looked slightly broken with the footer up too close to the content. 

Note that for nav items that don't have children, we need to specifically pass the `isTunerFont` property for this item in `toc.json`. Not ideal but I figure these are the edge cases as most top-level nav items have children.
