### PR TITLE
Docs index

### DIFF
--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -33,9 +33,9 @@ Learning how to build a CMS is no small feat! We've compiled a variety of resour
 
 ## Constructing The User Interface
 
-Tina lets you choose the user interface that best fits your workflow. You can use one of it's default interfaces or construct your own. You can even build editing capabilities directly into your page.
+Tina lets you choose the user interface that best fits your workflow. You can use one of its default interfaces or construct your own. You can even build editing capabilities directly into your page!
 
-* Learn about the [Toolbar](/docs/cms/ui#toolbar-configuration "Tina Toolbar") or [Sidebar](/docs/cms/ui#sidebar-configuration "Tina Sidebar") UIs to decide which one fits your needs.
+* Learn about the [Toolbar](/docs/cms/ui#toolbar-configuration "Tina Toolbar") and [Sidebar](/docs/cms/ui#sidebar-configuration "Tina Sidebar") UI components.
 * Take control of the appearance of your CMS using [Custom Styling](/docs/cms/styles "Styles")
 * Add features to your CMS using [Screen Plugins](/blog/screen-plugins "Screen Plugins")  and Toolbar Widgets _(docs coming soon)_.
 * Wander off the beaten trail and create a totally custom UI _(Coming Soon)_

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -4,7 +4,7 @@ id: introduction
 prev: null
 next: /docs/getting-started/how-tina-works
 ---
-Tina is a toolkit for building content management systems.
+Tina is a **toolkit for building content management systems.** By creating a custom CMS with Tina instead of opting for a conventional, "turn-key" solution, developers that use Tina have a lot more control over the editing experience of their users.
 
 ## First Steps
 
@@ -28,7 +28,7 @@ Learning how to build a CMS is no small feat! Luckily this website has tons of h
 
 * [Docs]() describe the main Tina concepts and how to use them to build your CMS.
 * [Guides](/guides "Tina Guides") take you through the steps involved in addressing key problems and specific use-cases.
-* The [Blog](/blog "Tina Blog") is where release notes, tips, and other announcements are posted. 
+* The [Blog](/blog "Tina Blog") is where release notes, tips, and other announcements are posted.
 * Visit the Packages Lookup _(Coming Soon)_ to find more tools and make building your CMS even easier.
 
 ## Constructing The User Interface

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -29,7 +29,7 @@ Learning how to build a CMS is no small feat! Luckily this website has tons of h
 * [Docs]() describe the main Tina concepts and how to use them to build your CMS.
 * [Guides](/guides "Tina Guides") take you through the steps involved in addressing key problems and specific use-cases.
 * [Blog and Release Notes](/blog "Tina Blog")
-* Packages _(Coming Soon)_
+* Visit the Packages Lookup _(Coming Soon)_ to find more tools and make building your CMS even easier.
 
 ## Constructing The User Interface
 
@@ -42,11 +42,11 @@ Tina gives you the power to choose the user interface that best fits your workfl
 
 ## Tools for Managing Content
 
-Tina gives you the tools you need to manage content from the sata source of your choosing. Read these docs to learn how to edit content the exact way you want.
+Tina gives you the tools you need to manage content from the data source of your choosing. Read these docs to learn how to edit content the exact way you want.
 
 * **Editing Content:** [Creating Forms](/docs/forms), [Fields](/docs/fields),[ Custom Fields](/docs/fields/custom-fields), [Inline Editing](/docs/inline-editing), [Working with Inline Blocks](/guides//general/inline-blocks/overview)
 * **Creating Content:** Using Content Creators _(Coming Soon)_
-* **Deleting Content:** _(Coming Soon)_
+* **Deleting Content:** Using Form Actions. _(Coming Soon)_
 * **Media Management:** [Media Stores](/docs/media "Tina Media Store"), [Image Fields](/docs/fields/image "Image Field Plugin"), [Inline Images](/docs/inline-editing/inline-image "Inline Images")
 
 ## Integrating with React Frameworks

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -4,4 +4,48 @@ id: introduction
 prev: null
 next: /docs/getting-started/how-tina-works
 ---
-...
+Tina is a toolkit for building content management systems.
+
+## First Steps
+
+Are you new to using Tina to build a CMS? This is the place to start!
+
+* Visit the [Getting Started Guide](/docs/getting-started/introduction "Getting Started") to learn the basics of using Tina to build superb content editing experiences.
+* Click **Edit this Site** at the bottom of the page to fork the [tinacms.org repository](https://github.com/tinacms/tinacms.org "Tinacms.org Repository"), make changes, and then open a Pull Request!
+
+## Getting Help
+
+Have questions on how to use Tina to build your CMS?
+
+* Visit the [Tina Forum](https://community.tinacms.org "Tina Forum") to engage with the core team and community.
+* Report bugs using [GitHub Issues](https://github.com/tinacms/tinacms/issues "Tina Github Issues")
+* FAQ _(Coming Soon)_
+
+## How This Site Is Organized
+
+Learning how to build a CMS is no small feat! Luckily this website has tons of helpful information to help make the process a delight.
+
+* [Docs]() describe the main Tina concepts and how to use them to build your CMS.
+* [Guides](/guides "Tina Guides") take you through the steps involved in addressing key problems and specific use-cases.
+* [Blog and Release Notes](/blog "Tina Blog")
+* Packages _(Coming Soon)_
+
+## Constructing The User Interface
+
+Tina gives you the power to choose the interface that best fits your workflow. You can use one of it's default interfaces or construct your own. You can even build editing capabilities directly into your page.
+
+* Learn about the [Toolbar](/docs/cms/ui#toolbar-configuration "Tina Toolbar") or [Sidebar](/docs/cms/ui#sidebar-configuration "Tina Sidebar") UIs to decide which one fits your needs.
+* Take control of the appearance of your CMS using [Custom Styling](/docs/cms/styles "Styles")
+* Add features to your CMS using [Screen Plugins](/blog/screen-plugins "Screen Plugins")  and Toolbar Widgets _(docs coming soon)_.
+
+## Managing Content
+
+* **Editing Content:** [Creating Forms](/docs/forms), [Fields](/docs/fields),[ Custom Fields](/docs/fields/custom-fields), [Inline Editing](/docs/inline-editing), [Working with Inline Blocks](/guides//general/inline-blocks/overview)
+* **Creating Content:** Using Content Creators _(Coming Soon)_
+* **Deleting Content:** _(Coming Soon)_
+* **Media Management:** [Media Stores](/docs/media "Tina Media Store"), [Image Fields](/docs/fields/image "Image Field Plugin"), [Inline Images](/docs/inline-editing/inline-image "Inline Images")
+
+## Integrating with React Frameworks
+
+* **Next.js:** [Available Packages](/docs/nextjs/overview "Next.js Packages"), [Adding Tina to a Next.js Site](/guides/nextjs/adding-tina/overview "Adding Tina to a Next.js Site"), [Using Tina with Next + GitHub](/guides/nextjs/github-open-authoring/initial-setup "Using Tina with Next and GitHub")
+* **Gatsby:**  [Adding Tina to a Gatsby Site](/guides/gatsby/adding-tina/overview)

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -24,7 +24,7 @@ Have questions on how to use Tina to build your CMS?
 
 ## How This Site Is Organized
 
-Learning how to build a CMS is no small feat! Luckily this website has tons of helpful information to help make the process a delight.
+Learning how to build a CMS is no small feat! We've compiled a variety of resources to help you along.
 
 * [Docs]() describe the main Tina concepts and how to use them to build your CMS.
 * [Guides](/guides "Tina Guides") take you through the steps involved in addressing key problems and specific use-cases.

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -51,7 +51,7 @@ Tina gives you the tools you need to manage content from the data source of your
 
 ## Integrating with React Frameworks
 
-Tina is designed to work with just about any React framework. These guides will help you learn the specifics of building CMSs using Next.js and Gatsby.
+Tina is designed to work with just about any React framework. These guides will help you learn the specifics of building a CMS using Next.js or Gatsby.
 
 * **Next.js:** [Available Packages](/docs/nextjs/overview "Next.js Packages"), [Adding Tina to a Next.js Site](/guides/nextjs/adding-tina/overview "Adding Tina to a Next.js Site"), [Storing Content using the GitHub API](/guides/nextjs/github-open-authoring/initial-setup "Using Tina with Next and GitHub")
 * **Gatsby:**  [Adding Tina to a Gatsby Site](/guides/gatsby/adding-tina/overview), [Storing Content Using the Git Filesystem](/docs/gatsby/manual-setup "Using Tina with Gatsby and Git")

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -28,12 +28,12 @@ Learning how to build a CMS is no small feat! Luckily this website has tons of h
 
 * [Docs]() describe the main Tina concepts and how to use them to build your CMS.
 * [Guides](/guides "Tina Guides") take you through the steps involved in addressing key problems and specific use-cases.
-* [Blog and Release Notes](/blog "Tina Blog")
+* The [Blog](/blog "Tina Blog") is where release notes, tips, and other announcements are posted. 
 * Visit the Packages Lookup _(Coming Soon)_ to find more tools and make building your CMS even easier.
 
 ## Constructing The User Interface
 
-Tina gives you the power to choose the user interface that best fits your workflow. You can use one of it's default interfaces or construct your own. You can even build editing capabilities directly into your page.
+Tina lets you choose the user interface that best fits your workflow. You can use one of it's default interfaces or construct your own. You can even build editing capabilities directly into your page.
 
 * Learn about the [Toolbar](/docs/cms/ui#toolbar-configuration "Tina Toolbar") or [Sidebar](/docs/cms/ui#sidebar-configuration "Tina Sidebar") UIs to decide which one fits your needs.
 * Take control of the appearance of your CMS using [Custom Styling](/docs/cms/styles "Styles")

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -8,10 +8,11 @@ Tina is a toolkit for building content management systems.
 
 ## First Steps
 
-Are you new to using Tina to build a CMS? This is the place to start!
+Are you new to using Tina to build content management systems? Start with these resources to build your understanding of Tina and what's possible.
 
 * Visit the [Getting Started Guide](/docs/getting-started/introduction "Getting Started") to learn the basics of using Tina to build superb content editing experiences.
 * Click **Edit this Site** at the bottom of the page to fork the [tinacms.org repository](https://github.com/tinacms/tinacms.org "Tinacms.org Repository"), make changes, and then open a Pull Request!
+* Checkout [this video of a page builder](https://youtu.be/4qGz0cP_DSA "Inline Editing Demo Video") created with TinaCMS.
 
 ## Getting Help
 
@@ -32,13 +33,16 @@ Learning how to build a CMS is no small feat! Luckily this website has tons of h
 
 ## Constructing The User Interface
 
-Tina gives you the power to choose the interface that best fits your workflow. You can use one of it's default interfaces or construct your own. You can even build editing capabilities directly into your page.
+Tina gives you the power to choose the user interface that best fits your workflow. You can use one of it's default interfaces or construct your own. You can even build editing capabilities directly into your page.
 
 * Learn about the [Toolbar](/docs/cms/ui#toolbar-configuration "Tina Toolbar") or [Sidebar](/docs/cms/ui#sidebar-configuration "Tina Sidebar") UIs to decide which one fits your needs.
 * Take control of the appearance of your CMS using [Custom Styling](/docs/cms/styles "Styles")
 * Add features to your CMS using [Screen Plugins](/blog/screen-plugins "Screen Plugins")  and Toolbar Widgets _(docs coming soon)_.
+* Wander off the beaten trail and create a totally custom UI _(Coming Soon)_
 
-## Managing Content
+## Tools for Managing Content
+
+Tina gives you the tools you need to manage content from the sata source of your choosing. Read these docs to learn how to edit content the exact way you want.
 
 * **Editing Content:** [Creating Forms](/docs/forms), [Fields](/docs/fields),[ Custom Fields](/docs/fields/custom-fields), [Inline Editing](/docs/inline-editing), [Working with Inline Blocks](/guides//general/inline-blocks/overview)
 * **Creating Content:** Using Content Creators _(Coming Soon)_
@@ -47,5 +51,7 @@ Tina gives you the power to choose the interface that best fits your workflow. Y
 
 ## Integrating with React Frameworks
 
-* **Next.js:** [Available Packages](/docs/nextjs/overview "Next.js Packages"), [Adding Tina to a Next.js Site](/guides/nextjs/adding-tina/overview "Adding Tina to a Next.js Site"), [Using Tina with Next + GitHub](/guides/nextjs/github-open-authoring/initial-setup "Using Tina with Next and GitHub")
-* **Gatsby:**  [Adding Tina to a Gatsby Site](/guides/gatsby/adding-tina/overview)
+Tina is designed to work with just about any React framework. These guides will help you learn the specifics of building CMSs using Next.js and Gatsby.
+
+* **Next.js:** [Available Packages](/docs/nextjs/overview "Next.js Packages"), [Adding Tina to a Next.js Site](/guides/nextjs/adding-tina/overview "Adding Tina to a Next.js Site"), [Storing Content using the GitHub API](/guides/nextjs/github-open-authoring/initial-setup "Using Tina with Next and GitHub")
+* **Gatsby:**  [Adding Tina to a Gatsby Site](/guides/gatsby/adding-tina/overview), [Storing Content Using the Git Filesystem](/docs/gatsby/manual-setup "Using Tina with Gatsby and Git")

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -42,7 +42,7 @@ Tina lets you choose the user interface that best fits your workflow. You can us
 
 ## Tools for Managing Content
 
-Tina gives you the tools you need to manage content from the data source of your choosing. Read these docs to learn how to edit content the exact way you want.
+Tina gives you the tools you need to manage content from the data source of your choosing. These docs will show you how to craft your ideal content editing experience.
 
 * **Editing Content:** [Creating Forms](/docs/forms), [Fields](/docs/fields),[ Custom Fields](/docs/fields/custom-fields), [Inline Editing](/docs/inline-editing), [Working with Inline Blocks](/guides//general/inline-blocks/overview)
 * **Creating Content:** Using Content Creators _(Coming Soon)_

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -1,52 +1,7 @@
 ---
-title: Tina is Not a CMS
+title: TinaCMS Documentation
 id: introduction
 prev: null
 next: /docs/getting-started/how-tina-works
 ---
-
-Tina is a **lightweight but powerful toolkit** for creating a content editing interface with JavaScript components. Tina surfaces superpowers for developers to create an intuitive UI for real-time content editing, built directly into their website.
-
-## The Next Generation of Content Management
-
-![tina-gif](https://res.cloudinary.com/forestry-demo/video/upload/du_16,w_700,e_loop/v1571159974/tina-hero-demo.gif)
-
-Tina is optimized for next-gen JAMstack tools. It is written in JavaScript and easily adapted to multiple different frameworks.
-
-Tina currently supports React-based frameworks, including:
-
-- Create-React-App
-- Gatsby
-- NextJS
-
-## Get Started
-
-To use Tina, you should have a good working knowledge of your JavaScript framework & JAMstack tools of choice.
-
-If you want to get started with some code right away, checkout the [Gatsby Quickstart](/docs/gatsby/quickstart) or [Next.js Overview](/docs/nextjs/overview).
-
-If you want to dive deep, start by learning more about [how Tina works](/docs/getting-started/how-tina-works) and get familiar with some core concepts.
-
-## For Gatsby
-
-- [Quickstart](/docs/gatsby/quickstart) with a Tina Starter to hit the ground running.
-- [Manual Setup](/docs/gatsby/manual-setup) for adding Tina to an existing Gatsby site.
-
-**Gatsby Starters**
-- [Gatsby Blog Starter](https://github.com/tinacms/gatsby-starter-tinacms) with Tina — The classic Gatsby starter, but Tinified.
-- [Tina Grande](https://github.com/tinacms/tina-starter-grande) — A more advanced starter to showcase the power of Tina.
-- [Tina Brevifolia](https://github.com/kendallstrautman/brevifolia-gatsby-tinacms) — A markdown-based blog with minimalist design and Tina for editing.
-
-Want to add your starter? Make a [PR](/docs/contributing/guidelines) to add your Tina site to this list.
-
-## For Next.js
-
-- [Next.js + Tina Overview](/docs/nextjs/overview) — Get started with the documentation
-- Read an in-depth tutorial on [Using TinaCMS with Next.js](/blog/using-tinacms-with-nextjs/)
-- Checkout this sample [Next.js Markdown Blog](https://github.com/kendallstrautman/brevifolia-next-tinacms) with Tina configured for reference.
-
-## Get Involved
-
-Want to help out with Tina's development? Please visit our [Contributing](/docs/contributing/guidelines) section in our docs to learn more.
-
-Looking for help with Tina, or want to stay on top of the latest developments? Checkout the [Tina Community Forum](https://community.tinacms.org/) to get answers, help, and llama-humor.
+...

--- a/content/navigation.json
+++ b/content/navigation.json
@@ -2,7 +2,7 @@
   {
     "id": "docs",
     "label": "Docs",
-    "href": "/docs/getting-started/introduction",
+    "href": "/docs",
     "external": false
   },
   {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -131,10 +131,7 @@ const HomePage = (props: any) => {
                 </h2>
                 <CtaBar>
                   <EditLink color="primary" />
-                  <DynamicLink
-                    href={'/docs/getting-started/introduction/'}
-                    passHref
-                  >
+                  <DynamicLink href="/docs/" passHref>
                     <Button as="a">Get Started</Button>
                   </DynamicLink>
                 </CtaBar>
@@ -162,10 +159,7 @@ const HomePage = (props: any) => {
                     blocks={SETUP_POINT_BLOCKS}
                   />
                 </ArrowList>
-                <DynamicLink
-                  href={'/docs/getting-started/introduction/'}
-                  passHref
-                >
+                <DynamicLink href="/docs" passHref>
                   <Button as="a" color="primary">
                     Get Started
                   </Button>


### PR DESCRIPTION
We rewrote the Docs index to serve as a jumping-off point for people visiting the website. This was inspired by the phenomenal [Django Docs](https://docs.djangoproject.com/en/3.0/) as well as the [Rust-lang learn page](https://www.rust-lang.org/learn)

[Checkout the preview here](https://tinacms-site-next-git-docs-index.tinacms.vercel.app/docs)