### PR TITLE
fix safari transparent color bug

### DIFF
--- a/components/DocumentationNavigation/DocsLeftSidebar.tsx
+++ b/components/DocumentationNavigation/DocsLeftSidebar.tsx
@@ -23,7 +23,7 @@ export const DocsLeftSidebar = styled.div<{ open: boolean }>`
   > ul {
     flex: 1 1 auto;
     padding: 1rem 1px 1rem 0;
-    background: linear-gradient(to bottom, white, transparent 1rem),
+    background: linear-gradient(to bottom, white, rgba(255, 255, 255, 0) 1rem),
       linear-gradient(to bottom, var(--tina-color-grey-1), white 1rem);
     background-attachment: local, scroll;
     background-repeat: no-repeat;


### PR DESCRIPTION
The docs nav header drop shadow was rendering funky in Safari. This fixes it.