### PR TITLE
Deprioritize non-default fields

### DIFF
--- a/content/docs/plugins/fields/blocks.md
+++ b/content/docs/plugins/fields/blocks.md
@@ -1,7 +1,7 @@
 ---
 title: Blocks Field
 prev: /docs/plugins/fields/group-list
-next: /docs/plugins/fields/custom-fields
+next: /docs/plugins/fields/date
 consumes:
   - file: /packages/tinacms/src/plugins/fields/BlocksFieldPlugin.tsx
     details: Shows blocks interface

--- a/content/docs/plugins/fields/custom-fields.md
+++ b/content/docs/plugins/fields/custom-fields.md
@@ -1,6 +1,6 @@
 ---
 title: Creating Custom Fields
-prev: /docs/plugins/fields/blocks
+prev: /docs/plugins/fields/html
 next: null
 consumes:
   - file: /packages/@tinacms/core/src/plugins.ts

--- a/content/docs/plugins/fields/date.md
+++ b/content/docs/plugins/fields/date.md
@@ -1,7 +1,7 @@
 ---
 title: Date & Time Field
-prev: /docs/plugins/fields/number
-next: /docs/plugins/fields/image
+prev: /docs/plugins/fields/blocks
+next: /docs/plugins/fields/markdown
 consumes:
   - file: /packages/tinacms/src/plugins/fields/DateFieldPlugin.tsx
     details: Documents how to use the date field plugin
@@ -11,75 +11,6 @@ consumes:
 
 The `date` field represents a date and time picker. It can be used for data values that are valid date strings.
 
+> **The `DateFieldPlugin` is NOT a default plugin.** See the [react-tinacms-date](/packages/react-tinacms-date) docs for instructions on how to use the `date` field in your website.
+
 ![tinacms-date-field](/img/fields/date.jpg)
-
-## Installation
-
-The Date Field plugin is provided by the `react-tinacms-date` package.
-
-```bash
-yarn add react-tinacms-date
-```
-
-### Registering the _DateFieldPlugin_
-
-```ts
-import { DateFieldPlugin } from 'react-tinacms-date'
-
-cms.plugins.add(DateFieldPlugin)
-```
-
-> Visit the [plugins](/docs/plugins) doc to learn how to reduce your initial bundle size by dynamically loading & registering the plugins.
-
-## Options
-
-This field plugin uses [`react-datetime`](https://www.npmjs.com/package/react-datetime) under the hood.
-
-```typescript
-interface DateConfig extends FieldConfig, DatetimepickerProps {
-  component: 'date'
-  name: string
-  label?: string
-  description?: string
-  dateFormat?: boolean | string // Extra properties from react-datetime
-  timeFormat?: boolean | string // Moment date format
-}
-```
-
-| Option        | Description                                                                                                                                                                                                                                                                                                                                                                                                               |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `component`   | The name of the plugin component. Always `'date'`.                                                                                                                                                                                                                                                                                                                                                                        |
-| `name`        | The path to some value in the data being edited.                                                                                                                                                                                                                                                                                                                                                                          |
-| `label`       | A human readable label for the field. Defaults to the `name`. _(Optional)_                                                                                                                                                                                                                                                                                                                                                |
-| `description` | Description that expands on the purpose of the field or prompts a specific action. _(Optional)_                                                                                                                                                                                                                                                                                                                           |
-| `dateFormat`  | Defines the format for the date. It accepts any [Moment.js date format](https://momentjs.com/docs/#/displaying/format/) (not in localized format). If true the date will be displayed using the defaults for the current locale. See [react-datetime docs](https://github.com/YouCanBookMe/react-datetime) for more details. _(Optional)_                                                                                 |
-| `timeFormat`  | Defines the format for the time. It accepts any [Moment.js time format](https://momentjs.com/docs/#/displaying/format/) (not in localized format). If true the time will be displayed using the defaults for the current locale. If false the timepicker is disabled and the component can be used as datepicker. See [react-datetime docs](https://github.com/YouCanBookMe/react-datetime) for more details._(Optional)_ |
-
-> ### FieldConfig
->
-> This interfaces only shows the keys unique to the date field.
->
-> Visit the [Field Config](/docs/plugins/fields) docs for a complete list of options.
->
-> ### DatetimepickerProps
->
-> Any extra properties added to the the `date` field definition will be passed along to the [`react-datettime`](https://www.npmjs.com/package/react-datetime) component. [Moment.js](https://momentjs.com/docs/#/displaying/format/) format is used. See the full list of options [here](https://www.npmjs.com/package/react-datetime#api).
-
-## Example
-
-Below is an example of how a `date` field could be used to edit a `created_at` date on a blog post.
-
-```javascript
-const BlogPostForm = {
-  fields: [
-    {
-      label: 'Date',
-      name: 'created_at',
-      component: 'date',
-      dateFormat: 'MMMM DD YYYY',
-      timeFormat: false,
-    },
-    // ...
-  ],
-}
-```

--- a/content/docs/plugins/fields/date.md
+++ b/content/docs/plugins/fields/date.md
@@ -11,6 +11,6 @@ consumes:
 
 The `date` field represents a date and time picker. It can be used for data values that are valid date strings.
 
-> **The `DateFieldPlugin` is NOT a default plugin.** See the [react-tinacms-date](/packages/react-tinacms-date) docs for instructions on how to use the `date` field in your website.
+> **The `DateFieldPlugin` is not a default plugin.** See the [react-tinacms-date](/packages/react-tinacms-date) docs for instructions on how to use the `date` field in your website.
 
 ![tinacms-date-field](/img/fields/date.jpg)

--- a/content/docs/plugins/fields/html.md
+++ b/content/docs/plugins/fields/html.md
@@ -9,61 +9,6 @@ consumes:
 
 The `html` field represents a chunk of HTML content.
 
+> **The `HtmlFieldPlugin` is NOT a default plugin.** See the [react-tinacms-editor](/packages/react-tinacms-editor) docs for instructions on how to use the `html` field in your website.
+
 ![tinacms-markdown-field](/img/fields/markdown.png)
-
-## Options
-
-```typescript
-interface HtmlConfig {
-  component: 'html'
-  name: string
-  label?: string
-  description?: string
-}
-```
-
-| Option        | Description                                                                                     |
-| ------------- | ----------------------------------------------------------------------------------------------- |
-| `component`   | The name of the plugin component. Always `'html'`.                                              |
-| `name`        | The path to some value in the data being edited.                                                |
-| `label`       | A human readable label for the field. Defaults to the `name`. _(Optional)_                      |
-| `description` | Description that expands on the purpose of the field or prompts a specific action. _(Optional)_ |
-
-> This interfaces only shows the keys unique to the html field.
->
-> Visit the [Field Config](/docs/plugins/fields) docs for a complete list of options.
-
-## Adding the Plugin
-
-The `html` field plugin is not a default plugin. In order to use it in your site you must install the `react-tinacms-editor` package:
-
-```
-yarn add react-tinacms-editor
-```
-
-You can then add it to your cms:
-
-```ts
-import { HtmlFieldPlugin } from 'react-tinacms-editor'
-
-cms.plugins.add(HtmlFieldPlugin)
-```
-
-> Visit the [plugins](/docs/plugins) doc to learn how to reduce your initial bundle size by dynamically loading & registering the plugins.
-
-## Definition
-
-Below is an example of how a `html` field could be defined. [Read more on passing in form field options](/guides/gatsby/git/customize-form).
-
-```javascript
-const BlogPostForm = {
-  fields: [
-    {
-      name: 'frontmatter.summary',
-      component: 'html',
-      label: 'Summary',
-    },
-    // ...
-  ],
-}
-```

--- a/content/docs/plugins/fields/html.md
+++ b/content/docs/plugins/fields/html.md
@@ -9,6 +9,6 @@ consumes:
 
 The `html` field represents a chunk of HTML content.
 
-> **The `HtmlFieldPlugin` is NOT a default plugin.** See the [react-tinacms-editor](/packages/react-tinacms-editor) docs for instructions on how to use the `html` field in your website.
+> **The `HtmlFieldPlugin` is not a default plugin.** See the [react-tinacms-editor](/packages/react-tinacms-editor) docs for instructions on how to use the `html` field in your website.
 
 ![tinacms-markdown-field](/img/fields/markdown.png)

--- a/content/docs/plugins/fields/image.md
+++ b/content/docs/plugins/fields/image.md
@@ -1,6 +1,6 @@
 ---
 title: Image Field
-prev: /docs/plugins/fields/date
+prev: /docs/plugins/fields/number
 next: /docs/plugins/fields/color
 consumes:
   - file: /packages/tinacms/src/plugins/fields/ImageFieldPlugin.tsx

--- a/content/docs/plugins/fields/markdown.md
+++ b/content/docs/plugins/fields/markdown.md
@@ -1,72 +1,11 @@
 ---
 title: Markdown Field
-prev: /docs/plugins/fields/textarea
+prev: /docs/plugins/fields/date
 next: /docs/plugins/fields/html
-consumes:
-  - file: /packages/tinacms/src/plugins/fields/MarkdownFieldPlugin.tsx
-    details: Shows markdown interface and config options
 ---
 
-The `markdown` field represents a chunk of Markdown content. This field is typically used for the body of Markdown files.
+The `markdown` field is a WYSIWYG for editing a Markdown content. This field is typically used for the body of Markdown files.
+
+> **The `MarkdownFieldPlugin` is NOT a default plugin.** See the [react-tinacms-editor](/packages/react-tinacms-editor) docs for instructions on how to use the `markdown` field in your website.
 
 ![tinacms-markdown-field](/img/fields/markdown.png)
-
-## Options
-
-```typescript
-interface MarkdownConfig {
-  component: 'markdown'
-  name: string
-  label?: string
-  description?: string
-}
-```
-
-| Option        | Description                                                                                     |
-| ------------- | ----------------------------------------------------------------------------------------------- |
-| `component`   | The name of the plugin component. Always `'markdown'`.                                          |
-| `name`        | The path to some value in the data being edited.                                                |
-| `label`       | A human readable label for the field. Defaults to the `name`. _(Optional)_                      |
-| `description` | Description that expands on the purpose of the field or prompts a specific action. _(Optional)_ |
-
-> ### FieldConfig
->
-> This interfaces only shows the keys unique to the markdown field.
->
-> Visit the [Field Config](/docs/plugins/fields) docs for a complete list of options.
-
-## Adding the Plugin
-
-The `markdown` field plugin is not a default plugin. In order to use it in your site you must install the `react-tinacms-editor` package:
-
-```
-yarn add react-tinacms-editor
-```
-
-You can then add it to your cms:
-
-```ts
-import { MarkdownFieldPlugin } from 'react-tinacms-editor'
-
-cms.plugins.add(MarkdownFieldPlugin)
-```
-
-> Visit the [plugins](/docs/plugins) doc to learn how to reduce your initial bundle size by dynamically loading & registering the plugins.
-
-## Definition
-
-Below is an example of how a `markdown` field could be defined in a Gatsby remark form. [Read more on passing in form field options](/guides/gatsby/git/customize-form).
-
-```javascript
-const BlogPostForm = {
-  fields: [
-    {
-      name: 'rawMarkdownBody',
-      component: 'markdown',
-      label: 'Post Body',
-      description: 'Edit the body of the post here',
-    },
-    // ...
-  ],
-}
-```

--- a/content/docs/plugins/fields/markdown.md
+++ b/content/docs/plugins/fields/markdown.md
@@ -6,6 +6,6 @@ next: /docs/plugins/fields/html
 
 The `markdown` field is a WYSIWYG for editing a Markdown content. This field is typically used for the body of Markdown files.
 
-> **The `MarkdownFieldPlugin` is NOT a default plugin.** See the [react-tinacms-editor](/packages/react-tinacms-editor) docs for instructions on how to use the `markdown` field in your website.
+> **The `MarkdownFieldPlugin` is not a default plugin.** See the [react-tinacms-editor](/packages/react-tinacms-editor) docs for instructions on how to use the `markdown` field in your website.
 
 ![tinacms-markdown-field](/img/fields/markdown.png)

--- a/content/docs/plugins/fields/number.md
+++ b/content/docs/plugins/fields/number.md
@@ -1,7 +1,7 @@
 ---
 title: Number Field
-prev: /docs/plugins/fields/html
-next: /docs/plugins/fields/date
+prev: /docs/plugins/fields/textarea
+next: /docs/plugins/fields/image
 consumes:
   - file: /packages/@tinacms/fields/src/plugins/NumberFieldPlugin.tsx
     details: Shows text field interface and config options

--- a/content/docs/plugins/fields/textarea.md
+++ b/content/docs/plugins/fields/textarea.md
@@ -1,7 +1,7 @@
 ---
 title: Text Area Field
 prev: /docs/plugins/fields/text
-next: /docs/plugins/fields/markdown
+next: /docs/plugins/fields/number
 consumes:
   - file: /packages/@tinacms/fields/src/plugins/TextareaFieldPlugin.tsx
     details: Shows textarea field interface and config options

--- a/content/toc-doc.json
+++ b/content/toc-doc.json
@@ -107,26 +107,13 @@
             "slug": "/docs/plugins/fields/textarea",
             "title": "Text Area"
           },
-          {
-            "id": "/docs/plugins/fields/markdown",
-            "slug": "/docs/plugins/fields/markdown",
-            "title": "Markdown"
-          },
-          {
-            "id": "/docs/plugins/fields/html",
-            "slug": "/docs/plugins/fields/html",
-            "title": "HTML"
-          },
+
           {
             "id": "/docs/plugins/fields/number",
             "slug": "/docs/plugins/fields/number",
             "title": "Number"
           },
-          {
-            "id": "/docs/plugins/fields/date",
-            "slug": "/docs/plugins/fields/date",
-            "title": "Date & Time"
-          },
+
           {
             "id": "/docs/plugins/fields/image",
             "slug": "/docs/plugins/fields/image",
@@ -171,6 +158,21 @@
             "id": "/docs/plugins/fields/blocks",
             "slug": "/docs/plugins/fields/blocks",
             "title": "Blocks"
+          },
+          {
+            "id": "/docs/plugins/fields/date",
+            "slug": "/docs/plugins/fields/date",
+            "title": "Date & Time"
+          },
+          {
+            "id": "/docs/plugins/fields/markdown",
+            "slug": "/docs/plugins/fields/markdown",
+            "title": "Markdown"
+          },
+          {
+            "id": "/docs/plugins/fields/html",
+            "slug": "/docs/plugins/fields/html",
+            "title": "HTML"
           },
           {
             "id": "/docs/plugins/fields/custom-fields",


### PR DESCRIPTION
- Move `date`, `markdown`, and `html` to the bottom of the Plugins Nav
- Remove content of said files and instead link to the appropriate package docs
