### PR TITLE
chore: fix guide redirects

### DIFF
--- a/now.json
+++ b/now.json
@@ -53,8 +53,12 @@
       "destination": "/docs/ui/inline-editing"
     },
     {
-      "source": "/guides/nextjs/github-open-authoring/initial-setup",
-      "destination": "/guides/nextjs/github/initial-setup/"
+      "source": "/guides/nextjs/github-open-authoring/",
+      "destination": "/guides/nextjs/github/"
+    },
+    {
+      "source": "/guides/nextjs/github-open-authoring/:slug*",
+      "destination": "/guides/nextjs/github/:slug*"
     },
     {
       "source": "/docs/gatsby/inline-editing",

--- a/now.json
+++ b/now.json
@@ -53,12 +53,8 @@
       "destination": "/docs/ui/inline-editing"
     },
     {
-      "source": "/guides/nextjs/github-open-authoring/",
-      "destination": "/guides/nextjs/github/"
-    },
-    {
-      "source": "/guides/nextjs/github-open-authoring/:slug*",
-      "destination": "/guides/nextjs/github/:slug*"
+      "source": "/guides/nextjs/github-open-authoring/(.*)",
+      "destination": "/guides/nextjs/github/$1"
     },
     {
       "source": "/docs/gatsby/inline-editing",


### PR DESCRIPTION
redirects all routes under `/guides/nextjs/github-open-authoring` to `guides/nextjs/github`

- https://tinacms-site-next-git-fix-guide-redirect.tinacms.vercel.app/guides/nextjs/github-open-authoring/initial-setup
- https://tinacms-site-next-git-fix-guide-redirect.tinacms.vercel.app/guides/nextjs/github-open-authoring/configure-custom-app/