### PR TITLE
Nav Scroll

### DIFF
--- a/components/DocumentationNavigation/DocsNavigationList.tsx
+++ b/components/DocumentationNavigation/DocsNavigationList.tsx
@@ -8,7 +8,7 @@ import { NavSection } from './NavSection'
 export const NavListContext = createContext({ current: null })
 
 export const DocsNavigationList = ({ navItems, guide }: DocsNavProps) => {
-  const navListRef = useRef<HTMLDivElement>(null)
+  const navListRef = useRef<HTMLUListElement>(null)
 
   return (
     <NavListContext.Provider value={navListRef}>

--- a/components/DocumentationNavigation/DocsNavigationList.tsx
+++ b/components/DocumentationNavigation/DocsNavigationList.tsx
@@ -1,36 +1,42 @@
+import { useRef, createContext } from 'react'
 import styled from 'styled-components'
 import Link from 'next/link'
-
 import { DocsLinkNav } from '../ui/DocsLinkNav'
 import { DocsNavProps } from './DocumentationNavigation'
 import { NavSection } from './NavSection'
 
+export const NavListContext = createContext({ current: null })
+
 export const DocsNavigationList = ({ navItems, guide }: DocsNavProps) => {
+  const navListRef = useRef<HTMLDivElement>(null)
+
   return (
-    <ul>
-      <MobileMainNav>
-        <DocsLinkNav />
-      </MobileMainNav>
-      {guide && (
-        <Breadcrumbs>
-          <Link href="/guides">guides</Link>
-          <Link href={`/guides#${guide.category}`}>{guide.category}</Link>
-        </Breadcrumbs>
-      )}
-      {navItems &&
-        navItems.map(section => (
-          <NavSection key={section.id} {...section} collapsible={false} />
-        ))}
-      <li>
-        <iframe
-          src="https://ghbtns.com/github-btn.html?user=tinacms&repo=tinacms&type=star&count=true&size=large"
-          frameBorder="0"
-          scrolling="0"
-          width="150px"
-          height="30px"
-        ></iframe>
-      </li>
-    </ul>
+    <NavListContext.Provider value={navListRef}>
+      <ul ref={navListRef}>
+        <MobileMainNav>
+          <DocsLinkNav />
+        </MobileMainNav>
+        {guide && (
+          <Breadcrumbs>
+            <Link href="/guides">guides</Link>
+            <Link href={`/guides#${guide.category}`}>{guide.category}</Link>
+          </Breadcrumbs>
+        )}
+        {navItems &&
+          navItems.map(section => (
+            <NavSection key={section.id} {...section} collapsible={false} />
+          ))}
+        <li>
+          <iframe
+            src="https://ghbtns.com/github-btn.html?user=tinacms&repo=tinacms&type=star&count=true&size=large"
+            frameBorder="0"
+            scrolling="0"
+            width="150px"
+            height="30px"
+          ></iframe>
+        </li>
+      </ul>
+    </NavListContext.Provider>
   )
 }
 

--- a/components/DocumentationNavigation/DocumentationNavigation.tsx
+++ b/components/DocumentationNavigation/DocumentationNavigation.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, createContext } from 'react'
+import { useState } from 'react'
 import { Overlay } from '../ui/Overlay'
 import { DocsLeftSidebar } from './DocsLeftSidebar'
 import { DocsNavigationList } from './DocsNavigationList'
@@ -21,21 +21,18 @@ export interface DocsNavProps {
   guide: false | { category: string }
 }
 
-export const NavContext = createContext({ current: null })
-
 export function DocumentationNavigation({ navItems, guide }: DocsNavProps) {
   const [mobileNavIsOpen, setMobileNavIsOpen] = useState(false)
-  const navRef = useRef<HTMLDivElement>(null)
   const router = useRouter()
 
   return (
-    <NavContext.Provider value={navRef}>
+    <>
       <MobileNavToggle
         open={mobileNavIsOpen}
         onClick={() => setMobileNavIsOpen(!mobileNavIsOpen)}
       />
       <MobileNavLogo />
-      <DocsLeftSidebar open={mobileNavIsOpen} ref={navRef}>
+      <DocsLeftSidebar open={mobileNavIsOpen}>
         <DocsSidebarHeader>
           <DocsDesktopTinaIcon docs />
           <Search collapse expanded={true} indices={searchIndices} />
@@ -51,7 +48,7 @@ export function DocumentationNavigation({ navItems, guide }: DocsNavProps) {
         onClick={() => setMobileNavIsOpen(false)}
       />
       <DocsHeaderNav color={'light'} open={mobileNavIsOpen} />
-    </NavContext.Provider>
+    </>
   )
 }
 

--- a/components/DocumentationNavigation/NavSection.tsx
+++ b/components/DocumentationNavigation/NavSection.tsx
@@ -1,8 +1,7 @@
 import { useContext, useState, useMemo, useEffect, useRef } from 'react'
 import { useRouter } from 'next/router'
 import styled, { css } from 'styled-components'
-import { NavContext } from 'components/DocumentationNavigation'
-
+import { NavListContext } from './DocsNavigationList'
 import RightArrowSvg from '../../public/svg/right-arrow.svg'
 import { DynamicLink } from '../ui/DynamicLink'
 import Link from 'next/link'
@@ -90,27 +89,29 @@ export const NavSection = (section: NavSectionProps) => {
 }
 
 const NavLink = ({ section, currentPage, router }) => {
-  const guidesTitleRef = useRef<HTMLElement>(null)
-  const sidebarNav = useContext(NavContext)
+  const linkTitleRef = useRef<HTMLElement>(null)
+  const sidebarNav = useContext(NavListContext)
 
   function scrollToGuides() {
-    if (router.pathname !== '/guides' || !guidesTitleRef.current) return
+    if (!currentPage || !sidebarNav.current || !linkTitleRef.current) return
 
-    const distanceFromTop = guidesTitleRef.current.getBoundingClientRect().y
+    const sidebarNavRect = sidebarNav.current.getBoundingClientRect()
+    const linkTitleRect = linkTitleRef.current.getBoundingClientRect()
 
-    return sidebarNav.current?.scrollTo(0, distanceFromTop)
+    const distanceFromTop = linkTitleRect.y - sidebarNavRect.y
+    const sidebarNavHeight = sidebarNavRect.height
+
+    if (distanceFromTop < sidebarNavHeight * 0.8) return
+
+    return sidebarNav.current.scrollTo(0, distanceFromTop)
   }
 
-  useEffect(scrollToGuides, [])
+  useEffect(scrollToGuides, [linkTitleRef.current, sidebarNav.current])
 
   if (section.slug) {
     return (
       <DynamicLink href={section.slug} passHref>
-        <NavSectionTitle
-          as="a"
-          currentPage={currentPage}
-          ref={section.slug === '/guides' && guidesTitleRef}
-        >
+        <NavSectionTitle as="a" currentPage={currentPage} ref={linkTitleRef}>
           {section.title}
         </NavSectionTitle>
       </DynamicLink>

--- a/components/DocumentationNavigation/NavSection.tsx
+++ b/components/DocumentationNavigation/NavSection.tsx
@@ -92,7 +92,7 @@ const NavLink = ({ section, currentPage, router }) => {
   const linkTitleRef = useRef<HTMLElement>(null)
   const sidebarNav = useContext(NavListContext)
 
-  function scrollToGuides() {
+  function scrollToCurrentLink() {
     if (!currentPage || !sidebarNav.current || !linkTitleRef.current) return
 
     const sidebarNavRect = sidebarNav.current.getBoundingClientRect()
@@ -110,7 +110,7 @@ const NavLink = ({ section, currentPage, router }) => {
     })
   }
 
-  useEffect(scrollToGuides, [linkTitleRef.current, sidebarNav.current])
+  useEffect(scrollToCurrentLink, [linkTitleRef.current, sidebarNav.current])
 
   if (section.slug) {
     return (

--- a/components/DocumentationNavigation/NavSection.tsx
+++ b/components/DocumentationNavigation/NavSection.tsx
@@ -101,9 +101,13 @@ const NavLink = ({ section, currentPage, router }) => {
     const distanceFromTop = linkTitleRect.y - sidebarNavRect.y
     const sidebarNavHeight = sidebarNavRect.height
 
-    if (distanceFromTop < sidebarNavHeight * 0.8) return
+    if (distanceFromTop < sidebarNavHeight * 0.5) return
 
-    return sidebarNav.current.scrollTo(0, distanceFromTop)
+    return sidebarNav.current.scrollTo({
+      top: distanceFromTop - 48,
+      left: 0,
+      behavior: 'auto',
+    })
   }
 
   useEffect(scrollToGuides, [linkTitleRef.current, sidebarNav.current])


### PR DESCRIPTION
This takes the logic @kendallstrautman wrote for auto scrolling to the guides nav section and applies it to all nav items. If a nav link appears more than half way down the nav, the nav will load scrolled to that location when the user is on that page.

<img width="777" alt="Screen Shot 2020-08-11 at 2 09 43 PM" src="https://user-images.githubusercontent.com/5075484/89927179-4f6c3100-dbdc-11ea-86ca-f88f4263780b.png">
