### PR TITLE
fix: docs navigation

### DIFF
--- a/content/docs-navigation.json
+++ b/content/docs-navigation.json
@@ -24,9 +24,9 @@
     "external": false
   },
   {
-    "id": "enterprise",
-    "label": "Enterprise",
-    "href": "/enterprise",
+    "id": "tinacloud",
+    "label": "Tina Cloud",
+    "href": "/early-access/",
     "external": false
   }
 ]

--- a/now.json
+++ b/now.json
@@ -106,7 +106,11 @@
     },
     {
       "source": "/teams",
-      "destination": "/enterprise"
+      "destination": "/early-access"
+    },
+    {
+      "source": "/enterprise",
+      "destination": "/early-access"
     },
     {
       "source": "/docs/gatsby/quickstart",


### PR DESCRIPTION
- [x] Rename `Enterprise` to `Tina Cloud` in the docs main navigation
- [x] Redirect to [`/early-access`](https://tina.io/early-access/)
