### PR TITLE
make shortcodes for rendering examples of fields

### DIFF
--- a/content/docs/fields/color.md
+++ b/content/docs/fields/color.md
@@ -67,3 +67,5 @@ const BlogPostForm = {
   ],
 }
 ```
+
+{{ ColorFieldExample }}

--- a/content/docs/fields/date.md
+++ b/content/docs/fields/date.md
@@ -65,3 +65,5 @@ const BlogPostForm = {
   ],
 }
 ```
+
+{{ FieldExample name="date" component="date" }}

--- a/content/docs/fields/text.md
+++ b/content/docs/fields/text.md
@@ -53,3 +53,5 @@ const BlogPostForm = {
   ],
 }
 ```
+
+{{ FieldExample component="text" name="title" label="Title" description="Enter the title of the post here" placeholder="..." }}

--- a/utils/shortcodes.tsx
+++ b/utils/shortcodes.tsx
@@ -52,7 +52,6 @@ export const FieldExample = styled(({ className, ...field }) => {
         return (
           <>
             <div className={className}>
-              <h3>Example</h3>
               <FieldsBuilder form={form} fields={form.fields} />
             </div>
           </>
@@ -61,9 +60,10 @@ export const FieldExample = styled(({ className, ...field }) => {
     </FormBuilder>
   )
 })`
-  border: 5px solid pink;
-  background: limegreen;
-  margin: 3.1415rem;
+  background-color: rgb(250, 250, 250);
+  border: 1px solid rgb(237, 238, 238);
+  margin: 1.5rem auto;
+  border-radius: 5px;
 `
 
 export const DateFieldExample = () => {

--- a/utils/shortcodes.tsx
+++ b/utils/shortcodes.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import styled from 'styled-components'
-import { useCMS } from 'tinacms'
+import { useCMS, FormBuilder, FieldsBuilder, useForm } from 'tinacms'
 import { Button } from '../components/ui'
 
 const DemoButtonWrapper = styled.div`
@@ -25,5 +25,73 @@ export function AlertTest({ type, message, timeout, buttonText }) {
         {buttonText || 'Try it'}
       </Button>
     </DemoButtonWrapper>
+  )
+}
+
+export const FieldExample = styled(({ className, ...field }) => {
+  const [isBrowser, setIsBrowser] = React.useState(false)
+
+  React.useEffect(() => {
+    setIsBrowser(true)
+  }, [])
+
+  const [, form] = useForm({
+    id: 'example',
+    label: 'Example',
+    onSubmit() {},
+    fields: [field],
+  })
+
+  if (!isBrowser) {
+    return null
+  }
+
+  return (
+    <FormBuilder form={form}>
+      {() => {
+        return (
+          <>
+            <div className={className}>
+              <h3>Example</h3>
+              <FieldsBuilder form={form} fields={form.fields} />
+            </div>
+          </>
+        )
+      }}
+    </FormBuilder>
+  )
+})`
+  border: 5px solid pink;
+  background: limegreen;
+  margin: 3.1415rem;
+`
+
+export const DateFieldExample = () => {
+  return (
+    <FieldExample
+      {...{
+        label: 'Date',
+        name: 'created_at',
+        component: 'date',
+        dateFormat: 'MMMM DD YYYY',
+        timeFormat: false,
+      }}
+    />
+  )
+}
+
+export const ColorFieldExample = () => {
+  return (
+    <FieldExample
+      {...{
+        name: 'rawFrontmatter.background_color',
+        component: 'color',
+        label: 'Background Color',
+        description: 'Edit the page background color here',
+        colorFormat: 'hex',
+        colors: ['#EC4815', '#241748', '#B4F4E0', '#E6FAF8'],
+        widget: 'sketch',
+      }}
+    />
   )
 }


### PR DESCRIPTION
This is a prototype

It's to setup the docs fields to render the field  in question directly in the body of the page

[Check it out on the text page](https://tinacms-site-next-pm1ymqxdn.vercel.app/docs/fields/text#example-blog-post-title)

This is what the shortcode looks like:

```markdown

## Example TextField

{{ FieldExample name="title" component="text" label="Title" }}

```