### PR TITLE
Change language in docs 

### DIFF
--- a/content/docs/getting-started/introduction.md
+++ b/content/docs/getting-started/introduction.md
@@ -3,9 +3,9 @@ title: Introductory Tutorial
 id: introduction
 prev: null
 next: /docs/getting-started/cms-set-up
+last_edited: '2020-11-26T14:38:26.429Z'
 ---
-
-Tina is a toolkit for building content management systems. This tutorial will walk you through Tina's fundamental building blocks by setting up editing on a basic `create-react-app` [demo](https://github.com/tinacms/tina-intro-tutorial). **To get the most from Tina, you should have a good working knowledge of JavaScript and React**.
+Tina is a **toolkit for building visual editing** into your site. This tutorial will walk you through Tina's fundamental building blocks by setting up editing on a basic `create-react-app` [demo](https://github.com/tinacms/tina-intro-tutorial). **To get the most from Tina, you should have a good working knowledge of JavaScript and React**.
 
 ## Why _create-react-app_?
 

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -1,9 +1,9 @@
 ---
 title: TinaCMS Documentation
 id: introduction
-last_edited: '2020-08-17T20:43:06.481Z'
+last_edited: '2020-11-26T14:36:44.986Z'
 ---
-Tina is a **toolkit for building content management systems.** By creating a custom CMS with Tina instead of opting for a conventional, "turn-key" solution, developers that use Tina have a lot more control over the editing experience of their users.
+Tina is a **toolkit for building visual editing** into your site**.** By creating a custom editing experience with Tina instead of opting for a conventional CMS, developers can give their teams a contextual, intuitive editing experience without sacrificing code quality.  
 
 ## First Steps
 

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -1,9 +1,9 @@
 ---
 title: TinaCMS Documentation
 id: introduction
-last_edited: '2020-11-26T14:36:44.986Z'
+last_edited: '2020-11-26T14:37:54.481Z'
 ---
-Tina is a **toolkit for building visual editing** into your site**.** By creating a custom editing experience with Tina instead of opting for a conventional CMS, developers can give their teams a contextual, intuitive editing experience without sacrificing code quality.  
+Tina is a **toolkit for building visual editing** into your site. By creating a custom editing experience with Tina instead of opting for a conventional CMS, developers can give their teams a contextual, intuitive editing experience without sacrificing code quality.
 
 ## First Steps
 


### PR DESCRIPTION
Changing the language from "Tina is a toolkit for building custom CMSs", to "Tina is a toolkit for building visual editing into your site".  

Feedback from interviews done with developers in the past indicated that people were confused by the idea of building a custom CMS.  When they think of a CMS, they picture something like WordPress and are not interested in building that.  