### PR TITLE
FIX: typo in component name in code example

### DIFF
--- a/content/docs/plugins/fields/toggle.md
+++ b/content/docs/plugins/fields/toggle.md
@@ -17,7 +17,7 @@ The `toggle` field represents a true/false toggle. This field is typically used 
 
 ```typescript
 interface ToggleConfig extends FieldConfig {
-  component: 'Toggle'
+  component: 'toggle'
   name: string
   label?: string
   description?: string


### PR DESCRIPTION
No biggie, but tripped up the olde copy n' paster