### PR TITLE
Temporary fix for file access in preview mode lambdas

### DIFF
--- a/pages/guides/index.tsx
+++ b/pages/guides/index.tsx
@@ -139,7 +139,8 @@ const GuideWrapper = styled(Wrapper)`
 export default GuideTemplate
 
 export const getStaticProps = async () => {
-  const path = require('path')
+  // @ts-ignore
+  const path = __non_webpack_require__('path')
   return {
     props: {
       slug: '/guides',

--- a/pages/packages/[slug].tsx
+++ b/pages/packages/[slug].tsx
@@ -116,7 +116,7 @@ export const getStaticProps: GetStaticProps = async function(props) {
 }
 
 export const getStaticPaths: GetStaticPaths = async function() {
-  const filePath = path.join(process.cwd(), 'content/packages.json')
+  const filePath = path.resolve(process.cwd(), './content/packages.json')
   const file = await JSON.parse(fs.readFileSync(filePath, 'utf8'))
 
   return {

--- a/pages/packages/[slug].tsx
+++ b/pages/packages/[slug].tsx
@@ -2,8 +2,10 @@ import React, { useState } from 'react'
 import { NextSeo } from 'next-seo'
 import { GetStaticProps, GetStaticPaths } from 'next'
 import { GithubError } from 'next-tinacms-github'
-import path from 'path'
 import fs from 'fs'
+
+// @ts-ignore
+const path = __non_webpack_require__('path')
 
 import {
   DocsLayout,

--- a/utils/docs/getPackageProps.ts
+++ b/utils/docs/getPackageProps.ts
@@ -4,7 +4,9 @@ import toc from 'markdown-toc'
 
 const atob = require('atob')
 import { slugifyTocHeading } from './slugifyToc'
-import path from 'path'
+
+// @ts-ignore
+const path = __non_webpack_require__('path')
 
 const b64DecodeUnicode = (str: string) => {
   // Going backwards: from bytestream, to percent-encoding, to original string.


### PR DESCRIPTION
There is a bug in the Vercel builder that is preventing some files from being accessed in preview mode lambdas, causing errors when trying to edit the site. This workaround should solve the problem until they implement a long-term fix.

When the workaround is no longer needed, we should revert `4b085db51c8aa6f3b37b5087dffe154a79adf414`.