### PR TITLE
Gatsby guide

### DIFF
--- a/content/guides/gatsby/adding-tina/add-gatsby-plugin-tinacms.md
+++ b/content/guides/gatsby/adding-tina/add-gatsby-plugin-tinacms.md
@@ -1,0 +1,70 @@
+---
+title: Adding gatsby-plugin-tinacms
+---
+
+Learn how to set up Tina on an existing Gatsby site.
+
+After this guide, you will have installed and added the TinaCMS sidebar to your project. However, this won't make your content editable. Go to the [next guide](/docs/gatsby/markdown) to learn how to make content editable.
+
+Assumptions: This guide assumes you have the Gatsby CLI installed, Node & a package manager.
+
+Note: Don't have a site yet? Refer to the [quickstart page](/docs/gatsby/quickstart).
+
+## Installation
+
+```
+npm install --save gatsby-plugin-tinacms styled-components
+```
+
+or
+
+```
+yarn add gatsby-plugin-tinacms styled-components
+```
+
+## Adding the Plugin
+
+Open your `gatsby-config.js` file and add `'gatsby-plugin-tinacms'` to the list of plugins:
+
+**gatsby-config.js**
+
+```javascript
+module.exports = {
+  // ...
+  plugins: [
+    {
+      resolve: 'gatsby-plugin-tinacms',
+      options: {
+        sidebar: {
+          hidden: process.env.NODE_ENV === 'production',
+          position: 'displace',
+        },
+        plugins: [
+          // We'll add some Tinacms plugins in the next step.
+        ],
+      },
+    },
+    // ...
+  ],
+}
+```
+
+## Accessing the CMS
+
+1. **Start the Gatsby development server**
+
+   ```
+   gatsby develop
+   ```
+
+1. **Visit your Website**
+
+   Go to https://localhost:8000 to access your website.
+
+1. **Open the CMS**
+
+   You will notice there's a pencil icon, this is the way you can toggle the Tina sidebar.
+
+Hooray!
+
+If you see the icon and can open the editing sidebar, this means you've successfully installed & configured Tina. You will see a note that there is no editable content on the site yet. Follow the next steps to learn how to make content editable.

--- a/content/guides/gatsby/adding-tina/creating-forms.md
+++ b/content/guides/gatsby/adding-tina/creating-forms.md
@@ -1,0 +1,123 @@
+---
+title: Creating Forms
+---
+
+After wrapping our App component in the Tina Provider, we can create forms by calling the `useForm` hook inside our Post component. `useForm` returns two values in an array, similar to `React.useState`, which we assign via destructuring:
+
+```js
+const [modifiedValues, form] = useForm(formConfig)
+```
+
+`modifiedValues` contains the values we provide to the form (inside of `formConfig`) after being modified by the end user. `form` contains the form object created by calling `useForm`, which we'll need in a moment.
+
+To simplify our implementation, we'd like to store `modifiedValues` in the `post` variable so that our layout code can continue to work without modification. Let's rename the incoming `post` variable to `initialPost`, to differentiate it from the `post` values that Tina sends back to us:
+
+```js
+export default function Post({ post: initialPost, morePosts, preview }) {
+  const router = useRouter()
+  if (!router.isFallback && !initialPost?.slug) {
+    return <ErrorPage statusCode={404} />
+  }
+
+  //...
+}
+```
+
+## Form Configuration
+
+For details on how to configure forms, take a look at our [form configuration docs](/docs/forms#form-configuration). For the purposes of this guide, we will use the following configuration:
+
+```js
+const formConfig = {
+  id: initialPost.slug,           // a unique identifier for this instance of the form
+  label: 'Blog Post',             // name of the form to appear in the sidebar
+  initialValues: initialPost,     // populate the form with starting values
+  onSubmit: (values) => {         // do something with the data when the form is submitted
+    alert(`Submitting ${values.title}`)
+  }
+  fields: [                    // define fields to appear in the form
+    {
+      name: 'title',           // field name maps to the corresponding key in initialValues
+      label: 'Post Title',     // label that appears above the field
+      component: 'text',       // the component used to handle UI and input to the field
+    },
+    {
+      name: 'rawMarkdownBody', // remember we want `rawMarkdownBody`, not `content` here
+      label: 'Content',
+      component: 'markdown',   // `component` accepts a predefined components or a custom React component
+    },
+  ]
+}
+```
+
+> Note that our `onSubmit` handler is just a stub. How you implement this function will depend on how your content is stored, and will be explored in later guides.
+
+## Adding the Form to the Post Component
+
+First, we'll need to import `useForm` and `usePlugin` from the `tinacms` package:
+
+```js
+import { useForm, usePlugin } from 'tinacms'
+```
+
+Now, just add the form to the `Post` component with the configuration we laid out previously:
+
+```js
+export default function Post({ post, morePosts, preview }) {
+  //...
+
+  const formConfig = {
+    id: initialPost.slug,
+    label: 'Blog Post',
+    initialValues: initialPost,
+    onSubmit: (values) => {
+      alert(`Submitting ${values.title}`)
+    },
+    fields: [
+      {
+        name: 'title',
+        label: 'Post Title',
+        component: 'text',
+      },
+      {
+        name: 'rawMarkdownBody',
+        label: 'Content',
+        component: 'markdown',
+      },
+    ],
+  }
+  const [post, form] = useForm(formConfig)
+
+  const [htmlContent, setHtmlContent] = useState(post.content)
+  const initialContent = useMemo(() => post.rawMarkdownBody, [])
+  useEffect(() => {
+    if (initialContent == post.rawMarkdownBody) return
+    markdownToHtml(post.rawMarkdownBody).then(setHtmlContent)
+  }, [post.rawMarkdownBody])
+
+  return (
+    //...
+  )
+}
+```
+
+### Adding the Form to the Sidebar
+
+At this point, the form is all wired up with its field configuration, and our `post` object will send updated values back through our layout rendering code. However, if you've followed along this far, you'll see that the form does not appear in the Tina sidebar.
+
+In order to hook our form into the sidebar, we'll need to call `usePlugin` and pass it our form object:
+
+```diff
+  const [post, form] = useForm(formConfig)
++ usePlugin(form)
+```
+
+That's it!
+
+> **Why do we need to call usePlugin?**
+>
+> There are a few different ways to use forms: in the sidebar, in the global utility menu, and [inline](/docs/inline-editing). How you plan to use the form will determine how you should set it up in the CMS.
+
+## More Info
+
+- [Tina Docs: Forms](/docs/forms)

--- a/content/guides/gatsby/adding-tina/meta.json
+++ b/content/guides/gatsby/adding-tina/meta.json
@@ -1,0 +1,11 @@
+{
+  "title": "Adding Tina to a Gatsby Site",
+  "steps": [
+    {
+      "title": "Add gatsby-plugin-tinacms",
+      "id": "/guides/gatsby/adding-tina/add-gatsby-plugin-tinacms",
+      "slug": "/guides/gatsby/adding-tina/add-gatsby-plugin-tinacms",
+      "data": "./add-gatsby-plugin-tinacms.md"
+    }
+  ]
+}

--- a/content/guides/gatsby/adding-tina/meta.json
+++ b/content/guides/gatsby/adding-tina/meta.json
@@ -14,12 +14,6 @@
       "data": "./project-setup.md"
     },
     {
-      "title": "Adding the Tina Provider",
-      "id": "/guides/gatsby/adding-tina/adding-tina-provider",
-      "slug": "/guides/gatsby/adding-tina/adding-tina-provider",
-      "data": "./adding-tina-provider.md"
-    },
-    {
       "title": "Creating Forms",
       "id": "/guides/gatsby/adding-tina/creating-forms",
       "slug": "/guides/gatsby/adding-tina/creating-forms",

--- a/content/guides/gatsby/adding-tina/meta.json
+++ b/content/guides/gatsby/adding-tina/meta.json
@@ -2,10 +2,34 @@
   "title": "Adding Tina to a Gatsby Site",
   "steps": [
     {
-      "title": "Add gatsby-plugin-tinacms",
-      "id": "/guides/gatsby/adding-tina/add-gatsby-plugin-tinacms",
-      "slug": "/guides/gatsby/adding-tina/add-gatsby-plugin-tinacms",
-      "data": "./add-gatsby-plugin-tinacms.md"
+      "title": "Overview",
+      "id": "/guides/gatsby/adding-tina/overview",
+      "slug": "/guides/gatsby/adding-tina/overview",
+      "data": "./overview.md"
+    },
+    {
+      "title": "Project Setup",
+      "id": "/guides/gatsby/adding-tina/project-setup",
+      "slug": "/guides/gatsby/adding-tina/project-setup",
+      "data": "./project-setup.md"
+    },
+    {
+      "title": "Adding the Tina Provider",
+      "id": "/guides/gatsby/adding-tina/adding-tina-provider",
+      "slug": "/guides/gatsby/adding-tina/adding-tina-provider",
+      "data": "./adding-tina-provider.md"
+    },
+    {
+      "title": "Creating Forms",
+      "id": "/guides/gatsby/adding-tina/creating-forms",
+      "slug": "/guides/gatsby/adding-tina/creating-forms",
+      "data": "./creating-forms.md"
+    },
+    {
+      "title": "Next Steps",
+      "id": "/guides/gatsby/adding-tina/next-steps",
+      "slug": "/guides/gatsby/adding-tina/next-steps",
+      "data": "./next-steps.md"
     }
   ]
 }

--- a/content/guides/gatsby/adding-tina/next-steps.md
+++ b/content/guides/gatsby/adding-tina/next-steps.md
@@ -1,0 +1,27 @@
+---
+title: Next Steps
+---
+
+At this point, we've bootstrapped Tina into the Next.js blog starter. We were able to do so by making a few small modifications:
+
+1. Added [client-side content transformation](/guides/nextjs/adding-tina/project-setup) to the `Post` component
+2. Wrapped the site in [the Tina provider](/guides/nextjs/adding-tina/adding-tina-provider)
+3. [Created a form](http://localhost:3000/guides/nextjs/adding-tina/creating-forms) to edit some values in the `Post` component
+
+This guide is intended as a jumping off point to get you started with Tina, but to make a fully-functional CMS there is a little more work to do.
+
+## Add More Fields
+
+Our simplified example only exposes the title and post body to the Tina form. Take a look at our [fields](/docs/fields) documentation and try adding fields for the rest of the post data in the blog demo.
+
+> **Image Fields**
+>
+> Support for image fields in Tina is still a work-in-progress. Handling images requires setting up a [media store](/docs/media) that integrates with your strategy for saving content. Expect more information on this front soon!
+
+## Inline Editing
+
+Consider creating an **inline editing** experience for your blog, where content is edited directly where it appears on the site instead of in the sidebar. Take a look at our [inline editing docs](/docs/inline-editing) for more information, and expect a guide on this in the near future!
+
+## Saving Content
+
+Editing content isn't much use if you can't save it! Our `onSubmit` handler doesn't really do anything right now. We are currently working on a comprehensive solution for using the GitHub API with Tina and Next.js; keep an eye out for that!

--- a/content/guides/gatsby/adding-tina/next-steps.md
+++ b/content/guides/gatsby/adding-tina/next-steps.md
@@ -2,7 +2,7 @@
 title: Next Steps
 ---
 
-At this point, we've bootstrapped Tina into the Next.js blog starter. We were able to do so by making a few small modifications:
+At this point, we've bootstrapped Tina into the Gatsby blog starter. We were able to do so by making a few small modifications:
 
 1. Added [gatsby-plugin-tinacms](/guides/gatsby/adding-tina/project-setup) to our blog starter.
 2. [Created a form](http://localhost:3000/guides/gatsby/adding-tina/creating-forms) to edit some values in the `Post` template.

--- a/content/guides/gatsby/adding-tina/next-steps.md
+++ b/content/guides/gatsby/adding-tina/next-steps.md
@@ -4,9 +4,8 @@ title: Next Steps
 
 At this point, we've bootstrapped Tina into the Next.js blog starter. We were able to do so by making a few small modifications:
 
-1. Added [client-side content transformation](/guides/nextjs/adding-tina/project-setup) to the `Post` component
-2. Wrapped the site in [the Tina provider](/guides/nextjs/adding-tina/adding-tina-provider)
-3. [Created a form](http://localhost:3000/guides/nextjs/adding-tina/creating-forms) to edit some values in the `Post` component
+1. Added [gatsby-plugin-tinacms](/guides/gatsby/adding-tina/project-setup) to our blog starter.
+2. [Created a form](http://localhost:3000/guides/gatsby/adding-tina/creating-forms) to edit some values in the `Post` template.
 
 This guide is intended as a jumping off point to get you started with Tina, but to make a fully-functional CMS there is a little more work to do.
 
@@ -24,4 +23,4 @@ Consider creating an **inline editing** experience for your blog, where content 
 
 ## Saving Content
 
-Editing content isn't much use if you can't save it! Our `onSubmit` handler doesn't really do anything right now. We are currently working on a comprehensive solution for using the GitHub API with Tina and Next.js; keep an eye out for that!
+Editing content isn't much use if you can't save it! Our `onSubmit` handler doesn't really do anything right now. You can look at using the `gatsby-tinacms-git` to edit content Markdown and JSON sourced from your repository.

--- a/content/guides/gatsby/adding-tina/next-steps.md
+++ b/content/guides/gatsby/adding-tina/next-steps.md
@@ -13,14 +13,10 @@ This guide is intended as a jumping off point to get you started with Tina, but 
 
 Our simplified example only exposes the title and post body to the Tina form. Take a look at our [fields](/docs/fields) documentation and try adding fields for the rest of the post data in the blog demo.
 
-> **Image Fields**
->
-> Support for image fields in Tina is still a work-in-progress. Handling images requires setting up a [media store](/docs/media) that integrates with your strategy for saving content. Expect more information on this front soon!
-
 ## Inline Editing
 
 Consider creating an **inline editing** experience for your blog, where content is edited directly where it appears on the site instead of in the sidebar. Take a look at our [inline editing docs](/docs/inline-editing) for more information, and expect a guide on this in the near future!
 
 ## Saving Content
 
-Editing content isn't much use if you can't save it! Our `onSubmit` handler doesn't really do anything right now. You can look at using the `gatsby-tinacms-git` to edit content Markdown and JSON sourced from your repository.
+Editing content isn't much use if you can't save it! Our `onSubmit` handler doesn't really do anything right now. You can look at using the [`gatsby-tinacms-git`](/docs/gatsby/markdown) to edit content Markdown and JSON sourced from your repository.

--- a/content/guides/gatsby/adding-tina/overview.md
+++ b/content/guides/gatsby/adding-tina/overview.md
@@ -1,0 +1,11 @@
+---
+title: Overview
+---
+
+This guide will show you how to set up Tina on a Gatsby site. Since Gatsby let's you pull contentin from multiple data sources, these docs will only cover adding to Tina to your site and creating forms for content only stored in memory.
+
+<!--
+> **The Finished Product**
+>
+> The repository at [dwalkr/next-tina-blog-starter](https://github.com/dwalkr/next-tina-blog-starter) contains the end product of this guide. Feel free to fork it and follow along!
+-->

--- a/content/guides/gatsby/adding-tina/overview.md
+++ b/content/guides/gatsby/adding-tina/overview.md
@@ -2,7 +2,7 @@
 title: Overview
 ---
 
-This guide will show you how to set up Tina on a Gatsby site. Since Gatsby let's you pull contentin from multiple data sources, these docs will only cover adding to Tina to your site and creating forms for content only stored in memory.
+This guide will show you how to set up Tina on a Gatsby site. Since Gatsby lets you pull content in from multiple data sources, these docs will only cover adding to Tina to your site and creating forms for content stored in memory.
 
 <!--
 > **The Finished Product**

--- a/content/guides/gatsby/adding-tina/project-setup.md
+++ b/content/guides/gatsby/adding-tina/project-setup.md
@@ -1,28 +1,29 @@
 ---
-title: Adding gatsby-plugin-tinacms
+title: Project Setup
 ---
 
-Learn how to set up Tina on an existing Gatsby site.
+We're going to use the [Gatsby Starter Blog](https://www.gatsbyjs.org/starters/gatsbyjs/gatsby-starter-blog/) as the base for our project. Create a new project by running the following commands in your terminal:
 
-After this guide, you will have installed and added the TinaCMS sidebar to your project. However, this won't make your content editable. Go to the [next guide](/docs/gatsby/markdown) to learn how to make content editable.
-
-Assumptions: This guide assumes you have the Gatsby CLI installed, Node & a package manager.
-
-Note: Don't have a site yet? Refer to the [quickstart page](/docs/gatsby/quickstart).
-
-## Installation
-
-```
-npm install --save gatsby-plugin-tinacms styled-components
+```bash
+gatsby new gatsby-starter-blog https://github.com/gatsbyjs/gatsby-starter-blog
 ```
 
-or
+This will create a new blog starter in the `gatsby-starter-blog` directory. Navigate to the project directory and run `yarn dev` to start the website in dev mode.
+
+```bash
+cd gatsby-starter-blog
+gatsby develop
+```
+
+You will now be able to visit your site at https://localhost:8000
+
+## Installing
 
 ```
 yarn add gatsby-plugin-tinacms styled-components
 ```
 
-## Adding the Plugin
+## Add the Plugin
 
 Open your `gatsby-config.js` file and add `'gatsby-plugin-tinacms'` to the list of plugins:
 
@@ -35,12 +36,10 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-tinacms',
       options: {
-        sidebar: {
-          hidden: process.env.NODE_ENV === 'production',
-          position: 'displace',
-        },
+        // The CMS will be disabled on your production site
+        enabled: process.env.NODE_ENV !== 'production',
         plugins: [
-          // We'll add some Tinacms plugins in the next step.
+          // We'll add some gatsby-tinacms plugins later
         ],
       },
     },
@@ -51,7 +50,7 @@ module.exports = {
 
 ## Accessing the CMS
 
-1. **Start the Gatsby development server**
+1. **Restart the Gatsby development server**
 
    ```
    gatsby develop

--- a/content/guides/gatsby/meta.json
+++ b/content/guides/gatsby/meta.json
@@ -1,0 +1,3 @@
+{
+  "title": "Gatsby"
+}


### PR DESCRIPTION
[Preview URL](https://tinacms-site-next-git-gatsby-guide.tinacms.now.sh/guides/gatsby/adding-tina/overview)

This PR migrates the Gatsby docs to being a guide

- [x] Overview: This could use more work but it's a good start
- [x] Project Setup: adding the plugin
- [x] Creating Forms: still the Next text
- [x] Next steps