### PR TITLE
Fix typo in table of contents on gatsby guides

### DIFF
--- a/content/guides/gatsby/adding-tina/next-steps.md
+++ b/content/guides/gatsby/adding-tina/next-steps.md
@@ -11,7 +11,7 @@ This guide is intended as a jumping off point to get you started with Tina, but 
 
 ## Set up a backend to persist content changes
 
-Checkout the [Using a Git Backend](/guides/gatsby/git) guide to learn more.
+Checkout the [Using a Git Backend](/guides/gatsby/git/installation) guide to learn more.
 
 ## Add More Fields
 

--- a/content/guides/gatsby/adding-tina/project-setup.md
+++ b/content/guides/gatsby/adding-tina/project-setup.md
@@ -8,7 +8,7 @@ The purpose of this is to get you familiar with the rudimentary steps of setting
 
 ---
 
-#### Prerequisites
+## Prerequisites
 
 To run all the tools required you need at least the following installed:
 


### PR DESCRIPTION
Hey!

I was going through the **Adding Tina to a Gatsby Site** and found this typo on *Table of Contents* section.

_A snap from [https://tinacms.org/guides/gatsby/adding-tina/project-setup](https://tinacms.org/guides/gatsby/adding-tina/project-setup)_

![](https://i.imgur.com/Z0Pt5fm.png)


**This was just due to a couple extra (`##`) in the markdown file. This is fixed in this PR.**

_A view from my local setup (after the fix)_ 


![](https://i.imgur.com/pW1iIP6.png)

Thanks for your amazing work, folks! 💙
