### PR TITLE
docs: adds cms methods docs

### DIFF
--- a/content/docs/cms.md
+++ b/content/docs/cms.md
@@ -194,7 +194,7 @@ It is now recommended to configure button text on the form intead of in the CMS 
 
 There are a number of [core properties](https://github.com/tinacms/tinacms/blob/master/packages/%40tinacms/core/src/cms.ts) that can be helpful in working with the CMS.
 
-### Interface
+### TinaCMS Interface
 
 ```ts
 interface TinaCMS {

--- a/content/docs/cms.md
+++ b/content/docs/cms.md
@@ -190,28 +190,21 @@ const cms = new TinaCMS({
 
 It is now recommended to configure button text on the form intead of in the CMS object. Please read further on [configuring custom buttons](/docs/forms#customizing-form-buttons) in the form documentation.
 
-## Getters
+## Reference
 
-This is a list of available _getters_ to retrieve information about the CMS.
+There are a number of [core properties](https://github.com/tinacms/tinacms/blob/master/packages/%40tinacms/core/src/cms.ts) that can be helpful in working with the CMS.
 
-| getter                  | usage                                                            |
-| ----------------------- | ---------------------------------------------------------------- |
-| `cms.enabled: boolean`  | When `true`, the CMS is _enabled_ and content can be edited.     |
-| `cms.disabled: boolean` | When `true`, the CMS is _disabled_ and content cannot be edited. |
-
-## Methods
-
-There are a number of [core methods](https://github.com/tinacms/tinacms/blob/master/packages/%40tinacms/core/src/cms.ts) that can be helpful in working with the CMS.
-
-| method                                            | usage                                               |
-| ------------------------------------------------- | --------------------------------------------------- |
-| `cms.registerApi( name: string, api: any ): void` | Registers a new external API with the CMS.          |
-| `cms.enable(): void`                              | Enable the CMS so content can be edited.            |
-| `cms.disable(): void`                             | Disable the CMS so content can no longer be edited. |
-| `cms.toggle(): void`                              | Toggles the enabled/disabled state of the CMS .     |
+| property                                      | usage                                                            |
+| --------------------------------------------- | ---------------------------------------------------------------- |
+| `enabled: boolean`                            | When `true`, the CMS is _enabled_ and content can be edited.     |
+| `disabled: boolean`                           | When `true`, the CMS is _disabled_ and content cannot be edited. |
+| `registerApi( name: string, api: any ): void` | Registers a new external API with the CMS.                       |
+| `enable(): void`                              | Enable the CMS so content can be edited.                         |
+| `disable(): void`                             | Disable the CMS so content can no longer be edited.              |
+| `toggle(): void`                              | Toggles the enabled/disabled state of the CMS .                  |
 
 > Use the `useCMS` hook to [access the CMS](/docs/cms#accessing-the-cms-object) and execute these methods as needed.
 
 **Examples**
 
-Reference the `cms.toggle` [example](/docs/cms#disabling--enabling-the-cms) above or checkout the [API documentation](/docs/apis#adding-an-api) for an example using `cms.registerApi`.
+Reference the enabling / disabling the cms [example](/docs/cms#disabling--enabling-the-cms) above to see use of `cms.enabled` & `cms.toggle()`, or checkout the [API documentation](/docs/apis#adding-an-api) for an example using `cms.registerApi`.

--- a/content/docs/cms.md
+++ b/content/docs/cms.md
@@ -194,14 +194,27 @@ It is now recommended to configure button text on the form intead of in the CMS 
 
 There are a number of [core properties](https://github.com/tinacms/tinacms/blob/master/packages/%40tinacms/core/src/cms.ts) that can be helpful in working with the CMS.
 
-| property                                      | usage                                                            |
-| --------------------------------------------- | ---------------------------------------------------------------- |
-| `enabled: boolean`                            | When `true`, the CMS is _enabled_ and content can be edited.     |
-| `disabled: boolean`                           | When `true`, the CMS is _disabled_ and content cannot be edited. |
-| `registerApi( name: string, api: any ): void` | Registers a new external API with the CMS.                       |
-| `enable(): void`                              | Enable the CMS so content can be edited.                         |
-| `disable(): void`                             | Disable the CMS so content can no longer be edited.              |
-| `toggle(): void`                              | Toggles the enabled/disabled state of the CMS .                  |
+### Interface
+
+```ts
+interface TinaCMS {
+  enabled: boolean
+  disabled: boolean
+  registerApi(name: string, api: any): void
+  enable(): void
+  disable(): void
+  toggle(): void
+}
+```
+
+| property      | description                                                                                  |
+| ------------- | -------------------------------------------------------------------------------------------- |
+| `enabled`     | Returns the enabled state. When `true`, the CMS is _enabled_ and content can be edited.      |
+| `disabled`    | Returns the disabled state. When `true`, the CMS is _disabled_ and content cannot be edited. |
+| `registerApi` | A function to register a new external API with the CMS.                                      |
+| `enable`      | A function to enable the CMS so content can be edited.                                       |
+| `disable`     | A function to disable the CMS so content can no longer be edited.                            |
+| `toggle`      | A function to toggle the enabled/disabled state of the CMS .                                 |
 
 > Use the `useCMS` hook to [access the CMS](/docs/cms#accessing-the-cms-object) and execute these methods as needed.
 

--- a/content/docs/cms.md
+++ b/content/docs/cms.md
@@ -207,17 +207,13 @@ interface TinaCMS {
 }
 ```
 
-| property      | description                                                                                  |
-| ------------- | -------------------------------------------------------------------------------------------- |
-| `enabled`     | Returns the enabled state. When `true`, the CMS is _enabled_ and content can be edited.      |
-| `disabled`    | Returns the disabled state. When `true`, the CMS is _disabled_ and content cannot be edited. |
-| `registerApi` | A function to register a new external API with the CMS.                                      |
-| `enable`      | A function to enable the CMS so content can be edited.                                       |
-| `disable`     | A function to disable the CMS so content can no longer be edited.                            |
-| `toggle`      | A function to toggle the enabled/disabled state of the CMS .                                 |
+| property      | description                                                                                   |
+| ------------- | --------------------------------------------------------------------------------------------- |
+| `enabled`     | Returns the enabled state. When `true`, content _can_ be edited.                              |
+| `disabled`    | Returns the disabled state. When `true`, content _cannot_ be edited.                          |
+| `registerApi` | Registers a new [external API](/docs/apis#adding-an-api) with the CMS.                        |
+| `enable`      | [Enables](/docs/cms#disabling--enabling-the-cms) the CMS so content can be edited.            |
+| `disable`     | [Disables](/docs/cms#disabling--enabling-the-cms) the CMS so content can no longer be edited. |
+| `toggle`      | [Toggles](/docs/cms#disabling--enabling-the-cms) the enabled/disabled state of the CMS .      |
 
 > Use the `useCMS` hook to [access the CMS](/docs/cms#accessing-the-cms-object) and execute these methods as needed.
-
-**Examples**
-
-Reference the enabling / disabling the cms [example](/docs/cms#disabling--enabling-the-cms) above to see use of `cms.enabled` & `cms.toggle()`, or checkout the [API documentation](/docs/apis#adding-an-api) for an example using `cms.registerApi`.

--- a/content/docs/cms.md
+++ b/content/docs/cms.md
@@ -189,3 +189,29 @@ const cms = new TinaCMS({
 ### Customize 'Save' & 'Reset' button text
 
 It is now recommended to configure button text on the form intead of in the CMS object. Please read further on [configuring custom buttons](/docs/forms#customizing-form-buttons) in the form documentation.
+
+## Getters
+
+This is a list of available _getters_ to retrieve information about the CMS.
+
+| getter                  | usage                                                            |
+| ----------------------- | ---------------------------------------------------------------- |
+| `cms.enabled: boolean`  | When `true`, the CMS is _enabled_ and content can be edited.     |
+| `cms.disabled: boolean` | When `true`, the CMS is _disabled_ and content cannot be edited. |
+
+## Methods
+
+There are a number of [core methods](https://github.com/tinacms/tinacms/blob/master/packages/%40tinacms/core/src/cms.ts) that can be helpful in working with the CMS.
+
+| method                                            | usage                                               |
+| ------------------------------------------------- | --------------------------------------------------- |
+| `cms.registerApi( name: string, api: any ): void` | Registers a new external API with the CMS.          |
+| `cms.enable(): void`                              | Enable the CMS so content can be edited.            |
+| `cms.disable(): void`                             | Disable the CMS so content can no longer be edited. |
+| `cms.toggle(): void`                              | Toggles the enabled/disabled state of the CMS .     |
+
+> Use the `useCMS` hook to [access the CMS](/docs/cms#accessing-the-cms-object) and execute these methods as needed.
+
+**Examples**
+
+Reference the `cms.toggle` [example](/docs/cms#disabling--enabling-the-cms) above or checkout the [API documentation](/docs/apis#adding-an-api) for an example using `cms.registerApi`.


### PR DESCRIPTION
Noticed that we didn't have a reference for the methods on the CMS. While they're used in examples, I thought a base reference would be helpful.