### PR TITLE
Fix 404 from jamstack.org

### DIFF
--- a/now.json
+++ b/now.json
@@ -44,6 +44,10 @@
     { "source": "/docs/fields/", "destination": "/docs/plugins/fields" },
     { "source": "/docs/concepts/backends", "destination": "/docs/cms#apis" },
     { "source": "/docs/concepts/plugins", "destination": "/docs/cms#plugins" },
+    { 
+      "source": "/docs/getting-started/how-tina-works/", 
+      "destination": "/docs/getting-started/introduction/" 
+    },
     {
       "source": "/docs/getting-started/overview",
       "destination": "/docs/getting-started/introduction"


### PR DESCRIPTION
404 on https://tina.io/docs/getting-started/how-tina-works/ 

linked from:
- https://jamstack.org/headless-cms/tinacms/
- https://github.com/TryGhost/nodecmsguide/blob/master/content/projects/tinacms.md 

note: we'll need to update those descriptions, as they are amongst our best referrers. 