### PR TITLE
Blog Template: next / prev posts

### DIFF
--- a/components/ui/BlogPagination.tsx
+++ b/components/ui/BlogPagination.tsx
@@ -24,12 +24,12 @@ export const BlogPagination = styled(
         <PaginationLinks>
           {!isFirst && (
             <DynamicLink href={prevPage} passHref>
-              <a>← Newer</a>
+              <a onClick={() => setSelectValue(selectValue - 1)}>← Newer</a>
             </DynamicLink>
           )}
           {!isLast && (
             <DynamicLink href={nextPage} passHref>
-              <a>Older →</a>
+              <a onClick={() => setSelectValue(selectValue + 1)}>Older →</a>
             </DynamicLink>
           )}
         </PaginationLinks>

--- a/content/blog/add-and-delete-files.md
+++ b/content/blog/add-and-delete-files.md
@@ -12,6 +12,8 @@ consumes:
     details: Shows how to add delete action
   - file: /packages/tinacms/src/components/CreateContent.tsx
     details: Has image of what the create form looks like
+next: /blog/jamstack-denver-talk
+prev: /blog/dynamic-plugin-system
 ---
 
 [Creating](https://tinacms.org/blog/add-and-delete-files/#creating-new-files) and [deleting](https://tinacms.org/blog/add-and-delete-files/#deleting-files) content — two fundamental sides of the CMS coin. This article will cover how to set up this functionality with TinaCMS on a [Gatsby](https://www.gatsbyjs.org/) site. But first, some overview.

--- a/content/blog/announcing-tinacms.md
+++ b/content/blog/announcing-tinacms.md
@@ -3,6 +3,8 @@ title: 'Announcing TinaCMS '
 date: '2019-10-16T07:00:00.000Z'
 author: Scott Gallant
 draft: false
+prev: null
+next: /blog/creating-markdown-drafts
 ---
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/iPDCmbaEF0Y" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/content/blog/creating-markdown-drafts.md
+++ b/content/blog/creating-markdown-drafts.md
@@ -3,6 +3,8 @@ title: Creating Markdown Drafts with Gatsby
 date: '2019-10-28T22:17:53.124Z'
 author: Nolan Phillips & Kendall Strautman
 draft: false
+next: /blog/simple-markdown-blog-nextjs
+prev: /blog/announcing-tinacms
 ---
 
 One of the core features of an editorial workflow is to provide writers & editors a safe space for creating and iterating on content without these in-process posts publishing to production — **draft-mode**.

--- a/content/blog/custom-field-components.md
+++ b/content/blog/custom-field-components.md
@@ -12,6 +12,8 @@ consumes:
     details: Depends on the Field interface
   - file: /packages/@tinacms/form-builder/src/field-plugin.tsx
     details: Depends on the FieldPlugin interface
+next: /blog/custom-field-plugins
+prev: /blog/exporting-wordpress-content-to-gatsby
 ---
 
 Form fields are the bread and butter of any CMS. While Tina provides a solid collection of fields 'out-of-the-box', you can also create your own. This post will show you the basic concepts of how to create custom field components and use them in the Tina sidebar.

--- a/content/blog/custom-field-plugins.md
+++ b/content/blog/custom-field-plugins.md
@@ -10,6 +10,8 @@ consumes:
     details: Example shows useLocalJsonForm in use
   - file: /packages/@tinacms/form-builder/src/field-plugin.tsx
     details: Depends on the FieldPlugin interface
+next: /blog/gatsby-tina-101
+prev: /blog/custom-field-components
 ---
 
 In the [previous post](https://tinacms.org/blog/custom-field-components), we learned how to create a custom field component and register it to the sidebar. With that baseline, let's go full circle on the topic of custom fields in TinaCMS. In this short but sweet post 🧁, we’ll cover how to _turn a field component into a field plugin._

--- a/content/blog/deprecating-tina-git-server.md
+++ b/content/blog/deprecating-tina-git-server.md
@@ -3,6 +3,8 @@ title: Updated Next.js Docs + Deprecating tina-git-server
 date: '2019-12-06T07:00:00.000Z'
 author: DJ Walker
 draft: false
+next: /blog/dynamic-plugin-system
+prev: /blog/using-tinacms-with-nextjs
 ---
 
 We've changed our recommended approach for using Tina's Git Backend with Next.js websites. Check out [Tina's Next.js documentation](/guides/nextjs/git/adding-backend) for details.

--- a/content/blog/designing-an-extensible-styling-system.md
+++ b/content/blog/designing-an-extensible-styling-system.md
@@ -2,6 +2,8 @@
 title: 'Designing an Extensible Styling System'
 date: '2020-03-23T00:00:00.000Z'
 author: Scott Byrne
+next: /blog/screen-plugins
+prev: /blog/tinacms-ui-whats-next
 ---
 
 ## Writing an adaptable UI is hard.

--- a/content/blog/dynamic-plugin-system.md
+++ b/content/blog/dynamic-plugin-system.md
@@ -8,6 +8,8 @@ consumes:
     details: Talks at a high level about the plugin manager
   - file: /packages/gatsby-tinacms-remark/src/remark-creator-plugin.ts
     details: Shows example of RemarkCreatorPlugin in use
+next: /blog/add-and-delete-files
+prev: /blog/deprecating-tina-git-server
 ---
 
 One of the most important aspects of TinaCMS is its dynamic plugin system.

--- a/content/blog/editing-on-the-cloud.md
+++ b/content/blog/editing-on-the-cloud.md
@@ -3,6 +3,8 @@ title: How can my editors edit a TinaCMS site?
 date: '2019-12-23T10:00:00.000Z'
 draft: false
 author: James O'Halloran
+next: /blog/using-tinacms-on-gatsby-cloud
+prev: /blog/what-are-blocks
 ---
 
 TinaCMS allows you to build live-editing functionality directly into your site. Tina differs from other headless CMS's (e.g [Forestry.io](https://Forestry.io), [NetlifyCMS](https://NetlifyCMS.org), [Contentful](https://contentful.com)) which simply allow you to edit your site's content and are relatively detached from your site's code. Having Tina sit in between your content and your site's template gives editors an amazing real-time editing experience where they can navigate to any area of the site, start making changes, and immediately see these changes reflected within the site.

--- a/content/blog/exporting-wordpress-content-to-gatsby.md
+++ b/content/blog/exporting-wordpress-content-to-gatsby.md
@@ -3,6 +3,8 @@ title: Export WordPress Content to Markdown and Gatsby
 date: '2020-01-13T00:00:00.000Z'
 draft: false
 author: Mitch MacKenzie
+next: /blog/custom-field-components
+prev: /blog/three-ways-to-edit-md
 ---
 
 Say hello to the [WordPress to Gatsby Markdown Exporter](https://github.com/tinacms/wp-gatsby-markdown-exporter)! It's a WordPress plugin to export posts, pages, and other content from WordPress to Markdown.

--- a/content/blog/gatsby-tina-101.md
+++ b/content/blog/gatsby-tina-101.md
@@ -10,6 +10,8 @@ consumes:
     details: Shows how to use inlineRemarkForm HOC
   - file: /packages/@tinacms/fields/src/Wysiwyg/Wysiwyg.tsx
     details: TinaField uses Wysiwyg component for inline editing
+next: /blog/introducing-visual-open-authoring
+prev: /blog/custom-field-plugins
 ---
 
 Static site generators like [Gatsby](https://www.gatsbyjs.org/) are a massive win for developers. They provide us with automated deployments, faster development cycles, and reduced security burden.

--- a/content/blog/inline-editing-project.md
+++ b/content/blog/inline-editing-project.md
@@ -2,8 +2,8 @@
 title: Inline Editing Revamped
 date: '2020-06-29T11:28:19-03:00'
 author: Kendall Strautman
-prev: null
-next: /blog/upgrade-notice-improved-github-security
+next: null
+prev: /blog/upgrade-notice-improved-github-security
 ---
 
 6 weeks ago, we embarked on a dedicated project with the goal of improving [Inline Editing](https://tinacms.org/docs/ui/inline-editing). We believe that **this way of creating content is the future**, and we want to be a driver in actualizing that future.

--- a/content/blog/inline-editing-project.md
+++ b/content/blog/inline-editing-project.md
@@ -2,6 +2,8 @@
 title: Inline Editing Revamped
 date: '2020-06-29T11:28:19-03:00'
 author: Kendall Strautman
+prev: null
+next: /blog/upgrade-notice-improved-github-security
 ---
 
 6 weeks ago, we embarked on a dedicated project with the goal of improving [Inline Editing](https://tinacms.org/docs/ui/inline-editing). We believe that **this way of creating content is the future**, and we want to be a driver in actualizing that future.

--- a/content/blog/introducing-tina-grande.md
+++ b/content/blog/introducing-tina-grande.md
@@ -3,6 +3,8 @@ title: "Introducing Tina Grande \U0001F389"
 date: '2019-11-21T14:58:24.451Z'
 draft: false
 author: Scott Byrne
+next: /blog/using-tinacms-with-nextjs
+prev: /blog/simple-markdown-blog-nextjs
 ---
 
 [Tina Grande](https://github.com/tinacms/tina-starter-grande 'Tina Grande Repo') is a Gatsby starter with built-in TinaCMS integration. _Grande_ was built to provide a reference implementation of Tina that covers a variety of use cases. Even for those that don’t need a starter, we hope that Grande will prove to be a useful reference for both designers and developers looking to use TinaCMS.

--- a/content/blog/introducing-visual-open-authoring.md
+++ b/content/blog/introducing-visual-open-authoring.md
@@ -4,6 +4,8 @@ date: '2020-03-09T07:00:00.000Z'
 author: Scott Gallant
 draft: false
 consumes: null
+next: /blog/tinacms-ui-whats-next
+prev: /blog/gatsby-tina-101
 ---
 
 We're focused on improving the independent web as a whole. We want to craft tools that help people build better sites and create better content.

--- a/content/blog/jamstack-denver-talk.md
+++ b/content/blog/jamstack-denver-talk.md
@@ -3,6 +3,8 @@ title: JAMstack Denver Talks Tina
 date: '2019-12-17T07:00:00.000Z'
 author: Kendall Strautman
 draft: false
+next: /blog/what-are-blocks
+prev: /blog/add-and-delete-files
 ---
 
 <iframe width="620" height="348" src="https://www.youtube.com/embed/LhBH9RTEK78?start=234" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/content/blog/screen-plugins.md
+++ b/content/blog/screen-plugins.md
@@ -6,6 +6,8 @@ draft: false
 consumes:
   - file: /packages/tinacms/src/plugins/screen-plugin.ts
     details: Explains the screen plugin interface properties
+next: /blog/software-engineering-daily-podcast-tinacms
+prev: /blog/designing-an-extensible-styling-system
 ---
 
 Plugins are a powerful concept. In general plugins are used to extend core functionality of a base system. While many plugin systems are static, TinaCMS is powered by a [dynamic plugin system](https://tinacms.org/blog/dynamic-plugin-system/). In this approach, plugins are added and removed programmatically. This dynamism allows developers to add and remove CMS features based on the context.

--- a/content/blog/simple-markdown-blog-nextjs.md
+++ b/content/blog/simple-markdown-blog-nextjs.md
@@ -3,6 +3,8 @@ title: Creating a Markdown Blog with Next.js
 date: '2019-11-16T07:00:00.000Z'
 author: Kendall Strautman
 draft: false
+next: /blog/introducing-tina-grande
+prev: /blog/creating-markdown-drafts
 ---
 
 ## Tina + Next Part I

--- a/content/blog/software-engineering-daily-podcast-tinacms.md
+++ b/content/blog/software-engineering-daily-podcast-tinacms.md
@@ -3,6 +3,8 @@ title: Software Engineering Daily Talks TinaCMS
 date: '2020-04-30T07:00:00.000Z'
 author: Kendall Strautman
 draft: false
+prev: /blog/screen-plugins
+next: /blog/upgrade-notice-improved-github-security
 ---
 
 Recently, our founders, Scott Gallant and Jordan Patterson, along with Lead Tina Developer, Nolan Phillips, sat down with the folks from the [Software Engineering Daily Podcast](https://softwareengineeringdaily.com/) to talk about the CMS space.

--- a/content/blog/three-ways-to-edit-md.md
+++ b/content/blog/three-ways-to-edit-md.md
@@ -10,6 +10,8 @@ consumes:
     details: Shows how to use remarkForm HOC
   - file: /packages/gatsby-tinacms-remark/src/useRemarkForm.tsx
     details: Demonstrates useLocalRemarkForm usage
+next: /blog/exporting-wordpress-content-to-gatsby
+prev: /blog/using-tinacms-on-gatsby-cloud
 ---
 
 **Supercharge your static site with real-time content editing!** 🚀

--- a/content/blog/tinacms-ui-whats-next.md
+++ b/content/blog/tinacms-ui-whats-next.md
@@ -2,6 +2,8 @@
 title: "TinaCMS UI: What's next?"
 date: '2020-03-13T00:00:00.000Z'
 author: Nolan Phillips
+next: /blog/designing-an-extensible-styling-system
+prev: /blog/introducing-visual-open-authoring
 ---
 
 This week we deployed [Visual Open Authoring](https://tinacms.org/blog/introducing-visual-open-authoring 'Introducing Visual Open Authoring') on the TinaCMS website to make the editing experience for ourselves and all the community members totally amazing!

--- a/content/blog/upgrade-notice-improved-github-security.md
+++ b/content/blog/upgrade-notice-improved-github-security.md
@@ -3,8 +3,8 @@ title: 'Upgrade Notice: Improved GitHub Security'
 date: '2020-06-23T13:47:03-03:00'
 author: Joel Huggett
 last_edited: 'July 30, 2020'
-prev: /blog/inline-editing-project
-next: /blog/software-engineering-daily-podcast-tinacms
+next: /blog/inline-editing-project
+prev: /blog/software-engineering-daily-podcast-tinacms
 ---
 
 We've improved the overall security of our GitHub authentication. Below is an explanation of the changes and further down are the steps required to upgrade to the new authentication flow.

--- a/content/blog/upgrade-notice-improved-github-security.md
+++ b/content/blog/upgrade-notice-improved-github-security.md
@@ -3,7 +3,10 @@ title: 'Upgrade Notice: Improved GitHub Security'
 date: '2020-06-23T13:47:03-03:00'
 author: Joel Huggett
 last_edited: 'July 30, 2020'
+prev: /blog/inline-editing-project
+next: /blog/software-engineering-daily-podcast-tinacms
 ---
+
 We've improved the overall security of our GitHub authentication. Below is an explanation of the changes and further down are the steps required to upgrade to the new authentication flow.
 
 TinaCMS communicates with GitHub using a proxy, so the authentication token provided by GitHub is stored as an httpOnly cookie. This stops the client from accessing the token, and that's all very good. However, this strategy is still vulnerable to [Cross-Site Request Forgery (CSRF)](https://owasp.org/www-community/attacks/csrf) attacks. This means that any calls to the proxy, so long as that cookie is still there, will succeed, and that's not very good.
@@ -30,7 +33,7 @@ You can generate a key by running `openssl rand -base64 32` in your terminal, us
 
 The key should be stored in an environment variable; don't forget to add it to your hosted environment configurations.
 
-`createAuthHandler`, `apiProxy`, and `previewHandler` now  **require** the _Signing Key_ to be passed as a parameter.
+`createAuthHandler`, `apiProxy`, and `previewHandler` now **require** the _Signing Key_ to be passed as a parameter.
 
 ### **Required Changes:**
 

--- a/content/blog/using-tinacms-on-gatsby-cloud.md
+++ b/content/blog/using-tinacms-on-gatsby-cloud.md
@@ -8,6 +8,8 @@ consumes:
     details: Explains configuring git-specific environment variables to manually set author and ssh-key
   - file: /packages/@tinacms/gatsby-tinacms-git/index.ts
     details: Explains configuring git-specific environment variables to manually set author and ssh-key
+next: /blog/three-ways-to-edit-md
+prev: /blog/editing-on-the-cloud
 ---
 
 We've [recently written](/blog/editing-on-the-cloud/ 'TinaCMS on the cloud') about how TinaCMS will work on the cloud. Gatsby Cloud offers a great way for editors to edit TinaCMS sites, without having to run a local development environment.
@@ -22,9 +24,7 @@ Deploying a preview with Gatsby Cloud can be done in just a few clicks. Once we'
 
 And tada! ✨ Our site's preview should be live! Any commits we make to the repo going forward will automatically trigger a rebuild of our Gatsby preview.
 
->
-Note: This preview will act as our "Cloud Editing Environment" and not our production site. Your production site should be built and deployed separately.
-
+> Note: This preview will act as our "Cloud Editing Environment" and not our production site. Your production site should be built and deployed separately.
 
 Now that our **preview is live**, there's some extra configuration that we'll want to do to have Tina work smoothly on the cloud.
 
@@ -34,9 +34,7 @@ We don't want just any stranger making commits from our cloud editing environmen
 
 ## Configuring Git for Cloud Commits ✔️
 
->
-If you are using the gatsby-tinacms-git plugin, make sure to use version: 0.2.16-canary.0 or later!
-
+> If you are using the gatsby-tinacms-git plugin, make sure to use version: 0.2.16-canary.0 or later!
 
 To set up for canary, run `yarn add gatsby-tinacms-git@canary` until this version reaches a full release.
 
@@ -56,7 +54,7 @@ If you want the author to be based off of the logged-in user instead of a static
 
 ### `TINA_CEE`
 
-This needs to be set to ensure that Tina knows that it is being run in a *Cloud Editing Environment*. Set it to `true`.
+This needs to be set to ensure that Tina knows that it is being run in a _Cloud Editing Environment_. Set it to `true`.
 
 ### `SSH_KEY` 🔑
 
@@ -117,9 +115,7 @@ plugins: [
 
 Now after you trigger a rebuild, it should be able to commit to your repository!
 
->
-Note that Base64 encoding the key DOES NOT make it safe to make public!! **Do not commit this value to your repository.** We are Base64 encoding the key only to avoid formatting issues when using it as an environment variable.
-
+> Note that Base64 encoding the key DOES NOT make it safe to make public!! **Do not commit this value to your repository.** We are Base64 encoding the key only to avoid formatting issues when using it as an environment variable.
 
 ## Site Configuration 🔨
 

--- a/content/blog/using-tinacms-with-nextjs.md
+++ b/content/blog/using-tinacms-with-nextjs.md
@@ -20,6 +20,8 @@ consumes:
     details: Demonstrates usage of useWatchFormValues
   - file: /packages/react-tinacms/src/index.ts
     details: Imports useLocalForm and useWatchFormValues from react-tinacms metapackage
+next: /blog/deprecating-tina-git-server
+prev: /blog/introducing-tina-grande
 ---
 
 ## Tina + Next: Part II

--- a/content/blog/what-are-blocks.md
+++ b/content/blog/what-are-blocks.md
@@ -3,6 +3,8 @@ title: What are Blocks?
 date: '2019-12-18T03:15:26.426Z'
 draft: false
 author: DJ Walker
+next: /blog/editing-on-the-cloud
+prev: /blog/jamstack-denver-talk
 ---
 
 > "There are only two hard things in Computer Science: cache invalidation and naming things."

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -21,11 +21,10 @@ import Error from 'next/error'
 import { getMarkdownPreviewProps } from 'utils/getMarkdownFile'
 import { InlineWysiwyg } from 'components/inline-wysiwyg'
 import { usePlugin, useCMS } from 'tinacms'
-import { useEffect } from 'react'
 import { useLastEdited } from 'utils/useLastEdited'
 import { LastEdited, DocsPagination } from 'components/ui'
 
-function BlogTemplate({ file, siteConfig, preview, prevPage, nextPage }) {
+function BlogTemplate({ file, siteConfig, prevPage, nextPage }) {
   // fallback workaround
   if (!file) {
     return <Error statusCode={404} />


### PR DESCRIPTION
Pretty much just copied the implementation from the docs template. 

~~If we are okay with this manual approach, I can go through the old blogs and fill in the correct `next` / `prev` frontmatter values. Wanted to get feedback before I went and updated all those. To check this out, it works on the **two most recent blogs**.~~

Updated all fm values.