### PR TITLE
trigger Vercel builder to provide all content to lambdas

### DIFF
--- a/pages/guides/index.tsx
+++ b/pages/guides/index.tsx
@@ -122,6 +122,8 @@ export default GuideTemplate
 export const getStaticProps = async () => {
   // @ts-ignore
   const path = __non_webpack_require__('path')
+  // the following line will cause all content files to be available in a serverless context
+  path.resolve(process.cwd(), './content/')
   return {
     props: {
       slug: '/guides',


### PR DESCRIPTION
This should make the guides index work correctly when in edit mode