### PR TITLE
fix(guides/index): send preview data to getDocsNav

### DIFF
--- a/pages/guides/index.tsx
+++ b/pages/guides/index.tsx
@@ -72,7 +72,7 @@ export const getStaticProps = async ctx => {
     ctx.preview,
     ctx.previewData
   )
-  const navItems = await getDocsNav(preview, {})
+  const navItems = await getDocsNav(preview, ctx.previewData)
 
   return {
     props: {


### PR DESCRIPTION
this will fix the 502 error when visiting the guides index in edit mode