### PR TITLE
docs: Adds form buttons docs

### DIFF
--- a/content/docs/cms.md
+++ b/content/docs/cms.md
@@ -112,7 +112,7 @@ export default function ExitButton() {
 
 ## CMS Configuration
 
-When instantiating the `TinaCMS` object, you can pass in a configuration object. This allows you to configure some options for the sidebar, and also allows you to configure [Plugins](/docs/cms/plugins) and [APIs](/docs/cms/apis) declaratively.
+When instantiating the `TinaCMS` object, you can pass in a configuration object. This allows you to configure some options for the sidebar, toolbar, and also allows you to configure [Plugins](/docs/cms/plugins) and [APIs](/docs/cms/apis) declaratively.
 
 ```typescript
 interface TinaCMSConfig {
@@ -145,18 +145,18 @@ interface ToolbarConfig {
 
 ---
 
-| key                     | usage                                                                                                   |
-| ----------------------- | ------------------------------------------------------------------------------------------------------- |
-| **enabled**             | Controls whether the CMS is enabled or disabled. _Defaults to true_                                     |
-| **plugins**             | Array of plugins to be added to the CMS object.                                                         |
-| **apis**                | Object containing APIs to be registered to the CMS                                                      |
-| **sidebar**             | Enables and configures behavior of the sidebar                                                          |
-| **sidebar.position**    | 'displace': sidebar pushes content to the side when open; 'overlay': sidebar overlaps content when open |
-| **sidebar.placeholder** | Provides a placeholder component to render in the sidebar when there are no registered forms            |
-| **sidebar.buttons**     | Enables and configures the text on 'Save' and 'Reset' buttons                                           |
-| **toolbar**             | Configures behavior of the toolbar                                                                      |
-| **toolbar.buttons**     | Configures the text on 'Save' and 'Reset' buttons                                                       |
-| **media.store**         | Configures the [media store](/docs/media).                                                              |
+| key                     | usage                                                                                                                           |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| **enabled**             | Controls whether the CMS is enabled or disabled. _Defaults to true_                                                             |
+| **plugins**             | Array of plugins to be added to the CMS object.                                                                                 |
+| **apis**                | Object containing APIs to be registered to the CMS                                                                              |
+| **sidebar**             | Enables and configures behavior of the sidebar                                                                                  |
+| **sidebar.position**    | 'displace': sidebar pushes content to the side when open; 'overlay': sidebar overlaps content when open                         |
+| **sidebar.placeholder** | Provides a placeholder component to render in the sidebar when there are no registered forms                                    |
+| **sidebar.buttons**     | _Deprecated — [Configure on the form](/docs/forms#customizing-form-buttons)_: Configures the text on 'Save' and 'Reset' buttons |
+| **toolbar**             | Configures behavior of the toolbar                                                                                              |
+| **toolbar.buttons**     | _Deprecated — [Configure on the form](/docs/forms#customizing-form-buttons)_: Configures the text on 'Save' and 'Reset' buttons |
+| **media.store**         | Configures the [media store](/docs/media).                                                                                      |
 
 ---
 
@@ -183,3 +183,7 @@ const cms = new TinaCMS({
   toolbar: false,
 })
 ```
+
+### Customize 'Save' & 'Reset' button text
+
+It is now recommended to configure button text on the form intead of in the CMS object. Please read further on [configuring custom buttons](/docs/forms#customizing-form-buttons) in the form documentation.

--- a/content/docs/forms.md
+++ b/content/docs/forms.md
@@ -99,6 +99,7 @@ interface FormOptions<S> {
   label: string
   fields: Field[]
   loadInitialValues?: () => Promise<S>
+  onSubmit?: () => Promise<any>
   reset?(): void
   onChange?(state): void
   actions?: any[]
@@ -112,7 +113,8 @@ interface FormOptions<S> {
 | `label`             | A label for the form that will appear in the sidebar.                                                                                         |
 | `fields`            | An array of fields that will define the shape of the form and how content is edited.                                                          |
 | `loadInitialValues` | _Optional:_ A function to load the initial form state asynchronously. Return a promise that passes an object of form values when it resolves. |
-| `reset`             | _Optional:_ A function that runs when the form state is reset by the user.                                                                    |
+| `onSubmit`          | _Optional:_ An asynchronous function to invoke when the form is saved, i.e. when the 'Save' button is pressed.                                |
+| `reset`             | _Optional:_ A function that runs when the form state is reset by the user via the 'Reset' button.                                             |
 | `actions`           | _Optional:_ An array of custom actions that will be added to the form.                                                                        |
 | `onChange`          | _Optional:_ A function that runs when the form values are changed.                                                                            |
 | `__type`            | _Optional:_ Sets the Form's plugin type. Automatically set based on which form hook is used.                                                  |
@@ -144,7 +146,7 @@ export function Page(props) {
       title: props.title,
       markdownContent: props.markdownContent
     },
-    onSubmit: (formData) => {
+    onSubmit: async (formData) => {
       // save the new form data
     },
   })

--- a/content/docs/forms.md
+++ b/content/docs/forms.md
@@ -103,6 +103,10 @@ interface FormOptions<S> {
   reset?(): void
   onChange?(state): void
   actions?: any[]
+  buttons?: {
+    save: string
+    reset: string
+  }
   __type?: string
 }
 ```
@@ -116,6 +120,7 @@ interface FormOptions<S> {
 | `onSubmit`          | _Optional:_ An asynchronous function to invoke when the form is saved, i.e. when the 'Save' button is pressed.                                |
 | `reset`             | _Optional:_ A function that runs when the form state is reset by the user via the 'Reset' button.                                             |
 | `actions`           | _Optional:_ An array of custom actions that will be added to the form.                                                                        |
+| `buttons`           | _Optional:_ An object to customize the 'Save' and 'Reset' button text for the form.                                                           |
 | `onChange`          | _Optional:_ A function that runs when the form values are changed.                                                                            |
 | `__type`            | _Optional:_ Sets the Form's plugin type. Automatically set based on which form hook is used.                                                  |
 
@@ -186,6 +191,41 @@ interface WatchableFormValue {
 ### Form Helpers
 
 The three hooks described thus far are the basic interface for creating forms, and they aim to support a broad set of use cases. For specific use cases, we've created some simplified interfaces for quickly setting up forms. Take a look at our [Next.js form docs](/guides/nextjs/git-based/creating-git-forms) and [Gatsby docs](/docs/gatsby/markdown) to learn how to use these.
+
+### Customizing Form Buttons
+
+> _Note:_ The 'Save' and 'Reset' button text can also be configured on the sidebar or toolbar when defining the [CMS options](/docs/cms#cms-configuration). If `buttons` are configured on the CMS through the `sidebar` or `toolbar` options, those values will take precedent over button values passed to a form. **It is now recommended to configure button text on the form** intead of the CMS.
+
+'Save' & 'Reset' buttons accompany all forms. They may render at the bottom of the sidebar, in a modal, or on the toolbar. When clicked, these buttons should generally invoke the `onSubmit`(For 'Save') & `reset`(For 'Reset') functions associated with the form.
+
+There may be times when you want to change the button text to improve UX or provide a **better description of the action** for an editor. For example, you may want the 'Save' button to say 'Commit' and the 'Reset' button to say 'Discard Changes'.
+
+Below is an example of a form options object with these custom button options passed in:
+
+```js
+const [author, authorForm] = useJsonForm(data.dataJson, {
+  label: 'Author',
+  fields: [
+    {
+      name: 'author',
+      label: 'Author',
+      component: 'select',
+      options: [
+        'Herbert Huncke',
+        'Allen Ginsberg',
+        'Jack Kerouac',
+        'William S. Burroughs',
+      ],
+    },
+  ],
+  buttons: {
+    save: 'Commit',
+    reset: 'Discard Changes',
+  },
+})
+```
+
+#### Reuse with a composition
 
 ## Inline Forms
 


### PR DESCRIPTION
Relating changes from [this PR](https://github.com/tinacms/tinacms/pull/1324). Jump to the[ preview here](https://tinacms-site-next-p6fd1ev7i.vercel.app/docs/forms#customizing-form-buttons).

Not sure if we want to officially deprecate the old sidebar / toolbar buttons options, but I added that note.