### PR TITLE
docs: updates field overview

### DIFF
--- a/content/docs/plugins/fields.md
+++ b/content/docs/plugins/fields.md
@@ -131,7 +131,7 @@ The `name` property should be updated to reflect the different path:
 
 ### _component_
 
-The `component` field property can either be a string or the name of a field plugin, or a React Component.
+The `component` field property can either be the name of a field plugin (a string), or a React Component.
 
 All of the previous examples show the `component` being set with a string:
 

--- a/content/docs/plugins/fields.md
+++ b/content/docs/plugins/fields.md
@@ -146,7 +146,7 @@ All of the previous examples show the `component` being set with a string:
 }
 ```
 
-`color` is referring to the `name` of the Color [Field Plugin](/docs/plugins/fields/custom-fields#2-creating-field-plugins) that is hooked up to the CMS by default.
+`'color'` is referring to the `name` of the Color [Field Plugin](/docs/plugins/fields/custom-fields#2-creating-field-plugins) that is hooked up to the CMS by default.
 
 You can also define components inline to render in place of a default field:
 

--- a/content/docs/plugins/fields.md
+++ b/content/docs/plugins/fields.md
@@ -56,9 +56,9 @@ These are the default field plugins available through the CMS:
 
 These are plugins that must be installed through separate packages:
 
-- Date & Time
-- Markdown
-- HTML
+- [Date & Time](/docs/plugins/fields/date)
+- [Markdown](/docs/plugins/fields/markdown)
+- [HTML](/docs/plugins/fields/html))
 
 ## Field Definition
 

--- a/content/docs/plugins/fields.md
+++ b/content/docs/plugins/fields.md
@@ -34,3 +34,150 @@ interface FieldConfig {
 | `parse`     | _Optional:_ Prepare the data for usage in the field component.                                 |
 | `format`    | _Optional:_ Prepare the data for saving.                                                       |
 | `validate`  | _Optional:_ Return undefined when valid. Return a string or an object when there are errors.   |
+
+## Default Field Plugins
+
+These are the default field plugins available through the CMS:
+
+- [Text](/docs/plugins/fields/text)
+- [Textarea](/docs/plugins/fields/textarea)
+- [Number](/docs/plugins/fields/number)
+- [Image](/docs/plugins/fields/image)
+- [Color](/docs/plugins/fields/color) _May be external soon_
+- [Toggle](/docs/plugins/fields/toggle)
+- [Select](/docs/plugins/fields/select)
+- [Tags](/docs/plugins/fields/tags)
+- [List](/docs/plugins/fields/list)
+- [Group](/docs/plugins/fields/group)
+- [Group List](/docs/plugins/fields/group-list)
+- [Blocks](/docs/plugins/fields/blocks)
+
+## External Field Plugins
+
+These are plugins that must be installed through separate packages:
+
+- Date & Time
+- Markdown
+- HTML
+
+## Field Definition
+
+You can add fields to a form through the `fields` array in the [form configuration](/docs/plugins/forms#form-configuration). The Field definition at minimum needs a `name` and `component`. This is an example of a simple [`text`](/docs/plugins/fields/text) field definition.
+
+**Example form configuration**
+
+```js
+const formOptions = {
+  id: 'lynel-hoofs',
+  label: 'Edit This Page',
+  fields: [
+    {
+      name: 'tagline',
+      component: 'text',
+    },
+  ],
+}
+```
+
+> Refer to individual field plugin docs for additional examples.
+
+### _name_
+
+The `name` property connects the field with the source data by providing the path to that content from the root of the source data.
+
+For example, say we had a JSON object:
+
+```json
+{
+  "headline": "Banana Pancakes"
+}
+```
+
+Our field definition to edit `headline` would be:
+
+```js
+{
+  fields: [
+    {
+      name: 'headline',
+      component: 'text',
+    },
+  ],
+}
+```
+
+If the data structure looked a little different:
+
+```json
+{
+  "hero": {
+    "headline": "Banana Pancakes"
+  }
+}
+```
+
+The `name` property should be updated to reflect the different path:
+
+```js
+{
+  fields: [
+    {
+      name: 'hero.headline',
+      component: 'text',
+    },
+  ],
+}
+```
+
+### _component_
+
+The `component` field property can either be a string or the name of a field plugin, or a React Component.
+
+All of the previous examples show the `component` being set with a string:
+
+```js
+{
+  fields: [
+    {
+      name: 'background_color',
+      component: 'color',
+    },
+  ],
+}
+```
+
+`color` is referring to the `name` of the Color [Field Plugin](/docs/plugins/fields/custom-fields#2-creating-field-plugins) that is hooked up to the CMS by default.
+
+You can also define components inline to render in place of a default field:
+
+**Example**
+
+```js
+const formOptions = {
+  label: 'My Page',
+  fields: [
+    {
+      label: "Athlete's Name",
+      name: 'name',
+      component: 'text',
+    },
+    // The custom inline field
+    {
+      name: '_',
+      component: () => <h4>Best Scores</h4>,
+    },
+    {
+      name: 'scores',
+      component: 'list',
+      field: 'number',
+    },
+  ],
+}
+```
+
+In the example above, the custom inline field component isn't being used to edit data, but rather as a method of customizing the sidebar organization.
+
+## Additional Reading
+
+- Read these blogs on creating custom [field components](/blog/custom-field-components) and [field plugins](/blog/custom-field-plugins)
+- There are also [fields for Inline Editing](/docs/ui/inline-editing#using-pre-configured-inline-fields)

--- a/content/docs/plugins/fields.md
+++ b/content/docs/plugins/fields.md
@@ -58,7 +58,7 @@ These are plugins that must be installed through separate packages:
 
 - [Date & Time](/docs/plugins/fields/date)
 - [Markdown](/docs/plugins/fields/markdown)
-- [HTML](/docs/plugins/fields/html))
+- [HTML](/docs/plugins/fields/html)
 
 ## Field Definition
 

--- a/content/docs/ui/inline-editing.md
+++ b/content/docs/ui/inline-editing.md
@@ -105,7 +105,7 @@ export function Page(props) {
 }
 ```
 
-## Using Psre-configured Inline Fields
+## Using Pre-configured Inline Fields
 
 When using `InlineField`, you can create a custom _Inline Field_. This is helpful when you need precise control over rendering or input functionality.
 

--- a/content/docs/ui/inline-editing.md
+++ b/content/docs/ui/inline-editing.md
@@ -105,7 +105,7 @@ export function Page(props) {
 }
 ```
 
-## Using pre-configured Inline Fields
+## Using Psre-configured Inline Fields
 
 When using `InlineField`, you can create a custom _Inline Field_. This is helpful when you need precise control over rendering or input functionality.
 
@@ -146,7 +146,58 @@ export function Page(props) {
 }
 ```
 
-### Extending Inline Field Styles
+## Creating Custom Inline Fields
+
+There may be cases where you want to create your own Inline Fields. Below is an example of the `Page` component used above, but refactored to define its own custom Inline Fields.
+
+```js
+import * as React from React
+import ReactMarkdown from 'react-markdown'
+// import `useCMS`
+import { useForm, useCMS } from 'tinacms'
+import { Wysiwyg } from 'react-tinacms-editor'
+import { InlineForm, InlineField } from 'react-tinacms-inline'
+
+export function Page(props) {
+  // Access the CMS object
+  const cms = useCMS()
+  const [, form] = useForm(props.data)
+
+  return (
+    <InlineForm form={form}>
+      <main>
+      {/**
+      * Use `InlineField` and the render props
+      * pattern to create custom field inputs
+      * that render when the cms is enabled
+      */}
+        <InlineField name="title">
+          {({ input, status }) => {
+            if (cms.enabled) {
+              return <input type="text" {...input} />
+            }
+            return <h1>{input.value}</h1>
+          }}
+        </InlineField>
+        <InlineField name="markdownContent">
+          {({ input, status }) => {
+            if (cms.enabled) {
+              return <Wysiwyg input={input} />
+            }
+            return <ReactMarkdown source={input.value} />
+          }}
+        </InlineField>
+      </main>
+    </InlineForm>
+  )
+}
+```
+
+`InlineField` uses [render props](https://reactjs.org/docs/render-props.html) to pass the form state and other props to its children. Based on `cms.enabled`, you can conditionally render editing inputs or the original element / value.
+
+> If you have an idea for an Inline Field plugin, consider contributing! [Make an issue](https://github.com/tinacms/tinacms/issues) with your suggestion or reach out on [the forum](https://community.tinacms.org/) for support.
+
+## Extending Inline Field Styles
 
 The Inline Fields are meant to have minimal styles. But there may be situations where you'll want to override the base styles. This is made possible via [Styled Components](https://styled-components.com/docs/basics#extending-styles).
 


### PR DESCRIPTION
- Adds a list of default and external field plugins
- Adds more information on field definitions, the `name` and `component`
- Adds custom inline field example

I wrote these pretty fast. They could use a readthrough.