### PR TITLE
style: add 5px to github button to show star count

### DIFF
--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -24,7 +24,7 @@ export const Header = ({ color, fixedIcon, ...styleProps }: HeaderProps) => {
         src="https://ghbtns.com/github-btn.html?user=tinacms&repo=tinacms&type=star&count=true&size=large"
         frameBorder="0"
         scrolling="0"
-        width="145px"
+        width="150px"
         height="30px"
       ></iframe>
     </StyledHeader>

--- a/components/ui/DocsNav.tsx
+++ b/components/ui/DocsNav.tsx
@@ -127,7 +127,7 @@ export const DocsNav = styled(({ open, navItems, ...styleProps }) => {
             src="https://ghbtns.com/github-btn.html?user=tinacms&repo=tinacms&type=star&count=true&size=large"
             frameBorder="0"
             scrolling="0"
-            width="145px"
+            width="150px"
             height="30px"
           ></iframe>
         </li>


### PR DESCRIPTION
I needed a break from writing guides. So I made the GitHub star count show up again.