### PR TITLE
fix: updated inline-wysiwyg docs

### DIFF
--- a/content/docs/inline-editing/inline-wysiwyg.md
+++ b/content/docs/inline-editing/inline-wysiwyg.md
@@ -23,7 +23,8 @@ Below is an example of how an `InlineWysiwyg` field could be defined in an [Inli
 ```jsx
 import ReactMarkdown from 'react-markdown'
 import { useForm, usePlugin } from 'tinacms'
-import { InlineForm, InlineWysiwyg } from 'react-tinacms-inline'
+import { InlineForm } from 'react-tinacms-inline'
+import { InlineWysiwyg }from 'react-tinacms-editor'
 
 // Example 'Page' Component
 export function Page(props) {


### PR DESCRIPTION
got an error when I did
```
yarn add react-tinacms-{editor,github,inline}@next
```
I fixed it by switching the import to this. Should we update docs?