### PR TITLE
More packages

### DIFF
--- a/content/packages.json
+++ b/content/packages.json
@@ -1,16 +1,52 @@
 {
-    "packages": [
-        {
-            "name": "next-tinacms-github",
-            "link": "https://api.github.com/repos/tinacms/tinacms/contents/packages/next-tinacms-github/README.md"
-        },
-        {
-            "name": "next-tinacms-json",
-            "link": "https://api.github.com/repos/tinacms/tinacms/contents/packages/next-tinacms-json/README.md"
-        },
-        {
-            "name": "next-tinacms-markdown",
-            "link": "https://api.github.com/repos/tinacms/tinacms/contents/packages/next-tinacms-markdown/README.md"
-        }
-    ]
+  "packages": [
+    {
+      "link": "https://api.github.com/repos/tinacms/tinacms/contents/packages/react-tinacms-date/README.md",
+      "name": "react-tinacms-date"
+    },
+    {
+      "link": "https://api.github.com/repos/tinacms/tinacms/contents/packages/react-tinacms-editor/README.md",
+      "name": "react-tinacms-editor"
+    },
+    {
+      "link": "https://api.github.com/repos/tinacms/tinacms/contents/packages/react-tinacms-github/README.md",
+      "name": "react-tinacms-github"
+    },
+    {
+      "link": "https://api.github.com/repos/tinacms/tinacms/contents/packages/react-tinacms-inline/README.md",
+      "name": "react-tinacms-inline"
+    },
+    {
+      "link": "https://api.github.com/repos/tinacms/tinacms/contents/packages/react-tinacms-strapi/README.md",
+      "name": "react-tinacms-strapi"
+    },
+    {
+      "name": "next-tinacms-github",
+      "link": "https://api.github.com/repos/tinacms/tinacms/contents/packages/next-tinacms-github/README.md"
+    },
+    {
+      "name": "next-tinacms-json",
+      "link": "https://api.github.com/repos/tinacms/tinacms/contents/packages/next-tinacms-json/README.md"
+    },
+    {
+      "name": "next-tinacms-markdown",
+      "link": "https://api.github.com/repos/tinacms/tinacms/contents/packages/next-tinacms-markdown/README.md"
+    },
+    {
+      "link": "https://api.github.com/repos/tinacms/tinacms/contents/packages/gatsby-plugin-tinacms/README.md",
+      "name": "gatsby-plugin-tinacms"
+    },
+    {
+      "link": "https://api.github.com/repos/tinacms/tinacms/contents/packages/gatsby-tinacms-git/README.md",
+      "name": "gatsby-tinacms-git"
+    },
+    {
+      "link": "https://api.github.com/repos/tinacms/tinacms/contents/packages/gatsby-tinacms-json/README.md",
+      "name": "gatsby-tinacms-json"
+    },
+    {
+      "link": "https://api.github.com/repos/tinacms/tinacms/contents/packages/gatsby-tinacms-remark/README.md",
+      "name": "gatsby-tinacms-remark"
+    }
+  ]
 }

--- a/content/toc-doc.json
+++ b/content/toc-doc.json
@@ -230,6 +230,22 @@
     ]
   },
   {
+    "title": "Integrations",
+    "id": "nextjs",
+    "items": [
+      {
+        "id": "/docs/integrations/nextjs",
+        "slug": "/docs/integrations/nextjs",
+        "title": "Next.js"
+      },
+      {
+        "id": "/docs/integrations/gatsby",
+        "slug": "/docs/integrations/gatsby",
+        "title": "Gatsby"
+      }
+    ]
+  },
+  {
     "title": "Packages",
     "id": "packages",
     "items": [
@@ -292,22 +308,6 @@
         "id": "/packages/gatsby-tinacms-remark",
         "slug": "/packages/gatsby-tinacms-remark",
         "title": "gatsby-tinacms-remark"
-      }
-    ]
-  },
-  {
-    "title": "Integrations",
-    "id": "nextjs",
-    "items": [
-      {
-        "id": "/docs/integrations/nextjs",
-        "slug": "/docs/integrations/nextjs",
-        "title": "Next.js"
-      },
-      {
-        "id": "/docs/integrations/gatsby",
-        "slug": "/docs/integrations/gatsby",
-        "title": "Gatsby"
       }
     ]
   }

--- a/content/toc-doc.json
+++ b/content/toc-doc.json
@@ -234,6 +234,31 @@
     "id": "packages",
     "items": [
       {
+        "id": "/packages/react-tinacms-date",
+        "slug": "/packages/react-tinacms-date",
+        "title": "react-tinacms-date"
+      },
+      {
+        "id": "/packages/react-tinacms-editor",
+        "slug": "/packages/react-tinacms-editor",
+        "title": "react-tinacms-editor"
+      },
+      {
+        "id": "/packages/react-tinacms-github",
+        "slug": "/packages/react-tinacms-github",
+        "title": "react-tinacms-github"
+      },
+      {
+        "id": "/packages/react-tinacms-inline",
+        "slug": "/packages/react-tinacms-inline",
+        "title": "react-tinacms-inline"
+      },
+      {
+        "id": "/packages/react-tinacms-strapi",
+        "slug": "/packages/react-tinacms-strapi",
+        "title": "react-tinacms-strapi"
+      },
+      {
         "id": "/packages/next-tinacms-github",
         "slug": "/packages/next-tinacms-github",
         "title": "next-tinacms-github"
@@ -247,6 +272,26 @@
         "id": "/packages/next-tinacms-markdown",
         "slug": "/packages/next-tinacms-markdown",
         "title": "next-tinacms-markdown"
+      },
+      {
+        "id": "/packages/gatsby-plugin-tinacms",
+        "slug": "/packages/gatsby-plugin-tinacms",
+        "title": "gatsby-plugin-tinacms"
+      },
+      {
+        "id": "/packages/gatsby-tinacms-git",
+        "slug": "/packages/gatsby-tinacms-git",
+        "title": "gatsby-tinacms-git"
+      },
+      {
+        "id": "/packages/gatsby-tinacms-json",
+        "slug": "/packages/gatsby-tinacms-json",
+        "title": "gatsby-tinacms-json"
+      },
+      {
+        "id": "/packages/gatsby-tinacms-remark",
+        "slug": "/packages/gatsby-tinacms-remark",
+        "title": "gatsby-tinacms-remark"
       }
     ]
   },

--- a/pages/packages/[slug].tsx
+++ b/pages/packages/[slug].tsx
@@ -59,11 +59,7 @@ export default function Packages(props) {
         <DocsHeaderNav color={'light'} open={open} />
         <DocsTextWrapper>
           <DocsGrid>
-            <DocGridHeader>
-              <DocsPageTitle>{props.name}</DocsPageTitle>
-            </DocGridHeader>
             <DocGridContent ref={contentRef}>
-              <hr />
               <MarkdownContent escapeHtml={false} content={props.content} />
               <DocsPagination
                 prevPage={props.prevPage}

--- a/pages/packages/[slug].tsx
+++ b/pages/packages/[slug].tsx
@@ -25,10 +25,6 @@ import {
 } from 'pages/docs/[...slug]'
 
 export default function Packages(props) {
-  // TODO: have this actually source from the .md frontmatter
-  const frontmatter = {
-    title: 'Packages',
-  }
   const excerpt = 'A package for Tinacms.'
 
   const [open, setOpen] = useState(false)
@@ -37,21 +33,21 @@ export default function Packages(props) {
   return (
     <DocsLayout isEditing={false}>
       <NextSeo
-        title={frontmatter.title}
+        title={props.name}
         titleTemplate={'%s | TinaCMS Docs'}
         description={excerpt}
         openGraph={{
-          title: frontmatter.title,
+          title: props.name,
           description: excerpt,
           images: [
             {
               url:
                 'https://res.cloudinary.com/forestry-demo/image/upload/l_text:tuner-regular.ttf_90_center:' +
-                encodeURIComponent(frontmatter.title) +
+                encodeURIComponent(props.name) +
                 ',g_center,x_0,y_50,w_850,c_fit,co_rgb:EC4815/v1581087220/TinaCMS/tinacms-social-empty-docs.png',
               width: 1200,
               height: 628,
-              alt: frontmatter.title + ` | TinaCMS Docs`,
+              alt: props.name + ` | TinaCMS Docs`,
             },
           ],
         }}
@@ -64,7 +60,7 @@ export default function Packages(props) {
         <DocsTextWrapper>
           <DocsGrid>
             <DocGridHeader>
-              <DocsPageTitle>{frontmatter.title}</DocsPageTitle>
+              <DocsPageTitle>{props.name}</DocsPageTitle>
             </DocGridHeader>
             <DocGridContent ref={contentRef}>
               <hr />

--- a/utils/docs/getPackageProps.ts
+++ b/utils/docs/getPackageProps.ts
@@ -1,62 +1,64 @@
 import { getJsonPreviewProps, readJsonFile } from '../getJsonPreviewProps'
-import axios from "axios"
+import axios from 'axios'
 const atob = require('atob')
 
 const b64DecodeUnicode = (str: string) => {
-    // Going backwards: from bytestream, to percent-encoding, to original string.
-    return decodeURIComponent(
+  // Going backwards: from bytestream, to percent-encoding, to original string.
+  return decodeURIComponent(
     atob(str)
-        .split('')
-        .map(function(c: string) {
-            return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
-        })
-        .join('')
-    )
+      .split('')
+      .map(function(c: string) {
+        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+      })
+      .join('')
+  )
 }
 
-export async function getPackageProps({ preview, previewData }: any, slug: string) {
+export async function getPackageProps(
+  { preview, previewData }: any,
+  slug: string
+) {
+  const file = await readJsonFile('content/packages.json')
 
-    const file = await readJsonFile('content/packages.json')
+  interface GithubPackage {
+    name: string
+    link: string
+  }
 
-    interface GithubPackage {
-        name: string
-        link: string
+  var currentPackage: GithubPackage
+  var previousPackage, nextPackage: GithubPackage | null
+
+  file.packages.forEach((element, index) => {
+    if (element.name === slug) {
+      currentPackage = element
+      previousPackage = index > 0 ? file.packages[index - 1] : null
+      nextPackage =
+        index < file.packages.length - 1 ? file.packages[index + 1] : null
     }
+  })
 
-    var currentPackage: GithubPackage
-    var previousPackage, nextPackage: GithubPackage | null
+  const currentDoc = await axios.get(currentPackage.link)
+  const content = b64DecodeUnicode(currentDoc.data.content)
 
-    file.packages.forEach((element, index) => {
-        if (element.name === slug) {
-            currentPackage = element
-            previousPackage = index > 0 ? file.packages[index - 1] : null
-            nextPackage = index < file.packages.length - 1 ? file.packages[index + 1] : null
-        }
-    });
+  const previewProps = await getJsonPreviewProps(
+    'content/toc-doc.json',
+    preview,
+    previewData
+  )
+  const docsNavData = previewProps.props.file.data
 
-    const currentDoc = await axios.get(currentPackage.link)
-    const content = b64DecodeUnicode(currentDoc.data.content)
-
-    
-    const previewProps = await getJsonPreviewProps(
-        'content/toc-doc.json',
-        preview,
-        previewData
-    )
-    const docsNavData = previewProps.props.file.data
-
-    return {
-        props: {
-        content,
-        docsNav: docsNavData,
-        nextPage: {
-            slug: nextPackage?.name || null,
-            title: nextPackage?.name|| null,
-        },
-        prevPage: {
-            slug: previousPackage?.name || null,
-            title: previousPackage?.name || null,
-        },
-        },
-    }
+  return {
+    props: {
+      content,
+      docsNav: docsNavData,
+      nextPage: {
+        slug: nextPackage?.name || null,
+        title: nextPackage?.name || null,
+      },
+      prevPage: {
+        slug: previousPackage?.name || null,
+        title: previousPackage?.name || null,
+      },
+    },
+  }
 }

--- a/utils/docs/getPackageProps.ts
+++ b/utils/docs/getPackageProps.ts
@@ -49,6 +49,8 @@ export async function getPackageProps(
 
   return {
     props: {
+      name: currentPackage.name,
+      link: currentPackage.link,
       content,
       docsNav: docsNavData,
       nextPage: {


### PR DESCRIPTION
- Add more packages to the website
- Generate metadata using package name instead of always using "Packages"
- Stop rendering H1, let the README do that
- Switched Integrations with Packages in the sidebar

<img width="409" alt="image" src="https://user-images.githubusercontent.com/824015/88415450-e780b280-cdb4-11ea-9fa0-8cc58444a7cc.png">

<img width="886" alt="image" src="https://user-images.githubusercontent.com/824015/88415493-f9faec00-cdb4-11ea-939e-3b852707577b.png">
