### PR TITLE
Change release notes language re: GitHub project

### DIFF
--- a/content/blog/2020-05-19-release-notes.md
+++ b/content/blog/2020-05-19-release-notes.md
@@ -11,19 +11,19 @@ On Thursday we ran [a betting table](https://basecamp.com/shapeup/2.2-chapter-08
 
 The aim of TinaCMS is to let developers create amazing editing experiences. A large part of that is the inline editing experience. To help push this forward we will be creating a prototypical page-builder. Although this project may be used as a reference for future work, the goal of this particular project is _not_ to create a production ready template for people looking to create marketing sites. Instead the goal is to improve the inline editing experience (both UX and DX) so that Tina can be used with complex design systems
 
-### Project 2: Serverless GitHub Auth
+### Project 2: Cross-platform GitHub Workflow
 
-Currently TinaCMS + GitHub requires a server to function. In order to expand the range of possible use-cases we will be spending some to figure out if GitHub can be used without a server. The eventual goal being to support a GitHub-based workflow for people building sites with Create React App, Gatsby, or any other SSG. 
+Our current workflow for using TinaCMS with GitHub requires developers to use Next.js, and involves running a lot of server-side code. In order to expand the range of possible use-cases, we will be spending some to figure out how to create a vendor-agnostic workflow for GitHub; the eventual goal being to support a GitHub-based workflow for people building sites with Create React App, Gatsby, or any other SSG.
 
 ## Deprecation
 
 ### Markdown and HTML Fields as Default Plugins
 
-The WYSIWYG component defined in `react-tinacms-editor` is huge part of `tinacms`. I mean that both figuratively and literally. The WYSIWYG is necessity for editing content, but it takes a lot of code to build an Editor. 
+The WYSIWYG component defined in `react-tinacms-editor` is huge part of `tinacms`. I mean that both figuratively and literally. The WYSIWYG is necessity for editing content, but it takes a lot of code to build an Editor.
 
 Minimizing bundle-size is incredibly important for frontend development and as it stands the `react-tinacms-editor` is responsible for **over 60% of the bundle-size** impact by TinaCMS. Since the Markdown and HTML fields are included by default with `tinacms`, every website that uses Tina will be negatively impacted by that extra code, even if they aren't using them.
 
-As such, we've decided to deprecate the Markdown and HTML fields as _default_ plugins. This goes a long way to improving the performance of sites using TinaCMS. **These plugins are still available** however you will need to install them and include them manually. 
+As such, we've decided to deprecate the Markdown and HTML fields as _default_ plugins. This goes a long way to improving the performance of sites using TinaCMS. **These plugins are still available** however you will need to install them and include them manually.
 
 **This change will be released next week (May 25th 2020).**
 


### PR DESCRIPTION
It's misleading to refer to this project as "serverless" because it implies our previous solution wasn't serverless (since serverless is now a term with lots of connotation tied to it.)

Furthermore, I wanted to clarify that the main goal is to avoid reliance on vendor-specific behavior; minimizing server-side code is a strategy to help us get there.