### PR TITLE
docs: adds clearable to image field options

### DIFF
--- a/content/docs/plugins/fields/image.md
+++ b/content/docs/plugins/fields/image.md
@@ -21,6 +21,7 @@ interface ImageConfig {
   name: string
   label?: string
   description?: string
+  clearable?: boolean
   parse(media: Media): string
   previewSrc(formValues: any)?: string
   uploadDir(formValues: any)?: string
@@ -35,6 +36,7 @@ interface ImageConfig {
 | `name`        | The path to some value in the data being edited.                                                                                                                                                                         |
 | `label`       | A human readable label for the field. Defaults to the `name`. _(Optional)_                                                                                                                                               |
 | `description` | Description that expands on the purpose of the field or prompts a specific action. _(Optional)_                                                                                                                          |
+| `clearable`   | When true, editors can 'clear' the image field to an empty state via a trash icon. _(Optional)_                                                                                                                          |
 | `parse`       | Defines how the actual front matter or data value gets populated. The [media object](/docs/media#media) gets passed as an argument, and one can set the path this image as defined by the uploadDir property.            |
 | `previewSrc`  | Defines the path for the src attribute on the image preview. If using gatsby-image, the path to the `childImageSharp.fluid.src` needs to be provided. \_(Optional)                                                       |
 | `uploadDir`   | Defines the upload directory for the image. All of the form data is passed in, `fileRelativePath` is most useful in defining the upload directory, but you can also statically define the upload directory. \_(Optional) |


### PR DESCRIPTION
Should be merged once [this PR](https://github.com/tinacms/tinacms/pull/1594) is released.