### PR TITLE
Restructure docs

### DIFF
--- a/content/docs/fields/blocks.md
+++ b/content/docs/fields/blocks.md
@@ -6,6 +6,7 @@ consumes:
   - file: /packages/tinacms/src/plugins/fields/BlocksFieldPlugin.tsx
     details: Shows blocks interface
 ---
+
 The **Blocks** field represents a list of items, similar to the [Group List](/docs/fields/group-list) field, but allows each entity in the list to have a unique shape.
 
 > For an in-depth explanation of the Blocks field, read our ["What are Blocks?"](/blog/what-are-blocks/) blog post. To see a real-world example of Blocks in use, check out the [Tina Grande Starter](https://github.com/tinacms/tina-starter-grande).
@@ -63,24 +64,6 @@ The source data for the `ContentBlock` might look like the example below. When n
 
 ## Blocks Field Options
 
-* `name`: The path to the blocks value in the data being edited.
-* `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/fields).
-* `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
-* `description`: An optional description of the field.
-* `templates`: A list of **Block templates** that define the fields used in the Blocks.
-
-## Block Template Options
-
-* `label`: A human readable label for the Block.
-* `key`: Should be unique to optimize the [rendering of the list](https://reactjs.org/docs/lists-and-keys.html).
-* `fields`: An array of fields that will render as a sub-menu for each block. The fields should map to editable content.
-* `defaultItem`: An optional function to provide the block with default data upon being created.
-* `itemProps`: An optional function that generates `props` for each group item.
-  * `key`: This property is used to optimize the rendering of lists. If rendering is causing problems, use `defaultItem` to generate a new key, as is seen in [this example](http://tinacms.org/docs/fields/group-list#definition). Feel free to reference the [React documentation](https://reactjs.org/docs/lists-and-keys.html) for more on keys and lists.
-  * `label`: A readable label for the new Block.
-
-## Interfaces
-
 ```typescript
 import { Field } from '@tinacms/core'
 
@@ -93,7 +76,19 @@ interface BlocksConfig {
     [key: string]: BlockTemplate
   }
 }
+```
 
+| Option        | Description                                                                                     |
+| ------------- | ----------------------------------------------------------------------------------------------- |
+| `component`   | The name of the plugin component. Always `'blocks'`.                                            |
+| `name`        | The path to some value in the data being edited.                                                |
+| `label`       | A human readable label for the field. Defaults to the `name`. _(Optional)_                      |
+| `description` | Description that expands on the purpose of the field or prompts a specific action. _(Optional)_ |
+| `templates`   | A list of **Block templates** that define the fields used in the Blocks.                        |
+
+## Block Template Options
+
+```typescript
 interface BlockTemplate {
   label: string
   key: string
@@ -107,3 +102,15 @@ interface BlockTemplate {
   }
 }
 ```
+
+| Option        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `label`       | A human readable label for the Block.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `key`         | Should be unique to optimize the [rendering of the list](https://reactjs.org/docs/lists-and-keys.html).                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `fields`      | An array of [`fields`](/docs/fields) that will render as a sub-menu for each group item. The fields should map to editable content.                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `defaultItem` | A function to provide the block with default data upon being created. _(Optional)_                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `itemProps`   | A function that generates `props` for each group item. It takes the item as an argument. _(Optional)_ <br> It returns an object containing, <ul> <li>`key`: This property is used to optimize the rendering of lists. If rendering is causing problems, use `defaultItem` to generate a new key, as is seen in [this example](http://tinacms.org/docs/fields/group-list#definition). Feel free to reference the [React documentation](https://reactjs.org/docs/lists-and-keys.html) for more on keys and lists. </li> <li> `label`: A readable label for the new Block. </li> </ul> |
+
+> This interfaces only shows the keys unique to the blocks field.
+>
+> Visit the [Field Config](/docs/fields) docs for a complete list of options.

--- a/content/docs/fields/color.md
+++ b/content/docs/fields/color.md
@@ -19,6 +19,34 @@ The "block" widget allows the editor to choose from a set of predefined color sw
 
 ![tinacms-block-color-field](/img/fields/block-color-field.png)
 
+## Options
+
+```typescript
+interface ColorConfig {
+  component: 'color'
+  name: string
+  label?: string
+  description?: string
+  colorFormat?: 'hex' | 'rgb' // Defaults to "hex"
+  colors?: string[]
+  widget?: 'sketch' | 'block' // Defaults to "sketch"
+}
+```
+
+| Option        | Description                                                                                                                                                                                                                                  |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `component`   | The name of the plugin component. Always `'color'`.                                                                                                                                                                                          |
+| `name`        | The path to some value in the data being edited.                                                                                                                                                                                             |
+| `label`       | A human readable label for the field. Defaults to the `name`. _(Optional)_                                                                                                                                                                   |
+| `description` | Description that expands on the purpose of the field or prompts a specific action. _(Optional)_                                                                                                                                              |
+| `colorFormat` | Specify whether you want the color value to be a hexadecimal ('hex') or RBG value. _(Optional)_                                                                                                                                              |
+| `colors`      | An array of 'swatch' values that will either display as options below the "sketch" widget, or will serve as swatch options for the "block" widget. If no colors are passed, a set of default colors will render, ROYGBIV style. _(Optional)_ |
+| `widget`      | An optional string indicating whether the "sketch" or "block" widget should render. This will default to "sketch" if no value is passed. _(Optional)_                                                                                        |
+
+> This interfaces only shows the keys unique to the color field.
+>
+> Visit the [Field Config](/docs/fields) docs for a complete list of options.
+
 ## Definition
 
 Below is an example of how a `color` field could be defined in a Gatsby remark form. Read more on passing in form field options [here](/docs/gatsby/markdown#customizing-remark-forms).
@@ -37,29 +65,5 @@ const BlogPostForm = {
     },
     // ...
   ],
-}
-```
-
-## Options
-
-- `name`: The path to some value in the data being edited.
-- `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/fields)
-- `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
-- `description`: An optional description that expands on the purpose of the field or prompts a specific action.
-- `colorFormat`: Optionally specify whether you want the color value to be a hexadecimal ('hex') or RBG value.
-- `colors`: An array of 'swatch' values that will either display as options below the "sketch" widget, or will serve as swatch options for the "block" widget. If no colors are passed, a set of default colors will render, ROYGBIV style.
-- `widget`: An optional string indicating whether the "sketch" or "block" widget should render. This will default to "sketch" if no value is passed.
-
-## Interface
-
-```typescript
-interface ColorConfig {
-  component: 'color'
-  name: string
-  label?: string
-  description?: string
-  colorFormat?: 'hex' | 'rgb' // Defaults to "hex"
-  colors?: string[]
-  widget?: 'sketch' | 'block' // Defaults to "sketch"
 }
 ```

--- a/content/docs/fields/group-list.md
+++ b/content/docs/fields/group-list.md
@@ -13,6 +13,40 @@ Use this field when you want to support _multiple entities_ that all have the sa
 
 ![tinacms-group-list-gif](/gif/group-list.gif)
 
+## Options
+
+```typescript
+import { Field } from '@tinacms/core'
+
+interface GroupListConfig {
+  component: 'group-list'
+  name: string
+  fields: Field[]
+  label?: string
+  defaultItem?: object | (() => object)
+  itemProps?(
+    item: object
+  ): {
+    key?: string
+    label?: string
+  }
+}
+```
+
+| Option        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `component`   | The name of the plugin component. Always `'group-list'`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `name`        | The path to some value in the data being edited.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `fields`      | An array of [`fields`](/docs/fields) that will render as a sub-menu for each group item. The fields should map to editable content.                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `label`       | A human readable label for the field. Defaults to the `name`. _(Optional)_                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `description` | Description that expands on the purpose of the field or prompts a specific action. _(Optional)_                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `defaultItem` | A function to provide the `group-list` item with default data upon being created. _(Optional)_                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `itemProps`   | A function that generates `props` for each group item. It takes the item as an argument. _(Optional)_ <br> It returns an object containing, <ul> <li>`key`: This property is used to optimize the rendering of lists. If rendering is causing problems, use `defaultItem` to generate a new key, as is seen in [this example](http://tinacms.org/docs/fields/group-list#definition). Feel free to reference the [React documentation](https://reactjs.org/docs/lists-and-keys.html) for more on keys and lists. </li> <li> `label`: A readable label for the new `group-list` item. </li> </ul> |
+
+> This interfaces only shows the keys unique to the group-list field.
+>
+> Visit the [Field Config](/docs/fields) docs for a complete list of options.
+
 ## Definition
 
 Below is an example of how a `group-list` field could be defined in a JSON form. Read more on passing in JSON form field config options [here](/docs/gatsby/json#customizing-json-forms).
@@ -76,37 +110,5 @@ const formOptions = {
     },
     //...
   ],
-}
-```
-
-## Field Options
-
-- `name`: The path to some value in the data being edited.
-- `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/fields)
-- `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
-- `description`: An optional description of the field.
-- `fields`: An array of fields that will render as a sub-menu for each group item. The fields should map to editable content.
-- `defaultItem`: An optional function to provide the `group-list` item with default data upon being created.
-- `itemProps`: An optional function that generates `props` for each group item. It takes the item as an argument.
-  - `key`: This property is used to optimize the rendering of lists. If rendering is causing problems, use `defaultItem` to generate a new key, as is seen in [this example](http://tinacms.org/docs/fields/group-list#definition). Feel free to reference the [React documentation](https://reactjs.org/docs/lists-and-keys.html) for more on keys and lists.
-  - `label`: A readable label for the new `group-list` item.
-
-## Interface
-
-```typescript
-import { Field } from '@tinacms/core'
-
-interface GroupListConfig {
-  component: 'group-list'
-  name: string
-  label?: string
-  fields: Field[]
-  defaultItem?: object | (() => object)
-  itemProps?(
-    item: object
-  ): {
-    key?: string
-    label?: string
-  }
 }
 ```

--- a/content/docs/fields/html.md
+++ b/content/docs/fields/html.md
@@ -11,6 +11,28 @@ The `html` field represents a chunk of HTML content.
 
 ![tinacms-markdown-field](/img/fields/markdown.png)
 
+## Options
+
+```typescript
+interface HtmlConfig {
+  component: 'html'
+  name: string
+  label?: string
+  description?: string
+}
+```
+
+| Option        | Description                                                                                     |
+| ------------- | ----------------------------------------------------------------------------------------------- |
+| `component`   | The name of the plugin component. Always `'html'`.                                              |
+| `name`        | The path to some value in the data being edited.                                                |
+| `label`       | A human readable label for the field. Defaults to the `name`. _(Optional)_                      |
+| `description` | Description that expands on the purpose of the field or prompts a specific action. _(Optional)_ |
+
+> This interfaces only shows the keys unique to the html field.
+>
+> Visit the [Field Config](/docs/fields) docs for a complete list of options.
+
 ## Adding the Plugin
 
 The `html` field plugin is not a default plugin. In order to use it in your site you must install the `react-tinacms-editor` package:
@@ -45,20 +67,3 @@ const BlogPostForm = {
   ],
 }
 ```
-
-## Options
-
-```typescript
-interface HtmlConfig {
-  name: string
-  component: 'html'
-  label?: string
-  description?: string
-}
-```
-
-| Option        | Description                                                                                                                                              |     |
-| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
-| `name`        | The path to some value in the data being edited.                                                                                                         |
-| `label`       | A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name. |
-| `description` | An optional description that expands on the purpose of the field or prompts a specific action.                                                           |

--- a/content/docs/fields/html.md
+++ b/content/docs/fields/html.md
@@ -48,12 +48,6 @@ const BlogPostForm = {
 
 ## Options
 
-- `name`: The path to some value in the data being edited.
-- `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
-- `description`: An optional description that expands on the purpose of the field or prompts a specific action.
-
-## Interface
-
 ```typescript
 interface HtmlConfig {
   name: string
@@ -62,3 +56,9 @@ interface HtmlConfig {
   description?: string
 }
 ```
+
+| Option        | Description                                                                                                                                              |     |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
+| `name`        | The path to some value in the data being edited.                                                                                                         |
+| `label`       | A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name. |
+| `description` | An optional description that expands on the purpose of the field or prompts a specific action.                                                           |

--- a/content/docs/fields/image.md
+++ b/content/docs/fields/image.md
@@ -17,6 +17,7 @@ The `image` field is used for content values that point to an image used on the 
 
 ```typescript
 interface ImageConfig {
+  component: 'image'
   name: string
   label?: string
   description?: string
@@ -30,14 +31,19 @@ interface ImageConfig {
 
 | Key           | Description                                                                                                                                                                                                 |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `component`   | The name of the plugin component. Always `'image'`.                                                                                                                                                         |
 | `name`        | The path to some value in the data being edited.                                                                                                                                                            |
-| `label`       | A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.                                                    |
-| `description` | An optional description that expands on the purpose of the field or prompts a specific action.                                                                                                              |
+| `label`       | A human readable label for the field. Defaults to the `name`. _(Optional)_                                                                                                                                  |
+| `description` | Description that expands on the purpose of the field or prompts a specific action. _(Optional)_                                                                                                             |
 | `parse`       | Defines how the actual front matter or data value gets populated. The name of the file gets passed as an argument, and one can set the path this image as defined by the uploadDir property.                |
 | `previewSrc`  | Defines the path for the src attribute on the image preview. If using gatsby-image, the path to the `childImageSharp.fluid.src` needs to be provided.                                                       |
 | `uploadDir`   | Defines the upload directory for the image. All of the post data is passed in, `fileRelativePath` is most useful in defining the upload directory, but you can also statically define the upload directory. |
 
 ---
+
+> This interfaces only shows the keys unique to the image field.
+>
+> Visit the [Field Config](/docs/fields) docs for a complete list of options.
 
 ## Examples
 

--- a/content/docs/fields/markdown.md
+++ b/content/docs/fields/markdown.md
@@ -11,6 +11,30 @@ The `markdown` field represents a chunk of Markdown content. This field is typic
 
 ![tinacms-markdown-field](/img/fields/markdown.png)
 
+## Options
+
+```typescript
+interface MarkdownConfig {
+  name: string
+  component: 'markdown'
+  label?: string
+  description?: string
+}
+```
+
+| Option        | Description                                                                                                                                              |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`        | The path to some value in the data being edited.                                                                                                         |
+| `component`   | The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/fields)                 |
+| `label`       | A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name. |
+| `description` | An optional description that expands on the purpose of the field or prompts a specific action.                                                           |
+
+> ### FieldConfig
+>
+> This interfaces only shows the keys unique to the markdown field.
+>
+> Visit the [Field Config](/docs/fields) docs for a complete list of options.
+
 ## Adding the Plugin
 
 The `markdown` field plugin is not a default plugin. In order to use it in your site you must install the `react-tinacms-editor` package:
@@ -44,23 +68,5 @@ const BlogPostForm = {
     },
     // ...
   ],
-}
-```
-
-## Options
-
-- `name`: The path to some value in the data being edited.
-- `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/fields)
-- `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
-- `description`: An optional description that expands on the purpose of the field or prompts a specific action.
-
-## Interface
-
-```typescript
-interface MarkdownConfig {
-  name: string
-  component: 'markdown'
-  label?: string
-  description?: string
 }
 ```

--- a/content/docs/fields/markdown.md
+++ b/content/docs/fields/markdown.md
@@ -15,19 +15,19 @@ The `markdown` field represents a chunk of Markdown content. This field is typic
 
 ```typescript
 interface MarkdownConfig {
-  name: string
   component: 'markdown'
+  name: string
   label?: string
   description?: string
 }
 ```
 
-| Option        | Description                                                                                                                                              |
-| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`        | The path to some value in the data being edited.                                                                                                         |
-| `component`   | The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/fields)                 |
-| `label`       | A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name. |
-| `description` | An optional description that expands on the purpose of the field or prompts a specific action.                                                           |
+| Option        | Description                                                                                     |
+| ------------- | ----------------------------------------------------------------------------------------------- |
+| `component`   | The name of the plugin component. Always `'markdown'`.                                          |
+| `name`        | The path to some value in the data being edited.                                                |
+| `label`       | A human readable label for the field. Defaults to the `name`. _(Optional)_                      |
+| `description` | Description that expands on the purpose of the field or prompts a specific action. _(Optional)_ |
 
 > ### FieldConfig
 >

--- a/content/docs/fields/tags.md
+++ b/content/docs/fields/tags.md
@@ -11,6 +11,28 @@ The `tags` field represents a collection of tags.
 
 ![TinaCMS-tags-field](/img/fields/tags-field.png)
 
+## Options
+
+```typescript
+interface TagsField {
+  component: 'tags'
+  name: string
+  label?: string
+  description?: string
+}
+```
+
+| Option        | Description                                                                                     |
+| ------------- | ----------------------------------------------------------------------------------------------- |
+| `component`   | The name of the plugin component. Always `'tags'`.                                              |
+| `name`        | The path to some value in the data being edited.                                                |
+| `label`       | A human readable label for the field. Defaults to the `name`. _(Optional)_                      |
+| `description` | Description that expands on the purpose of the field or prompts a specific action. _(Optional)_ |
+
+> This interfaces only shows the keys unique to the tags field.
+>
+> Visit the [Field Config](/docs/fields) docs for a complete list of options.
+
 ## Definition
 
 Below is an example of how a `tags` field could be defined in a [form](/docs/forms).
@@ -26,23 +48,5 @@ const FormConfig = {
     },
     // ...
   ],
-}
-```
-
-## Options
-
-- `name`: The path to some value in the data being edited.
-- `component`: The name of the React component that should be used to edit this field. Available field component types are [defined here](/docs/fields)
-- `label`: A human readable label for the field. This label displays in the sidebar and is optional. If no label is provided, the sidebar will default to the name.
-- `description`: An optional description that expands on the purpose of the field or prompts a specific action.
-
-## Interface
-
-```typescript
-interface TagsField {
-  name: string
-  component: 'Tags'
-  label?: string
-  description?: string
 }
 ```


### PR DESCRIPTION
Restructured field docs to be the table format. The group list and block docs didn't really fit this format the best. let me know what you think. 