### PR TITLE
fix: image path

### DIFF
--- a/components/inline-wysiwyg.tsx
+++ b/components/inline-wysiwyg.tsx
@@ -20,7 +20,7 @@ export function InlineWysiwyg(props: any) {
           directory: 'public/img/',
           parse: filename => 'img/' + filename,
           previewSrc(src: string) {
-            return cms.api.github.getDownloadUrl('public/' + src)
+            return cms.api.github.getDownloadUrl('/public/' + src)
           },
         }}
       />


### PR DESCRIPTION
Given I usee GitHub as a media provider
When I upload an image 
Then I can see it in Edit mode
And I can see it in Production

props @dwalkr