### PR TITLE
Update Adding Media Store Example

### DIFF
--- a/content/docs/media.md
+++ b/content/docs/media.md
@@ -2,9 +2,8 @@
 title: Media
 prev: /docs/events
 next: /docs/apis
-last_edited: '2020-09-29T15:53:15.812Z'
+last_edited: '2020-10-07T18:15:58.042Z'
 ---
-
 **Media** in Tina refers to a set of APIs to allow packages to interact with a central store of files.
 
 ## Media Store
@@ -13,10 +12,10 @@ A **Media Store** handles media files for the CMS. Media Stores provide a set of
 
 > ### Supported Media Stores
 >
-> - [`GithubMediaStore`](/packages/react-tinacms-github): Saves and sources media to/from your Git repository through the GitHub API.
-> - [`NextGithubMediaStore`](/packages/next-tinacms-github#nextgithubmediastore): Configures media sourced from GitHub specifically for Next.js projects.
-> - [`StrapiMediaStore`](/packages/react-tinacms-strapi/): Handles media stored in a Strapi instance.
-> - [`GitMediaStore`](/guides/nextjs/git/adding-backend): Saves media to your Git repository by writing to the local system and commiting directly.
+> * [`GithubMediaStore`](/packages/react-tinacms-github): Saves and sources media to/from your Git repository through the GitHub API.
+> * [`NextGithubMediaStore`](/packages/next-tinacms-github#nextgithubmediastore): Configures media sourced from GitHub specifically for Next.js projects.
+> * [`StrapiMediaStore`](/packages/react-tinacms-strapi/): Handles media stored in a Strapi instance.
+> * [`GitMediaStore`](/guides/nextjs/git/adding-backend): Saves media to your Git repository by writing to the local system and commiting directly.
 
 ### Creating a Media Store
 
@@ -65,52 +64,52 @@ interface MediaListOptions {
 
 #### Media Store
 
-| Key          | Description                                                                                                                                                           |
-| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `accept`     | The [input accept string](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept) that describes what kind of files the Media Store will accept. |
-| `persist`    | Uploads a set of files to the Media Store and returns a Promise containing the Media objects for those files.                                                         |
-| `previewSrc` | Given a `src` string, it returns a url for previewing that content. This is helpful in cases where the file may not be available in production yet.                   |
-| `list`       | Lists all media in a specific directory. Used in the media manager.                                                                                                   |
-| `delete`     | Deletes a media object from the store.                                                                                                                                |
+| Key | Description |
+| --- | --- |
+| `accept` | The [input accept string](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept) that describes what kind of files the Media Store will accept. |
+| `persist` | Uploads a set of files to the Media Store and returns a Promise containing the Media objects for those files. |
+| `previewSrc` | Given a `src` string, it returns a url for previewing that content. This is helpful in cases where the file may not be available in production yet. |
+| `list` | Lists all media in a specific directory. Used in the media manager. |
+| `delete` | Deletes a media object from the store. |
 
 #### Media
 
 This represents an individual file in the `MediaStore`.
 
-| Key          | Description                                                    |
-| ------------ | -------------------------------------------------------------- |
-| `type`       | Indicates whether the object represents a file or a directory. |
-| `id`         | A unique identifier for the media item.                        |
-| `directory`  | The path to the file in the store. e.g. `public/images`        |
-| `filename`   | The name of the file. e.g.`boat.jpg`                           |
-| `previewSrc` | _Optional:_ A url that provides an image preview of the file.  |
+| Key | Description |
+| --- | --- |
+| `type` | Indicates whether the object represents a file or a directory. |
+| `id` | A unique identifier for the media item. |
+| `directory` | The path to the file in the store. e.g. `public/images` |
+| `filename` | The name of the file. e.g.`boat.jpg` |
+| `previewSrc` | _Optional:_ A url that provides an image preview of the file. |
 
 #### Media List
 
 This represents a paginated query to the `MediaStore` and its results.
 
-| Key          | Description                                                                 |
-| ------------ | --------------------------------------------------------------------------- |
-| `items`      | An array of `Media` objects.                                                |
-| `limit`      | The number of records returned by the current query.                        |
-| `offset`     | A number representing the beginning of the current record set.              |
+| Key | Description |
+| --- | --- |
+| `items` | An array of `Media` objects. |
+| `limit` | The number of records returned by the current query. |
+| `offset` | A number representing the beginning of the current record set. |
 | `nextOffset` | _Optional:_ A number representing the beginning of the next set of records. |
-| `totalCount` | The total number of records available.                                      |
+| `totalCount` | The total number of records available. |
 
 #### Media Upload Options
 
-| Key         | Description                                                                       |
-| ----------- | --------------------------------------------------------------------------------- |
-| `directory` | The directory where the file should be uploaded.                                  |
-| `file`      | The [File](https://developer.mozilla.org/en-US/docs/Web/API/File) to be uploaded. |
+| Key | Description |
+| --- | --- |
+| `directory` | The directory where the file should be uploaded. |
+| `file` | The [File](https://developer.mozilla.org/en-US/docs/Web/API/File) to be uploaded. |
 
 #### Media List Options
 
-| Key         | Description                                                                                            |
-| ----------- | ------------------------------------------------------------------------------------------------------ |
-| `directory` | _Optional:_ The current directory to list media from.                                                  |
-| `limit`     | _Optional:_ The number of records that should be returned.                                             |
-| `offset`    | _Optional:_ A number representing how far into the list the store should begin returning records from. |
+| Key | Description |
+| --- | --- |
+| `directory` | _Optional:_ The current directory to list media from. |
+| `limit` | _Optional:_ The number of records that should be returned. |
+| `offset` | _Optional:_ A number representing how far into the list the store should begin returning records from. |
 
 ### Adding a Media Store
 
@@ -125,24 +124,12 @@ cms.media.store = new MyMediaStore()
 Or you can define it in the [CMS config](/docs/getting-started/cms-set-up/#configure-the-cms-object) object:
 
 ```js
-const github = new GithubClient({
-  proxy: '/api/proxy-github',
-  authCallbackRoute: '/api/create-github-access-token',
-  clientId: process.env.GITHUB_CLIENT_ID,
-  baseRepoFullName: process.env.BASE_REPO_FULL_NAME,
+import { TinaCMS } from 'tinacms'
+import { MyMediaStore } from './my-media-store'
+
+const cms = new TinaCMS({
+  media: new MyMediaStore()
 })
-
-const tinaConfig = {
-  enabled: pageProps.preview,
-  toolbar: pageProps.preview,
-  apis: {
-    github,
-  },
-  media: new GithubMediaStore(github),
-  plugins: [BlogPostCreatorPlugin, ReleaseNotesCreatorPlugin],
-}
-
-const cms = React.useMemo(() => new TinaCMS(tinaConfig), [])
 ```
 
 ### Extending a Media Store


### PR DESCRIPTION
The first example–adding the store to an existing CMS–as really simple.

The second example–adding the store when instantiating the CMS– was much more complex and had React hook code.

This PR simplifies the second example