### PR TITLE
replaced invalid gatsby example

### DIFF
--- a/content/docs/ui.md
+++ b/content/docs/ui.md
@@ -97,16 +97,10 @@ You'll want to pass in this option to wherever the plugin is registered in the `
     enabled: process.env.NODE_ENV !== "production",
     sidebar: {
       position: 'displace',
-      placeholder: () => (
-        <>
-          <h3>
-            Welcome to your site!
-          </h3>
-          <p>
-           There are no forms registered on this page.
-          </p>
-        </>
-      )
+      buttons: {
+        save: "Commit",
+        reset: "Reset",
+      }
     },
   }
 }


### PR DESCRIPTION
It's not actually possible to pass functions through gatsby-config options The object gets serialzied to json or something and the function is lost.