### PR TITLE
fix guides pagination

### DIFF
--- a/pages/guides/[category]/[guide]/[step].tsx
+++ b/pages/guides/[category]/[guide]/[step].tsx
@@ -52,7 +52,7 @@ export default function GuideTemplate({
   const contentRef = React.useRef<HTMLDivElement>(null)
   const [activeIds, setActiveIds] = React.useState([])
   const router = useRouter()
-  const currentPath = router.asPath.replace(/\/$/, '')
+  const currentPath = router.asPath
   const excerpt = markdownFile.data.excerpt
 
   /** Handles active TOC */
@@ -255,9 +255,10 @@ function usePrevNextSteps(guide: any, currentPath: string) {
     }
     let prev = null,
       next = null
+    const currentPathStripped = currentPath.replace(/\/$/, '')
     const allSteps = guide.steps
     const currentItemIndex = allSteps.findIndex(
-      step => step.slug == currentPath
+      step => step.slug.replace(/\/$/, '') == currentPathStripped
     )
     if (currentItemIndex >= 0) {
       prev = allSteps[currentItemIndex - 1]

--- a/pages/guides/[category]/[guide]/[step].tsx
+++ b/pages/guides/[category]/[guide]/[step].tsx
@@ -52,7 +52,7 @@ export default function GuideTemplate({
   const contentRef = React.useRef<HTMLDivElement>(null)
   const [activeIds, setActiveIds] = React.useState([])
   const router = useRouter()
-  const currentPath = router.asPath
+  const currentPath = router.asPath.replace(/\/$/, '')
   const excerpt = markdownFile.data.excerpt
 
   /** Handles active TOC */


### PR DESCRIPTION
The previous/next links weren't working for guides pages. It looks like the currentPath had a trailing slash but the individual step slugs didn't. This is a quick fix but probably not the best way to fix this. I'm not sure if the slug format changed or why this was previously working.