### PR TITLE
fix overlap issue, improve  grid logic

### DIFF
--- a/components/DocumentationNavigation/DocumentationNavigation.tsx
+++ b/components/DocumentationNavigation/DocumentationNavigation.tsx
@@ -55,7 +55,7 @@ const MobileNavToggle = styled(NavToggle)`
   margin-top: 1.25rem;
   padding: 0 0 0 1rem;
   border-radius: 0 2rem 2rem 0;
-  width: 3.5rem;
+  width: 3.25rem;
   z-index: 1300;
 
   svg {

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -164,7 +164,8 @@ export const DocsGrid = styled.div`
   display: grid;
   width: 100%;
   position: relative;
-  grid-auto-columns: 2rem auto 2rem;
+  grid-auto-columns: minmax(1.5rem, 4rem) minmax(280px, 768px)
+    minmax(1.5rem, 4rem);
   grid-template-areas:
     '. header .'
     '. toc .'

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -176,24 +176,14 @@ export const DocsGrid = styled.div`
     grid-template-areas:
       '. header header .'
       '. content toc .';
-    grid-auto-columns: auto 450px 250px auto;
+    margin: 0 auto;
+    grid-auto-columns: minmax(2rem, auto) fit-content(768px) 240px
+      minmax(0, auto);
     grid-column-gap: 2rem;
   }
 
-  @media (min-width: 1000px) {
-    grid-auto-columns: auto 600px 300px auto;
-  }
-
-  @media (min-width: 1200px) {
-    grid-auto-columns: auto 550px 250px auto;
-  }
-
-  @media (min-width: 1400px) {
-    grid-auto-columns: auto 768px 300px auto;
-  }
-
-  @media (min-width: 1700px) {
-    grid-auto-columns: auto 768px 24rem auto;
+  @media (min-width: 1600px) {
+    grid-auto-columns: auto 768px 330px auto;
     grid-column-gap: 3rem;
   }
 `
@@ -201,8 +191,6 @@ export const DocsGrid = styled.div`
 export const DocGridHeader = styled.div`
   grid-area: header;
   width: 100%;
-  justify-self: center;
-  max-width: 768px;
 
   @media (min-width: 830px) {
     max-width: none;
@@ -212,8 +200,6 @@ export const DocGridHeader = styled.div`
 export const DocGridToc = styled.div`
   grid-area: toc;
   width: 100%;
-  justify-self: center;
-  max-width: 768px;
 
   @media (min-width: 830px) {
     padding-top: 4.5rem;
@@ -227,8 +213,6 @@ interface ContentProps {
 export const DocGridContent = styled.div<ContentProps>`
   grid-area: content;
   width: 100%;
-  justify-self: center;
-  max-width: 768px;
 `
 
 export const DocsPageTitle = styled.h1`


### PR DESCRIPTION
The series of breakpoints used to 'tame' the CSS grid was overly complicated so I've simplified it. The new grid is better at using the space available & balancing the placement of content.

Also, the hamburger toggle was overlapping the content on 'tablet' size, which is now fixed.

Before:

<img width="839" alt="Screen Shot 2020-08-19 at 11 22 05 AM" src="https://user-images.githubusercontent.com/5075484/90647011-3aac2080-e20e-11ea-8479-3ed0c0436c15.png">

After:

<img width="840" alt="Screen Shot 2020-08-19 at 11 28 20 AM" src="https://user-images.githubusercontent.com/5075484/90647795-1866d280-e20f-11ea-91b9-8c3bf6e56fab.png">
