### PR TITLE
Docs: Remove duplicated words from docs, and remove hard-coded localhost urls from GitClient config docs.

### DIFF
--- a/content/blog/custom-field-plugins.md
+++ b/content/blog/custom-field-plugins.md
@@ -62,7 +62,7 @@ export default class Site extends App {
     this.cms = new TinaCMS({
       enabled: process.env.NODE_ENV !== 'production',
       apis: {
-        git: new GitClient('http://localhost:3000/___tina'),
+        git: new GitClient('/___tina'),
       },
       sidebar: {
         position: 'overlay',

--- a/content/blog/using-tinacms-with-nextjs.md
+++ b/content/blog/using-tinacms-with-nextjs.md
@@ -150,7 +150,7 @@ app.prepare().then(() => {
     return handle(req, res)
   })
 
-  server.listen(port, err => {
+  server.listen(port, (err) => {
     if (err) throw err
     console.log(`> Ready on http://localhost:${port}`)
   })
@@ -184,7 +184,7 @@ class MyApp extends App {
     super()
     this.cms = new TinaCMS()
     // create the client
-    const client = new GitClient('http://localhost:3000/___tina')
+    const client = new GitClient('/___tina')
     // register client with the cms
     this.cms.registerApi('git', client)
   }
@@ -212,7 +212,7 @@ As a recap from [Part I](https://tinacms.org/blog/simple-markdown-blog-nextjs/),
 First, we need to add an additional property to the return object from `getInitialProps` called `fileRelativePath`. Tina needs this path in order to know what file to update. Here’s an example of how you could add `fileRelativePath`:
 
 ```javascript
-BlogTemplate.getInitialProps = async function(ctx) {
+BlogTemplate.getInitialProps = async function (ctx) {
   const { slug } = ctx.query
   const content = await import(`../../posts/${slug}.md`)
   const config = await import(`../../data/config.json`)

--- a/content/docs/nextjs/next-tinacms-github.md
+++ b/content/docs/nextjs/next-tinacms-github.md
@@ -17,7 +17,7 @@ providing helpers for **loading content from the Github API**.
 yarn add next-tinacms-github
 ```
 
-Any functions in the `pages/api` directory are are mapped to `/api/*` endpoints. The below helpers tend to be added to the `pages/api` directory in a Next.js project.
+Any functions in the `pages/api` directory are mapped to `/api/*` endpoints. The below helpers tend to be added to the `pages/api` directory in a Next.js project.
 
 ### `createCreateAccessTokenFn`
 

--- a/content/guides/nextjs/git-based/adding-backend.md
+++ b/content/guides/nextjs/git-based/adding-backend.md
@@ -54,7 +54,7 @@ app.prepare().then(() => {
     return handle(req, res)
   })
 
-  server.listen(port, err => {
+  server.listen(port, (err) => {
     if (err) throw err
     console.log(`> Ready on http://localhost:${port}`)
   })
@@ -114,7 +114,7 @@ Now we need to configure the CMS to consume the Git API now running on the backe
 When creating an instance of `GitClient`, we need to pass it the URL where the API endpoints can be reached. Since we're running the server locally on port 3000, the full URL to our Git backend is `http://localhost:3000/___tina`. We could then instantiate the Git client as follows:
 
 ```javascript
-const client = new GitClient('http://localhost:3000/___tina')
+const client = new GitClient('/___tina')
 ```
 
 We'll need to amend our `_app.js` application wrapper to register this with the CMS. We can pass [APIs](/docs/cms/apis), [Media](/docs/media), and [UI](/docs/cms/ui-components) settings in a config object to `TinaCMS`.
@@ -131,7 +131,7 @@ class MyApp extends App {
   constructor() {
     super()
 
-    const client = new GitClient('http://localhost:3000/___tina')
+    const client = new GitClient('/___tina')
 
     this.cms = new TinaCMS({
       apis: {

--- a/content/guides/nextjs/github-open-authoring/api-functions.md
+++ b/content/guides/nextjs/github-open-authoring/api-functions.md
@@ -2,7 +2,7 @@
 title: Adding API functions
 ---
 
-We need a few API functions to handle GitHub authorization and [Preview Mode](https://nextjs.org/docs/advanced-features/preview-mode). With Next.js, any functions in the `pages/api` directory are are mapped to `/api/*` endpoints. Files in this directory are treated as [API endpoints](<](https://nextjs.org/docs/api-routes/introduction)>) instead of pages.
+We need a few API functions to handle GitHub authorization and [Preview Mode](https://nextjs.org/docs/advanced-features/preview-mode). With Next.js, any functions in the `pages/api` directory are mapped to `/api/*` endpoints. Files in this directory are treated as [API endpoints](<](https://nextjs.org/docs/api-routes/introduction)>) instead of pages.
 
 > If you see a 'dummy' `hello.js` file in the `pages/api` directory, feel free to delete it.
 


### PR DESCRIPTION
The hard coded localhost url is not necessary as the currently used base url will be used instead (ie, on localhost:3000 it will use localhost:3000, and on 192.168.2.23:3000 it'll use 192.168.2.23:3000), but by hard coding it TinaCMS will not function if the running instance is accessed from a different url. TinaCMS will then become unresponsive and actually lock up the chrome tab if you attempt to access it that way.

Also removed two instances if `are are` in the documentation text.