### PR TITLE
Next.js guide: Add `enabled` and `sidebar` options to `withTina` 

### DIFF
--- a/content/guides/nextjs/adding-tina/adding-tina-provider.md
+++ b/content/guides/nextjs/adding-tina/adding-tina-provider.md
@@ -1,8 +1,8 @@
 ---
 title: Adding the Tina Provider
+last_edited: '2020-08-11T13:02:36.046Z'
 ---
-
-We need to wrap every page in the `<TinaProvider>` component. This component will provide the CMS to all of our pages, allowing us to create an editor for our content. We can do this in Next.js by [creating a custom _App_ component](https://nextjs.org/docs#custom-app). Next will then use our custom app component to render the page.
+We need to wrap every page in the `<TinaProvider>` component. This component will provide the CMS to all of our pages, allowing us to create an editor for our content. We can do this in Next.js by [creating a custom ](https://nextjs.org/docs#custom-app)_[App](https://nextjs.org/docs#custom-app)_[ component](https://nextjs.org/docs#custom-app). Next will then use our custom app component to render the page.
 
 Our blog starter already has this file created. Open up `pages/_app.js` and you should see something like this:
 
@@ -24,7 +24,7 @@ yarn add tinacms styled-components
 
 ## Adding the Provider
 
-Wrapping the main App component in the `withTina` higher-order component will automatically instantiate the CMS and set up the provider.
+Wrapping the main App component in the `withTina` higher-order component will automatically instantiate the CMS and set up the provider. We also need to pass `enabled` and `sidebar` options to enable CMS editing and sidebar for editing the page.
 
 ```javascript
 import '../styles/index.css'
@@ -34,12 +34,15 @@ function MyApp({ Component, pageProps }) {
   return <Component {...pageProps} />
 }
 
-export default withTina(MyApp)
+export default withTina(MyApp, {
+  enabled: process.env.NODE_ENV !== 'production',
+  sidebar: true,
+})
 ```
 
-> You can configure the CMS by passing a second argument into `withTina`. Refer to [setting up the CMS object](/docs/cms#setting-up-the-cms-object) for details.
+> The second argument of `withTina` configures the CMS. Refer to [setting up the CMS object](/docs/cms#setting-up-the-cms-object) for details.
 
 ## More Info
 
-- [NextJS.org: Custom App Component](https://nextjs.org/docs/advanced-features/custom-app)
-- [Tina Docs: Setting up the CMS Object](/docs/cms#setting-up-the-cms-object)
+* [NextJS.org: Custom App Component](https://nextjs.org/docs/advanced-features/custom-app)
+* [Tina Docs: Setting up the CMS Object](/docs/cms#setting-up-the-cms-object)

--- a/content/guides/nextjs/adding-tina/adding-tina-provider.md
+++ b/content/guides/nextjs/adding-tina/adding-tina-provider.md
@@ -2,7 +2,7 @@
 title: Adding the Tina Provider
 last_edited: '2020-08-11T13:02:36.046Z'
 ---
-We need to wrap every page in the `<TinaProvider>` component. This component will provide the CMS to all of our pages, allowing us to create an editor for our content. We can do this in Next.js by [creating a custom ](https://nextjs.org/docs#custom-app)_[App](https://nextjs.org/docs#custom-app)_[ component](https://nextjs.org/docs#custom-app). Next will then use our custom app component to render the page.
+We need to wrap every page in the `<TinaProvider>` component. This component will provide the CMS to all of our pages, allowing us to create an editor for our content. We can do this in Next.js by [creating a custom _App_ component](https://nextjs.org/docs#custom-app). Next will then use our custom app component to render the page.
 
 Our blog starter already has this file created. Open up `pages/_app.js` and you should see something like this:
 

--- a/content/guides/nextjs/adding-tina/adding-tina-provider.md
+++ b/content/guides/nextjs/adding-tina/adding-tina-provider.md
@@ -35,7 +35,7 @@ function MyApp({ Component, pageProps }) {
 }
 
 export default withTina(MyApp, {
-  enabled: process.env.NODE_ENV !== 'production',
+  enabled: true,
   sidebar: true,
 })
 ```


### PR DESCRIPTION
Hi, I am working through your Next.js guide. While it is very well done, I was quite confused that at the end I don't see any sidebar. Digging further I figured I need to pass a few options to `withTina`, so this is my attempt to fix the documentation.

Note that the guide is still outdated, after I open the sidebar I get a message about Markdown Field deprecation:
![](https://user-images.githubusercontent.com/616767/89900840-8cd4bc80-dbe4-11ea-8229-eeca67d7e4c2.png)