### PR TITLE
Regenerate package docs hourly

### DIFF
--- a/utils/docs/getPackageProps.ts
+++ b/utils/docs/getPackageProps.ts
@@ -52,7 +52,7 @@ export async function getPackageProps(
   var currentPackage: GithubPackage
   var previousPackage, nextPackage: GithubPackage | null
 
-  const packagePages = file.packages.filter( (p: { readme?: any }) => p.readme )
+  const packagePages = file.packages.filter((p: { readme?: any }) => p.readme)
 
   packagePages.forEach((element, index: number) => {
     if (element.name === slug) {
@@ -89,7 +89,7 @@ export async function getPackageProps(
   }
 
   return {
-    revalidate: 24 * HOURS,
+    revalidate: 1 * HOURS,
     props: {
       ...defaultProps,
       name: currentPackage.name,

--- a/utils/docs/getPackageProps.ts
+++ b/utils/docs/getPackageProps.ts
@@ -156,5 +156,4 @@ const shouldUpdate = (oldObject, newObject) => {
   if (!oldObject) return true
   if (oldObject.content != newObject.content) return true
   if (oldObject.excerpt != newObject.excerpt) return true
-  if (Date.now() - oldObject.lastUpdated > 72 * HOURS) return true
 }


### PR DESCRIPTION
Until we can invalidate pages via webhook, let's regenerate package docs once per hour. A 24-hour feedback loop for docs updates is too long.