### PR TITLE
fix: generate better slugs in docs ToC

### DIFF
--- a/utils/docs/getPackageProps.ts
+++ b/utils/docs/getPackageProps.ts
@@ -2,6 +2,7 @@ import { getJsonPreviewProps, readJsonFile } from '../getJsonPreviewProps'
 import axios from 'axios'
 import toc from 'markdown-toc'
 const atob = require('atob')
+import { slugifyTocHeading } from './slugifyToc'
 
 const b64DecodeUnicode = (str: string) => {
   // Going backwards: from bytestream, to percent-encoding, to original string.
@@ -54,7 +55,9 @@ export async function getPackageProps(
       link: currentPackage.link,
       content,
       docsNav: docsNavData,
-      tocItems: toc(content).content,
+      tocItems: toc(content, {
+        slugify: slugifyTocHeading,
+      }).content,
       nextPage: {
         slug: nextPackage?.name || null,
         title: nextPackage?.name || null,

--- a/utils/docs/slugifyToc.test.ts
+++ b/utils/docs/slugifyToc.test.ts
@@ -1,0 +1,29 @@
+import { slugifyTocHeading } from './slugifyToc'
+
+test('simple emphasized string', () => {
+  expect(slugifyTocHeading('_test_')).toEqual('test')
+})
+
+test('string with partial emphasis', () => {
+  expect(slugifyTocHeading('This is a _test_')).toEqual('this-is-a-test')
+})
+
+test('string with underscore', () => {
+  expect(slugifyTocHeading('_type')).toEqual('_type')
+})
+
+test('string with underscore and escaped underscore', () => {
+  expect(slugifyTocHeading('_test or _test')).toEqual('test-or-test')
+})
+
+test('emphasized string with escaped underscore', () => {
+  expect(slugifyTocHeading('_unstable\\_revalidate_')).toEqual(
+    'unstable_revalidate'
+  )
+})
+
+test('emphasized string with other escaped syntax', () => {
+  expect(slugifyTocHeading('_unstable\\#revalidate_')).toEqual(
+    'unstable#revalidate'
+  )
+})

--- a/utils/docs/slugifyToc.ts
+++ b/utils/docs/slugifyToc.ts
@@ -1,5 +1,5 @@
 import toc from 'markdown-toc'
-const captureEmphasis = /(.*)_([^\\]+)_(.*)/
+const captureEmphasis = /(.*)(?<!\\)_(.*)(?<!\\)_(.*)/
 
 export const slugifyTocHeading = heading => {
   const captured = captureEmphasis.exec(heading)

--- a/utils/docs/slugifyToc.ts
+++ b/utils/docs/slugifyToc.ts
@@ -1,0 +1,8 @@
+import toc from 'markdown-toc'
+const captureEmphasis = /(.*)_([^\\]+)_(.*)/
+
+export const slugifyTocHeading = heading => {
+  const captured = captureEmphasis.exec(heading)
+  const strippedHeading = captured ? captured.slice(1).join('') : heading
+  return toc.slugify(strippedHeading)
+}

--- a/utils/getMarkdownFile.ts
+++ b/utils/getMarkdownFile.ts
@@ -4,6 +4,8 @@ import { readFile } from './readFile'
 import { formatExcerpt } from '.'
 import { getGithubPreviewProps, parseMarkdown } from 'next-tinacms-github'
 import toc from 'markdown-toc'
+import { slugifyTocHeading } from './docs/slugifyToc'
+
 export const readMarkdownFile = async (filePath: string) => {
   const doc = matter(await readFile(path.resolve(`${filePath}`)))
   return {
@@ -46,7 +48,8 @@ export const getMarkdownPreviewProps = async (
       error: null,
       preview: false,
       file,
-      tocItems: toc(file.data.markdownBody).content,
+      tocItems: toc(file.data.markdownBody, { slugify: slugifyTocHeading })
+        .content,
     },
   }
 }


### PR DESCRIPTION
fixes #580 

This is the "cheap" fix I suggested in the issue, but likely fits the 80+% use case as underscores seem to be the main problem

I plan in going through the docs front-to-back today, I'm gonna check all the ToC links before merging this