### PR TITLE
if a codeblock's tags contain "copy" then a copy button will be rendered

### DIFF
--- a/components/layout/MarkdownContent.tsx
+++ b/components/layout/MarkdownContent.tsx
@@ -26,14 +26,11 @@ function WithCodeStyles({ language: tags = '', value }) {
       <SyntaxHighlighter language={language} style={CodeStyle}>
         {value}
       </SyntaxHighlighter>
-      {copy ? (
-        <CopyCodeButton onClick={() => copyToClipboard(value)}>
-          Copy
-        </CopyCodeButton>
-      ) : null}
+      {copy ? <CopyCodeButton value={value} /> : null}
     </>
   )
 }
+
 const copyToClipboard = (text: string) => {
   const el = document.createElement('textarea')
   el.value = text
@@ -42,7 +39,18 @@ const copyToClipboard = (text: string) => {
   document.execCommand('copy')
   document.body.removeChild(el)
 }
-const CopyCodeButton = styled.button``
+
+interface copyButtonProps {
+  value?: string
+}
+
+const CopyCodeButton = ({ value }: copyButtonProps) => {
+  const clickEvent = () => {
+    copyToClipboard(value)
+  }
+
+  return <button onClick={clickEvent}>Copy</button>
+}
 
 function WithHeadings({ children, level }) {
   const HeadingTag = `h${level}` as any

--- a/components/layout/MarkdownContent.tsx
+++ b/components/layout/MarkdownContent.tsx
@@ -17,9 +17,10 @@ interface MarkdownContentProps {
   skipHtml?: boolean
 }
 
-function WithCodeStyles({ language: tags, value }) {
+function WithCodeStyles({ language: tags = '', value }) {
   const [language, ...other] = tags.split(',')
   const copy = other.includes('copy') || language === 'copy'
+  console.log(value)
   return (
     <>
       <SyntaxHighlighter language={language} style={CodeStyle}>

--- a/components/layout/MarkdownContent.tsx
+++ b/components/layout/MarkdownContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import ReactMarkdown from 'react-markdown/with-html'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import CodeStyle from '../styles/Code'
@@ -17,13 +17,31 @@ interface MarkdownContentProps {
   skipHtml?: boolean
 }
 
-function WithCodeStyles({ language, value }) {
+function WithCodeStyles({ language: tags, value }) {
+  const [language, ...other] = tags.split(',')
+  const copy = other.includes('copy')
   return (
-    <SyntaxHighlighter language={language} style={CodeStyle}>
-      {value}
-    </SyntaxHighlighter>
+    <>
+      <SyntaxHighlighter language={language} style={CodeStyle}>
+        {value}
+      </SyntaxHighlighter>
+      {copy ? (
+        <CopyCodeButton onClick={() => copyToClipboard(value)}>
+          Copy
+        </CopyCodeButton>
+      ) : null}
+    </>
   )
 }
+const copyToClipboard = (text: string) => {
+  const el = document.createElement('textarea')
+  el.value = text
+  document.body.appendChild(el)
+  el.select()
+  document.execCommand('copy')
+  document.body.removeChild(el)
+}
+const CopyCodeButton = styled.button``
 
 function WithHeadings({ children, level }) {
   const HeadingTag = `h${level}` as any

--- a/components/layout/MarkdownContent.tsx
+++ b/components/layout/MarkdownContent.tsx
@@ -19,7 +19,7 @@ interface MarkdownContentProps {
 
 function WithCodeStyles({ language: tags, value }) {
   const [language, ...other] = tags.split(',')
-  const copy = other.includes('copy')
+  const copy = other.includes('copy') || language === 'copy'
   return (
     <>
       <SyntaxHighlighter language={language} style={CodeStyle}>

--- a/components/layout/MarkdownContent.tsx
+++ b/components/layout/MarkdownContent.tsx
@@ -22,12 +22,12 @@ function WithCodeStyles({ language: tags = '', value }) {
   const copy = other.includes('copy') || language === 'copy'
   console.log(value)
   return (
-    <>
+    <CodeWrapper>
       <SyntaxHighlighter language={language} style={CodeStyle}>
         {value}
       </SyntaxHighlighter>
       {copy ? <CopyCodeButton value={value} /> : null}
-    </>
+    </CodeWrapper>
   )
 }
 
@@ -45,12 +45,47 @@ interface copyButtonProps {
 }
 
 const CopyCodeButton = ({ value }: copyButtonProps) => {
+  const [copied, setCopied] = React.useState(false)
+
   const clickEvent = () => {
+    setCopied(true)
     copyToClipboard(value)
+    setTimeout(() => {
+      setCopied(false)
+    }, 2000)
   }
 
-  return <button onClick={clickEvent}>Copy</button>
+  return (
+    <StyledCopyCodeButton onClick={clickEvent}>
+      {!copied ? 'Copy' : 'Copied!'}
+    </StyledCopyCodeButton>
+  )
 }
+
+const StyledCopyCodeButton = styled.button`
+  position: absolute;
+  right: 0;
+  top: 0;
+  cursor: pointer;
+  border: 1px solid var(--tina-color-grey-3);
+  opacity: 0.6;
+  background: rgba(0, 0, 0, 0.03);
+  color: var(--tina-color-grey-7);
+  border-right-width: 0;
+  transition: all 150ms ease-out;
+  border-top-width: 0;
+  font-size: var(--tina-font-size-1);
+  border-radius: 0 0 0 5px;
+
+  &:hover {
+    color: var(--color-primary);
+    opacity: 1;
+  }
+`
+
+const CodeWrapper = styled.div`
+  position: relative;
+`
 
 function WithHeadings({ children, level }) {
   const HeadingTag = `h${level}` as any

--- a/content/docs/getting-started/cms-set-up.md
+++ b/content/docs/getting-started/cms-set-up.md
@@ -10,7 +10,7 @@ In this step we will install `tinacms`, create a CMS instance, wrap our app in t
 
 Install the `tinacms` package. This is the main package that you will use to create your CMS. You'll also need to install `styled-components` to render the editing UI properly.
 
-```bash
+```bash,copy
 yarn add tinacms styled-components
 ```
 
@@ -62,7 +62,7 @@ Update your CMS instance with the `sidebar` option:
 
 **src/App.js**
 
-```js
+```js,copy
 function App() {
   const cms = new TinaCMS({
     sidebar: true,


### PR DESCRIPTION
If a fenced code-block has the "copy" tag then it will be copyable. It is this way becase not all code-blocks should be copy-able.

## Todo
- [x] needs styling @spbyrne 

## Examples

Non-copyable JS

    ```js
    const christmastPresent = new Banana()
    ```

Copyable JS

    ```js,copy
    const christmastPresent = new Banana()
    ```

Copyable Text

    ```copy
    Hello World
    ```

<img width="716" alt="image" src="https://user-images.githubusercontent.com/824015/89543002-c5d0f380-d7d6-11ea-9de5-c156e240717b.png">
