### PR TITLE
use node 12 in workflow scripts

### DIFF
--- a/.github/workflows/create-indices.yml
+++ b/.github/workflows/create-indices.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x]
+        node-version: [12.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x]
+        node-version: [12.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
github actions should use the [same major version as Vercel](https://vercel.com/docs/runtimes#official-runtimes/node-js/node-js-version)