### PR TITLE
remove link to slack channel from the contributing doc

### DIFF
--- a/content/docs/contributing/guidelines.md
+++ b/content/docs/contributing/guidelines.md
@@ -4,20 +4,19 @@ id: /docs/contributing/guidelines
 prev: null
 next: /docs/contributing/setting-up
 ---
-
 The following is a set of guidelines and tips for contributing to the TinaCMS and its packages. Please also reference this [doc](https://github.com/tinacms/tinacms/blob/master/CONTRIBUTING.md) for the latest info on contributing.
 
-**If you have questions or need help, please post it on the [Forum](https://community.tinacms.org/).** If you are actively contributing and want to chat with the Tina Team easily, please join our [Slack](https://join.slack.com/t/tinacms/shared_invite/enQtNzgxNDY1OTA3ODI3LTNkNWEwYjQyYTA2ZDZjZGQ2YmI5Y2ZlOWVmMjlkYmYxMzVmNjM0YTk2MWM2MTIzMmMxMDg3NWIxN2EzOWQ0NDM) channel.
+**If you have questions or need help, please post it on the** [**Forum**](https://community.tinacms.org/)**.**
 
 ## How to Contribute
 
-- [Reporting Bugs](https://github.com/tinacms/tinacms/issues)
-- [Suggesting Enhancements](https://github.com/tinacms/tinacms/issues)
-- [Writing Docs, Guides, or Blog Posts](https://github.com/tinacms/tinacms.org)
-- Voluntering for User Testing
-- [Adding features, fixing bugs etc.](https://github.com/tinacms/tinacms/issues)
-- [Answer questions in the Tina Forum](https://community.tinacms.org/)
-- Tackle a [good-first-issue](https://github.com/tinacms/tinacms/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)!
+* [Reporting Bugs](https://github.com/tinacms/tinacms/issues)
+* [Suggesting Enhancements](https://github.com/tinacms/tinacms/issues)
+* [Writing Docs, Guides, or Blog Posts](https://github.com/tinacms/tinacms.org)
+* Voluntering for User Testing
+* [Adding features, fixing bugs etc.](https://github.com/tinacms/tinacms/issues)
+* [Answer questions in the Tina Forum](https://community.tinacms.org/)
+* Tackle a [good-first-issue](https://github.com/tinacms/tinacms/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)!
 
 ## Contributing Code
 
@@ -31,11 +30,11 @@ TinaCMS uses [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.
 
 Packages in Tina are organized according to their name
 
-| Type                    | Naming Convention  | Example Path            |
-| ----------------------- | ------------------ | ----------------------- |
-| Internal packages       | `@tinacms/*`       | `@tinacms/core`         |
-| Node API extensions     | `@tinacms/api-*`   | `@tinacms/api-git`      |
-| React specific packages | `react-tinacms-*`  | `react-tinacms-remark`  |
-| Gastby plugins          | `gatsby-tinacms-*` | `gatsby-tinacms-json`   |
-| NextJS package          | `next-tinacms-*`   | `next-tinacms-markdown` |
-| Demo Projects           | `demo-*`           | `demo-gatsby`           |
+| Type | Naming Convention | Example Path |
+| --- | --- | --- |
+| Internal packages | `@tinacms/*` | `@tinacms/core` |
+| Node API extensions | `@tinacms/api-*` | `@tinacms/api-git` |
+| React specific packages | `react-tinacms-*` | `react-tinacms-remark` |
+| Gastby plugins | `gatsby-tinacms-*` | `gatsby-tinacms-json` |
+| NextJS package | `next-tinacms-*` | `next-tinacms-markdown` |
+| Demo Projects | `demo-*` | `demo-gatsby` |

--- a/content/docs/contributing/guidelines.md
+++ b/content/docs/contributing/guidelines.md
@@ -13,7 +13,7 @@ The following is a set of guidelines and tips for contributing to the TinaCMS an
 * [Reporting Bugs](https://github.com/tinacms/tinacms/issues)
 * [Suggesting Enhancements](https://github.com/tinacms/tinacms/issues)
 * [Writing Docs, Guides, or Blog Posts](https://github.com/tinacms/tinacms.org)
-* Voluntering for User Testing
+* Volunteering for User Testing
 * [Adding features, fixing bugs etc.](https://github.com/tinacms/tinacms/issues)
 * [Answer questions in the Tina Forum](https://community.tinacms.org/)
 * Tackle a [good-first-issue](https://github.com/tinacms/tinacms/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)!


### PR DESCRIPTION
Since the #dev channel in the linked slack is archived with the reasoning that discussions should now all happen in community.tinacms.org it makes sense to remove the link from the docs. 
