### PR TITLE
Open Graph Image Fix

### DIFF
--- a/pages/guides/[category]/[guide]/[step].tsx
+++ b/pages/guides/[category]/[guide]/[step].tsx
@@ -148,7 +148,9 @@ export default function GuideTemplate({
         openGraph={{
           title: frontmatter.title,
           description: excerpt,
-          images: [openGraphImage(guideTitle)],
+          images: [
+            openGraphImage(guideTitle, ' | TinaCMS Docs', frontmatter.title),
+          ],
         }}
       />
       <DocsLayout navItems={guideNav} guide={breadcrumb}>

--- a/utils/open-graph-image.tsx
+++ b/utils/open-graph-image.tsx
@@ -1,22 +1,21 @@
 export function openGraphImage(
   title: string,
   altSuffix: string = '',
-  author: string = ''
+  subtitle?: string
 ) {
-  const base =
-    'https://res.cloudinary.com/forestry-demo/image/upload/l_text:tuner-regular.ttf_70:'
+  let url
+  const encodedTitle = encodeURIComponent(title)
+  const encodedSubtitle = subtitle && encodeURIComponent(subtitle)
+  const renderSubtitle = typeof encodedSubtitle === 'string'
 
-  const encodedTitle =
-    encodeURIComponent(title) +
-    ',g_north_west,x_270,y_95,w_840,c_fit,co_rgb:EC4815/l_text:tuner-regular.ttf_35:'
-
-  const encodedAuthor = author
-    ? encodeURIComponent(author) +
-      ',g_north_west,x_270,y_500,w_840,c_fit,co_rgb:241748/v1581087220/TinaCMS/tinacms-social-empty.png'
-    : ''
+  if (renderSubtitle) {
+    url = `https://res.cloudinary.com/forestry-demo/image/upload/l_text:tuner-regular.ttf_70:${encodedTitle},g_north_west,x_270,y_95,w_840,c_fit,co_rgb:EC4815/l_text:tuner-regular.ttf_35:${encodedSubtitle},g_north_west,x_270,y_500,w_840,c_fit,co_rgb:241748/v1581087220/TinaCMS/tinacms-social-empty.png`
+  } else {
+    url = `https://res.cloudinary.com/forestry-demo/image/upload/l_text:tuner-regular.ttf_90_center:${encodedTitle},g_center,x_0,y_50,w_850,c_fit,co_rgb:EC4815/v1581087220/TinaCMS/tinacms-social-empty-docs.png`
+  }
 
   return {
-    url: base + encodedTitle + encodedAuthor,
+    url,
     width: 1200,
     height: 628,
     alt: title + altSuffix,


### PR DESCRIPTION
The new open graph image function didn't support the old single line layout, so docs and guides SEO images weren't showing up. I added support for both layouts to the new function.