### PR TITLE
Ts absolute paths

### DIFF
--- a/components/layout/MarkdownContent.tsx
+++ b/components/layout/MarkdownContent.tsx
@@ -6,7 +6,7 @@ import CodeStyle from '../styles/Code'
 import LinkSvg from '../../public/svg/link.svg'
 import styled from 'styled-components'
 
-import * as shortcodeRenderers from '../../utils/shortcodes'
+import * as shortcodeRenderers from 'utils/shortcodes'
 
 var GithubSlugger = require('github-slugger')
 const shortcodes = require('remark-shortcodes')

--- a/components/layout/OpenAuthoringSiteForm.tsx
+++ b/components/layout/OpenAuthoringSiteForm.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { InlineForm, InlineFormProps } from 'react-tinacms-inline'
 import { useGithubToolbarPlugins } from 'react-tinacms-github'
-import { useLocalStorageCache } from '../../utils/plugins/browser-storage-api/useLocalStorageCache'
+import { useLocalStorageCache } from 'utils/plugins/browser-storage-api/useLocalStorageCache'
 import AutoAuthModal from '../open-authoring/AutoAuthModal'
 
 interface Props extends InlineFormProps {

--- a/components/ui/DynamicLink.tsx
+++ b/components/ui/DynamicLink.tsx
@@ -1,5 +1,5 @@
 import Link, { LinkProps } from 'next/link'
-import { getDynamicPath } from '../../utils/getDynamicPath'
+import { getDynamicPath } from 'utils/getDynamicPath'
 
 type ExtraProps = Omit<LinkProps, 'as' | 'href'>
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,7 +6,7 @@ import { DefaultSeo } from 'next-seo'
 import data from '../content/siteConfig.json'
 import TagManager from 'react-gtm-module'
 import { GlobalStyles, FontLoader } from '@tinacms/styles'
-import { BrowserStorageApi } from '../utils/plugins/browser-storage-api/BrowserStorageApi'
+import { BrowserStorageApi } from 'utils/plugins/browser-storage-api/BrowserStorageApi'
 import { GithubClient, TinacmsGithubProvider } from 'react-tinacms-github'
 import { GlobalStyle } from '../components/styles/GlobalStyle'
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,7 +8,7 @@ import TagManager from 'react-gtm-module'
 import { GlobalStyles, FontLoader } from '@tinacms/styles'
 import { BrowserStorageApi } from 'utils/plugins/browser-storage-api/BrowserStorageApi'
 import { GithubClient, TinacmsGithubProvider } from 'react-tinacms-github'
-import { GlobalStyle } from '../components/styles/GlobalStyle'
+import { GlobalStyle } from 'components/styles/GlobalStyle'
 
 const MainLayout = ({ Component, pageProps }) => {
   const tinaConfig = {

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -9,16 +9,16 @@ import {
   Wrapper,
   MarkdownContent,
   DocsTextWrapper,
-} from '../../components/layout'
+} from 'components/layout'
 import { InlineTextareaField } from 'react-tinacms-inline'
 import { useGithubMarkdownForm } from 'react-tinacms-github'
 import { fileToUrl } from 'utils/urls'
-import { OpenAuthoringSiteForm } from '../../components/layout/OpenAuthoringSiteForm'
+import { OpenAuthoringSiteForm } from 'components/layout/OpenAuthoringSiteForm'
 const fg = require('fast-glob')
-import { Button } from '../../components/ui/Button'
+import { Button } from 'components/ui/Button'
 import Error from 'next/error'
 import { getMarkdownPreviewProps } from 'utils/getMarkdownFile'
-import { InlineWysiwyg } from '../../components/inline-wysiwyg'
+import { InlineWysiwyg } from 'components/inline-wysiwyg'
 import { usePlugin, useCMS } from 'tinacms'
 
 function BlogTemplate({ file, siteConfig, preview }) {

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -12,12 +12,12 @@ import {
 } from '../../components/layout'
 import { InlineTextareaField } from 'react-tinacms-inline'
 import { useGithubMarkdownForm } from 'react-tinacms-github'
-import { fileToUrl } from '../../utils/urls'
+import { fileToUrl } from 'utils/urls'
 import { OpenAuthoringSiteForm } from '../../components/layout/OpenAuthoringSiteForm'
 const fg = require('fast-glob')
 import { Button } from '../../components/ui/Button'
 import Error from 'next/error'
-import { getMarkdownPreviewProps } from '../../utils/getMarkdownFile'
+import { getMarkdownPreviewProps } from 'utils/getMarkdownFile'
 import { InlineWysiwyg } from '../../components/inline-wysiwyg'
 import { usePlugin, useCMS } from 'tinacms'
 

--- a/pages/blog/page/[page_index].tsx
+++ b/pages/blog/page/[page_index].tsx
@@ -12,9 +12,9 @@ import {
   Hero,
   MarkdownContent,
   RichTextWrapper,
-} from '../../../components/layout'
-import { DynamicLink, BlogPagination } from '../../../components/ui'
-import { OpenAuthoringSiteForm } from '../../../components/layout/OpenAuthoringSiteForm'
+} from 'components/layout'
+import { DynamicLink, BlogPagination } from 'components/ui'
+import { OpenAuthoringSiteForm } from 'components/layout/OpenAuthoringSiteForm'
 import { useForm } from 'tinacms'
 import { getMarkdownPreviewProps } from 'utils/getMarkdownFile'
 import { PreviewData } from 'next-tinacms-github'

--- a/pages/blog/page/[page_index].tsx
+++ b/pages/blog/page/[page_index].tsx
@@ -16,7 +16,7 @@ import {
 import { DynamicLink, BlogPagination } from '../../../components/ui'
 import { OpenAuthoringSiteForm } from '../../../components/layout/OpenAuthoringSiteForm'
 import { useForm } from 'tinacms'
-import { getMarkdownPreviewProps } from '../../../utils/getMarkdownFile'
+import { getMarkdownPreviewProps } from 'utils/getMarkdownFile'
 import { PreviewData } from 'next-tinacms-github'
 const Index = props => {
   const { currentPage, numPages } = props

--- a/pages/community.tsx
+++ b/pages/community.tsx
@@ -19,7 +19,7 @@ import GithubIconSvg from '../public/svg/github-icon.svg'
 import ForumIconSvg from '../public/svg/forum-icon.svg'
 import { NextSeo } from 'next-seo'
 import { OpenAuthoringSiteForm } from '../components/layout/OpenAuthoringSiteForm'
-import { getJsonPreviewProps } from '../utils/getJsonPreviewProps'
+import { getJsonPreviewProps } from 'utils/getJsonPreviewProps'
 import { useGithubJsonForm } from 'react-tinacms-github'
 import { InlineWysiwyg } from '../components/inline-wysiwyg'
 

--- a/pages/community.tsx
+++ b/pages/community.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { DynamicLink } from '../components/ui/DynamicLink'
+import { DynamicLink } from 'components/ui/DynamicLink'
 import { GetStaticProps } from 'next'
 
 import {
@@ -10,18 +10,18 @@ import {
   Section,
   RichTextWrapper,
   MarkdownContent,
-} from '../components/layout'
+} from 'components/layout'
 import { InlineTextareaField } from 'react-tinacms-inline'
-import { Button, ButtonGroup } from '../components/ui'
-import { EmailForm } from '../components/forms'
+import { Button, ButtonGroup } from 'components/ui'
+import { EmailForm } from 'components/forms'
 import TwitterIconSvg from '../public/svg/twitter-icon.svg'
 import GithubIconSvg from '../public/svg/github-icon.svg'
 import ForumIconSvg from '../public/svg/forum-icon.svg'
 import { NextSeo } from 'next-seo'
-import { OpenAuthoringSiteForm } from '../components/layout/OpenAuthoringSiteForm'
+import { OpenAuthoringSiteForm } from 'components/layout/OpenAuthoringSiteForm'
 import { getJsonPreviewProps } from 'utils/getJsonPreviewProps'
 import { useGithubJsonForm } from 'react-tinacms-github'
-import { InlineWysiwyg } from '../components/inline-wysiwyg'
+import { InlineWysiwyg } from 'components/inline-wysiwyg'
 
 function CommunityPage({ file: community, metadata, preview }) {
   // Registers Tina Form

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -8,21 +8,21 @@ import {
   DocsTextWrapper,
   Wrapper,
   Footer,
-} from '../../components/layout'
+} from 'components/layout'
 import {
   DocsNav,
   NavToggle,
   DocsHeaderNav,
   Overlay,
   DocsPagination,
-} from '../../components/ui'
+} from 'components/ui'
 import { InlineTextareaField, useInlineForm } from 'react-tinacms-inline'
-import { TinaIcon } from '../../components/logo'
+import { TinaIcon } from 'components/logo'
 import { useGithubMarkdownForm } from 'react-tinacms-github'
 import { getDocProps } from 'utils/docs/getDocProps'
-import { OpenAuthoringSiteForm } from '../../components/layout/OpenAuthoringSiteForm'
+import { OpenAuthoringSiteForm } from 'components/layout/OpenAuthoringSiteForm'
 import { GithubError } from 'next-tinacms-github'
-import { InlineWysiwyg } from '../../components/inline-wysiwyg'
+import { InlineWysiwyg } from 'components/inline-wysiwyg'
 import { usePlugin } from 'tinacms'
 
 function DocTemplate(props) {

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -19,7 +19,7 @@ import {
 import { InlineTextareaField, useInlineForm } from 'react-tinacms-inline'
 import { TinaIcon } from '../../components/logo'
 import { useGithubMarkdownForm } from 'react-tinacms-github'
-import { getDocProps } from '../../utils/docs/getDocProps'
+import { getDocProps } from 'utils/docs/getDocProps'
 import { OpenAuthoringSiteForm } from '../../components/layout/OpenAuthoringSiteForm'
 import { GithubError } from 'next-tinacms-github'
 import { InlineWysiwyg } from '../../components/inline-wysiwyg'

--- a/pages/docs/index.tsx
+++ b/pages/docs/index.tsx
@@ -1,5 +1,5 @@
 import DocTemplate from './[...slug]'
-import { getDocProps } from '../../utils/docs/getDocProps'
+import { getDocProps } from 'utils/docs/getDocProps'
 import { GetStaticProps } from 'next'
 import { GithubError } from 'next-tinacms-github'
 

--- a/pages/enterprise.tsx
+++ b/pages/enterprise.tsx
@@ -15,7 +15,7 @@ import {
 } from 'react-tinacms-inline'
 import { OpenAuthoringSiteForm } from '../components/layout/OpenAuthoringSiteForm'
 import { useGithubJsonForm } from 'react-tinacms-github'
-import { getJsonPreviewProps } from '../utils/getJsonPreviewProps'
+import { getJsonPreviewProps } from 'utils/getJsonPreviewProps'
 
 const formOptions = {
   label: 'Teams',

--- a/pages/enterprise.tsx
+++ b/pages/enterprise.tsx
@@ -4,16 +4,16 @@ import { BlockTemplate } from 'tinacms'
 import { NextSeo } from 'next-seo'
 import { GetStaticProps } from 'next'
 
-import { Layout, Wrapper, RichTextWrapper } from '../components/layout'
-import { ArrowList } from '../components/ui'
-import { TeamsForm } from '../components/forms'
+import { Layout, Wrapper, RichTextWrapper } from 'components/layout'
+import { ArrowList } from 'components/ui'
+import { TeamsForm } from 'components/forms'
 import {
   InlineTextareaField,
   InlineBlocks,
   BlockTextarea,
   BlocksControls,
 } from 'react-tinacms-inline'
-import { OpenAuthoringSiteForm } from '../components/layout/OpenAuthoringSiteForm'
+import { OpenAuthoringSiteForm } from 'components/layout/OpenAuthoringSiteForm'
 import { useGithubJsonForm } from 'react-tinacms-github'
 import { getJsonPreviewProps } from 'utils/getJsonPreviewProps'
 

--- a/pages/guides/[category]/[guide]/[step].tsx
+++ b/pages/guides/[category]/[guide]/[step].tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { GetStaticProps, GetStaticPaths } from 'next'
-import { readFile } from '../../../../utils/readFile'
-import { getMarkdownPreviewProps } from '../../../../utils/getMarkdownFile'
+import { readFile } from 'utils/readFile'
+import { getMarkdownPreviewProps } from 'utils/getMarkdownFile'
 import {
   DocsLayout,
   DocsTextWrapper,
@@ -22,15 +22,15 @@ import {
   DocsContent,
 } from '../../../docs/[...slug]'
 import { useRouter } from 'next/router'
-import { getGuideNavProps } from '../../../../utils/guide_helpers'
+import { getGuideNavProps } from 'utils/guide_helpers'
 import { useMemo } from 'react'
 import { OpenAuthoringSiteForm } from '../../../../components/layout/OpenAuthoringSiteForm'
 import { usePlugin, useFormScreenPlugin } from 'tinacms'
 import { InlineTextareaField } from 'react-tinacms-inline'
 import { useGithubMarkdownForm, useGithubJsonForm } from 'react-tinacms-github'
 import { InlineWysiwyg } from '../../../../components/inline-wysiwyg'
-import { getJsonPreviewProps } from '../../../../utils/getJsonPreviewProps'
-import { MarkdownCreatorPlugin } from '../../../../utils/plugins'
+import { getJsonPreviewProps } from 'utils/getJsonPreviewProps'
+import { MarkdownCreatorPlugin } from 'utils/plugins'
 import { fileToUrl } from '../../../../utils'
 
 export default function GuideTemplate(props) {

--- a/pages/guides/[category]/[guide]/[step].tsx
+++ b/pages/guides/[category]/[guide]/[step].tsx
@@ -8,14 +8,9 @@ import {
   Wrapper,
   MarkdownContent,
   Footer,
-} from '../../../../components/layout'
+} from 'components/layout'
 import { NextSeo } from 'next-seo'
-import {
-  DocsNav,
-  DocsPagination,
-  Overlay,
-  DocsHeaderNav,
-} from '../../../../components/ui'
+import { DocsNav, DocsPagination, Overlay, DocsHeaderNav } from 'components/ui'
 import {
   DocsNavToggle,
   DocsMobileTinaIcon,
@@ -24,11 +19,11 @@ import {
 import { useRouter } from 'next/router'
 import { getGuideNavProps } from 'utils/guide_helpers'
 import { useMemo } from 'react'
-import { OpenAuthoringSiteForm } from '../../../../components/layout/OpenAuthoringSiteForm'
+import { OpenAuthoringSiteForm } from 'components/layout/OpenAuthoringSiteForm'
 import { usePlugin, useFormScreenPlugin } from 'tinacms'
 import { InlineTextareaField } from 'react-tinacms-inline'
 import { useGithubMarkdownForm, useGithubJsonForm } from 'react-tinacms-github'
-import { InlineWysiwyg } from '../../../../components/inline-wysiwyg'
+import { InlineWysiwyg } from 'components/inline-wysiwyg'
 import { getJsonPreviewProps } from 'utils/getJsonPreviewProps'
 import { MarkdownCreatorPlugin } from 'utils/plugins'
 import { fileToUrl } from '../../../../utils'

--- a/pages/guides/index.tsx
+++ b/pages/guides/index.tsx
@@ -1,5 +1,5 @@
-import { getGuideNavProps } from '../../utils/guide_helpers'
-import { readMarkdownFile } from '../../utils/getMarkdownFile'
+import { getGuideNavProps } from 'utils/guide_helpers'
+import { readMarkdownFile } from 'utils/getMarkdownFile'
 import React, { useState, useEffect, useMemo } from 'react'
 import { useRouter } from 'next/router'
 import {

--- a/pages/guides/index.tsx
+++ b/pages/guides/index.tsx
@@ -8,20 +8,15 @@ import {
   Wrapper,
   MarkdownContent,
   Footer,
-} from '../../components/layout'
+} from 'components/layout'
 import { NextSeo } from 'next-seo'
 import {
   DocsNavToggle,
   DocsMobileTinaIcon,
   DocsContent,
 } from '../docs/[...slug]'
-import {
-  DocsNav,
-  Overlay,
-  DynamicLink,
-  DocsHeaderNav,
-} from '../../components/ui'
-import { CardGrid, Card } from '../../components/ui/Cards'
+import { DocsNav, Overlay, DynamicLink, DocsHeaderNav } from 'components/ui'
+import { CardGrid, Card } from 'components/ui/Cards'
 import RightArrowSvg from '../../public/svg/right-arrow.svg'
 
 const GuideTemplate = props => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,20 +10,20 @@ import {
   BlockTextarea,
   BlocksControls,
 } from 'react-tinacms-inline'
-import { EditLink } from '../components/layout/EditLink'
+import { EditLink } from 'components/layout/EditLink'
 import { DefaultSeo } from 'next-seo'
 import { useCMS, BlockTemplate } from 'tinacms'
-import { DynamicLink } from '../components/ui/DynamicLink'
+import { DynamicLink } from 'components/ui/DynamicLink'
 import {
   Layout,
   Hero,
   Wrapper,
   Section,
   RichTextWrapper,
-} from '../components/layout'
+} from 'components/layout'
 
-import { Button, Video, ArrowList } from '../components/ui'
-import { OpenAuthoringSiteForm } from '../components/layout/OpenAuthoringSiteForm'
+import { Button, Video, ArrowList } from 'components/ui'
+import { OpenAuthoringSiteForm } from 'components/layout/OpenAuthoringSiteForm'
 import { useGithubJsonForm } from 'react-tinacms-github'
 import { getJsonPreviewProps } from 'utils/getJsonPreviewProps'
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -25,7 +25,7 @@ import {
 import { Button, Video, ArrowList } from '../components/ui'
 import { OpenAuthoringSiteForm } from '../components/layout/OpenAuthoringSiteForm'
 import { useGithubJsonForm } from 'react-tinacms-github'
-import { getJsonPreviewProps } from '../utils/getJsonPreviewProps'
+import { getJsonPreviewProps } from 'utils/getJsonPreviewProps'
 
 const HomePage = (props: any) => {
   const cms = useCMS()

--- a/tinacms/BlogPostCreator.ts
+++ b/tinacms/BlogPostCreator.ts
@@ -1,4 +1,4 @@
-import { MarkdownCreatorPlugin } from '../utils/plugins'
+import { MarkdownCreatorPlugin } from 'utils/plugins'
 import { slugify, fileToUrl } from '../utils'
 import moment from 'moment'
 

--- a/tinacms/ReleaseNotesCreator.ts
+++ b/tinacms/ReleaseNotesCreator.ts
@@ -1,4 +1,4 @@
-import { MarkdownCreatorPlugin } from '../utils/plugins'
+import { MarkdownCreatorPlugin } from 'utils/plugins'
 import { slugify, fileToUrl } from '../utils'
 import moment from 'moment'
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,

--- a/utils/shortcodes.tsx
+++ b/utils/shortcodes.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import styled from 'styled-components'
 import { useCMS } from 'tinacms'
-import { Button } from '../components/ui'
+import { Button } from 'components/ui'
 
 const DemoButtonWrapper = styled.div`
   display: block;


### PR DESCRIPTION
instead of:

```ts
import { Something } from "../../../../../../components/Something"
```

we can now just do

```ts
import { Something } from "components/Something"
```

I only updated the paths that go all the way up to `utils` and `components`. 

This is made possibly by adding `baseUrl: "."` to the `tsconfig.json`.

[See Next.js Docs for details](https://nextjs.org/docs/advanced-features/module-path-aliases)