### PR TITLE
update package search index when package pages are updated

### DIFF
--- a/components/DocumentationNavigation/DocumentationNavigation.tsx
+++ b/components/DocumentationNavigation/DocumentationNavigation.tsx
@@ -10,11 +10,7 @@ import { useRouter } from 'next/router'
 import { FallbackPlaceholder } from 'components/fallback-placeholder'
 import Search from '../search'
 import { HitsWrapper } from 'components/search/styles'
-
-const searchIndices = [
-  { name: `Tina-Docs-Next`, title: `Docs`, hitComp: `DocHit` },
-  { name: `Tina-Blogs-Next`, title: `Blog`, hitComp: `BlogHit` },
-]
+import { searchIndices } from 'components/search/indices'
 
 export interface DocsNavProps {
   navItems: any

--- a/components/search/hitComps.tsx
+++ b/components/search/hitComps.tsx
@@ -62,8 +62,24 @@ const BlogHit = (clickHandler: any) => ({ hit }: { hit: Hit }) => {
   )
 }
 
+const PackageHit = (clickHandler: any) => ({ hit }: { hit: Hit }) => {
+  return (
+    <DynamicLink href={path.join('/packages', `/${hit.package}`)}>
+      <div onClick={clickHandler}>
+        <h4>
+          <Highlight attribute="package" hit={hit} tagName="mark" />
+        </h4>
+        {hit['_highlightResult'].excerpt.matchLevel !== 'none' && (
+          <Highlight attribute="excerpt" hit={hit} tagName="mark" />
+        )}
+      </div>
+    </DynamicLink>
+  )
+}
+
 export const hitComponents = {
   ['DocHit']: DocHit,
   ['GuideHit']: GuideHit,
   ['BlogHit']: BlogHit,
+  ['PackageHit']: PackageHit,
 }

--- a/components/search/indices.tsx
+++ b/components/search/indices.tsx
@@ -2,4 +2,5 @@ export const searchIndices = [
   { name: `Tina-Docs-Next`, title: `Docs`, hitComp: `DocHit` },
   { name: `Tina-Guides-Next`, title: `Guides`, hitComp: `GuideHit` },
   { name: `Tina-Blogs-Next`, title: `Blog`, hitComp: `BlogHit` },
+  { name: `Tina-Package-Docs`, title: `Packages`, hitComp: `PackageHit` },
 ]

--- a/utils/docs/getPackageProps.ts
+++ b/utils/docs/getPackageProps.ts
@@ -127,6 +127,7 @@ const updateSearchIndex = async ({ name, content }) => {
 
   const newObject = {
     objectID: name,
+    package: name,
     lastUpdated: Date.now(),
     excerpt: (await stripMarkdown(strippedContent)).substring(
       0,

--- a/utils/docs/getPackageProps.ts
+++ b/utils/docs/getPackageProps.ts
@@ -4,6 +4,10 @@ import toc from 'markdown-toc'
 
 const atob = require('atob')
 import { slugifyTocHeading } from './slugifyToc'
+import algoliasearch from 'algoliasearch'
+import { stripMarkdown } from '../../utils/blog_helpers'
+
+const MAX_BODY_LENGTH = 200
 
 // @ts-ignore
 const path = __non_webpack_require__('path')
@@ -70,6 +74,17 @@ export async function getPackageProps(
   const currentDoc = await axios.get(currentPackage.link)
   const content = b64DecodeUnicode(currentDoc.data.content)
 
+  if (process.env.VERCEL_GITHUB_COMMIT_REF === 'master' && !preview) {
+    // this should only run when performing incremental SSG on prod
+
+    updateSearchIndex({
+      name: currentPackage.name,
+      content: content,
+    }).catch(e => {
+      console.error(e)
+    })
+  }
+
   return {
     revalidate: 24 * HOURS,
     props: {
@@ -94,3 +109,47 @@ export async function getPackageProps(
 
 const MINUTES = 60 // seconds
 const HOURS = 60 * MINUTES
+
+const updateSearchIndex = async ({ name, content }) => {
+  const client = algoliasearch(
+    process.env.ALGOLIA_APP_ID,
+    process.env.ALGOLIA_ADMIN_KEY
+  )
+  const index = client.initIndex('Tina-Package-Docs')
+  let oldObject
+  try {
+    const objectResult = await index.findObject(hit => hit.objectID === name)
+    oldObject = objectResult.object
+  } catch (e) {
+    oldObject = null
+  }
+  const strippedContent = stripH1(content || '')
+
+  const newObject = {
+    objectID: name,
+    lastUpdated: Date.now(),
+    excerpt: (await stripMarkdown(strippedContent)).substring(
+      0,
+      MAX_BODY_LENGTH
+    ),
+    content: await stripMarkdown(strippedContent),
+  }
+
+  if (shouldUpdate(oldObject, newObject)) {
+    await index.saveObject(newObject)
+  }
+}
+
+const stripH1 = content => {
+  const captureH1 = /^#\s+.*\s*$/gm
+  const result = captureH1.exec(content)
+  if (!result) return content
+  return content.substring(result[0].length)
+}
+
+const shouldUpdate = (oldObject, newObject) => {
+  if (!oldObject) return true
+  if (oldObject.content != newObject.content) return true
+  if (oldObject.excerpt != newObject.excerpt) return true
+  if (Date.now() - oldObject.lastUpdated > 72 * HOURS) return true
+}


### PR DESCRIPTION
note that only `react-tinacms-github` is currently in the search index. other entries will only start indexing once this is pushed to prod.

![image](https://user-images.githubusercontent.com/15221702/89941431-0373b900-dbe9-11ea-8a96-cc083dc263dc.png)
