### PR TITLE
Tina cloud docs

### DIFF
--- a/components/DocumentationNavigation/DocsNavigationList.tsx
+++ b/components/DocumentationNavigation/DocsNavigationList.tsx
@@ -113,7 +113,7 @@ const DocsNavigationSection = ({
   )
 }
 
-const MobileMainNav = styled.li`
+const MobileMainNav = styled.div`
   padding-top: 0rem;
   margin-bottom: 1rem;
   padding-bottom: 1rem;

--- a/components/DocumentationNavigation/DocsNavigationList.tsx
+++ b/components/DocumentationNavigation/DocsNavigationList.tsx
@@ -6,6 +6,11 @@ import { DocsNavProps } from './DocumentationNavigation'
 import { NavSection } from './NavSection'
 import { useRouter } from 'next/router'
 
+export interface DocsSectionProps extends DocsNavProps {
+  onExit: () => void
+  category: string
+}
+
 export const NavListContext = createContext({ current: null })
 
 const getCategoryMatch = (navItems, currentPath) => {
@@ -88,7 +93,7 @@ const DocsNavigationSection = ({
   guide,
   onExit,
   category,
-}: DocsNavProps) => {
+}: DocsSectionProps) => {
   const navListRef = useRef<HTMLUListElement>(null)
 
   return (

--- a/components/DocumentationNavigation/DocsNavigationList.tsx
+++ b/components/DocumentationNavigation/DocsNavigationList.tsx
@@ -96,12 +96,16 @@ const DocsNavigationSection = ({
     <NavListContext.Provider value={navListRef}>
       <ul ref={navListRef}>
         <CategoryAnchor>
-          {category}
           <CategoryDescription>
-            <span role="button" onClick={onExit}>
-              ← Back
+            <span
+              role="button"
+              onClick={onExit}
+              style={{ display: 'block', marginBottom: '0.5em' }}
+            >
+              ← Docs Index
             </span>
           </CategoryDescription>
+          {category}
         </CategoryAnchor>
 
         {navItems &&

--- a/components/DocumentationNavigation/DocsNavigationList.tsx
+++ b/components/DocumentationNavigation/DocsNavigationList.tsx
@@ -1,27 +1,109 @@
-import { useRef, createContext } from 'react'
+import React, { useRef, createContext } from 'react'
 import styled from 'styled-components'
 import Link from 'next/link'
 import { DocsLinkNav } from '../ui/DocsLinkNav'
 import { DocsNavProps } from './DocumentationNavigation'
 import { NavSection } from './NavSection'
+import { useRouter } from 'next/router'
 
 export const NavListContext = createContext({ current: null })
 
+const getCategoryMatch = (navItems, currentPath) => {
+  for (let item of navItems) {
+    if (hasNestedSlug(item.items, currentPath)) {
+      return item.category
+    }
+  }
+  return null
+}
+
+const hasNestedSlug = (navItems, slug) => {
+  for (let item of navItems) {
+    if (item.slug === slug || `${item.slug}/` === slug) {
+      return true
+    }
+    if (item.items) {
+      return hasNestedSlug(item.items, slug)
+    }
+  }
+  return false
+}
+
+const useActiveCategory = navItems => {
+  const router = useRouter()
+  return getCategoryMatch(navItems, router.asPath)
+}
+
 export const DocsNavigationList = ({ navItems, guide }: DocsNavProps) => {
+  const activeCategory = useActiveCategory(navItems)
+  const [currentCategory, setCurrentCategory] = React.useState(activeCategory)
+  const currentCategoryData = React.useMemo(() => {
+    return navItems.find(
+      categoryData => categoryData.category === currentCategory
+    )
+  }, [currentCategory])
+  return (
+    <>
+      <MobileMainNav>
+        <DocsLinkNav />
+      </MobileMainNav>
+      {currentCategoryData ? (
+        <DocsNavigationSection
+          navItems={currentCategoryData.items}
+          guide={guide}
+          onExit={() => setCurrentCategory(null)}
+          category={currentCategoryData.category}
+        />
+      ) : (
+        <DocsCategoryList navItems={navItems} onSelect={setCurrentCategory} />
+      )}
+    </>
+  )
+}
+
+const DocsCategoryList = ({ navItems, onSelect }) => {
+  return (
+    <div style={{ padding: '1rem 0' }}>
+      {navItems.map(categoryData => {
+        return (
+          <>
+            <CategoryAnchor
+              role="button"
+              onClick={() => onSelect(categoryData.category)}
+            >
+              {categoryData.category} →
+              <CategoryDescription>
+                {categoryData.description}
+              </CategoryDescription>
+            </CategoryAnchor>
+          </>
+        )
+      })}
+    </div>
+  )
+}
+
+const DocsNavigationSection = ({
+  navItems,
+  guide,
+  onExit,
+  category,
+}: DocsNavProps) => {
+  console.log(JSON.stringify(navItems, null, 2))
   const navListRef = useRef<HTMLUListElement>(null)
 
   return (
     <NavListContext.Provider value={navListRef}>
       <ul ref={navListRef}>
-        <MobileMainNav>
-          <DocsLinkNav />
-        </MobileMainNav>
-        {guide && (
-          <Breadcrumbs>
-            <Link href="/guides">guides</Link>
-            <Link href={`/guides#${guide.category}`}>{guide.category}</Link>
-          </Breadcrumbs>
-        )}
+        <CategoryAnchor>
+          {category}
+          <CategoryDescription>
+            <span role="button" onClick={onExit}>
+              ← Back
+            </span>
+          </CategoryDescription>
+        </CategoryAnchor>
+
         {navItems &&
           navItems.map(section => (
             <NavSection key={section.id} {...section} collapsible={false} />
@@ -78,4 +160,21 @@ const Breadcrumbs = styled.li`
     margin: 0 0.25rem;
     color: var(--tina-color-grey-4);
   }
+`
+
+const CategoryAnchor = styled.span`
+  display: block;
+  cursor: pointer;
+  padding: 0.5rem 1.5rem 0.5rem 1.5rem;
+  color: var(--color-primary);
+  text-decoration: none;
+  transition: all 180ms ease-out;
+  font-family: var(--font-tuner);
+  font-size: 1.125rem;
+`
+const CategoryDescription = styled.p`
+  font-size: 0.8em;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+    'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
 `

--- a/components/DocumentationNavigation/DocsNavigationList.tsx
+++ b/components/DocumentationNavigation/DocsNavigationList.tsx
@@ -89,7 +89,6 @@ const DocsNavigationSection = ({
   onExit,
   category,
 }: DocsNavProps) => {
-  console.log(JSON.stringify(navItems, null, 2))
   const navListRef = useRef<HTMLUListElement>(null)
 
   return (

--- a/components/DocumentationNavigation/DocumentationNavigation.tsx
+++ b/components/DocumentationNavigation/DocumentationNavigation.tsx
@@ -15,8 +15,6 @@ import { searchIndices } from 'components/search/indices'
 export interface DocsNavProps {
   navItems: any
   guide: false | { category: string }
-  onExit?: () => void
-  category?: string
 }
 
 export function DocumentationNavigation({ navItems, guide }: DocsNavProps) {

--- a/components/DocumentationNavigation/DocumentationNavigation.tsx
+++ b/components/DocumentationNavigation/DocumentationNavigation.tsx
@@ -15,6 +15,8 @@ import { searchIndices } from 'components/search/indices'
 export interface DocsNavProps {
   navItems: any
   guide: false | { category: string }
+  onExit?: () => void
+  category?: string
 }
 
 export function DocumentationNavigation({ navItems, guide }: DocsNavProps) {

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -1,63 +1,28 @@
 ---
-title: TinaCMS Documentation
+title: Tina Docs
 id: introduction
 last_edited: '2020-11-26T14:37:54.481Z'
 ---
-Tina is a **toolkit for building visual editing** into your site. By creating a custom editing experience with Tina instead of opting for a conventional CMS, developers can give their teams a contextual, intuitive editing experience without sacrificing code quality.
 
-## First Steps
+**Tina** contains multiple tools and applications designed to improve collaboration between **content writers** and **developers** who work on web content. Under the umbrella of Tina, there are two main components:
 
-Are you new to using Tina to build content management systems? Start with these resources to build your understanding of Tina and what's possible.
+- The **TinaCMS toolkit**, a suite of NPM packages that enable developers to quickly create a custom content management frontend for a website.
+- **Tina Cloud**, a hosted service designed to make git-based content management more powerful and accessible for cross-functional teams.
 
-* Go through the [**Getting Started Tutorial**](/docs/getting-started/introduction "Getting Started"): [Installing ](/docs/getting-started/cms-set-up#install-tinacms)_[tinacms](/docs/getting-started/cms-set-up#install-tinacms)_ | [Creating a CMS instance and adding the ](/docs/getting-started/cms-set-up#create-a-cms-instance-add-tinaprovider)_[TinaProvider](/docs/getting-started/cms-set-up#create-a-cms-instance-add-tinaprovider)_
-  | [Configuring the CMS object](/docs/getting-started/cms-set-up#configure-the-cms-object)
-  | [Enabling the CMS](/docs/getting-started/cms-set-up#enabling-the-cms)
-  | [Creating and registering a form plugin](/docs/getting-started/edit-content#create--register-a-form)
-  | [Loading content from an external API](/docs/getting-started/backends#loading-content-from-an-external-api)
-  | [Saving content changes](/docs/getting-started/backends#saving-content)
-  | [Adding alerts](/docs/getting-started/backends#adding-alerts)
-* Click **Edit this Site** at the bottom of the page to fork the [tinacms.org repository](https://github.com/tinacms/tinacms.org "Tinacms.org Repository"), make changes, and then open a Pull Request!
-* Checkout [this video of a page builder](https://youtu.be/4qGz0cP_DSA "Inline Editing Demo Video") created with TinaCMS.
+## TinaCMS Toolkit
 
-## Getting Help
+The **TinaCMS Toolkit** empowers developers to build a visual editing experience directly on their sites. By creating a custom editing experience with Tina instead of opting for a conventional CMS, developers can give their teams a contextual, intuitive editing experience without sacrificing code quality.
 
-Have questions on how to use Tina to build your CMS?
+[Learn more about the TinaCMS toolkit](/docs/tinacms)
 
-* Visit the [Tina Forum](https://community.tinacms.org "Tina Forum") to engage with the core team and community.
-* Report bugs using [GitHub Issues](https://github.com/tinacms/tinacms/issues "Tina Github Issues")
-* [FAQ](/docs/getting-started/faq)
+## Tina Cloud
 
-## How This Site Is Organized
+**Tina Cloud** is a hosted service purpose built for integration with the TinaCMS Toolkit. Tina Cloud makes it possible for entire content teams to take advantage of a git-based workflow, regardless of whether they write code or have GitHub accounts. Additionally, Tina Cloud exposes a GraphQL API for your site's file-based content, giving developers a more powerful interface for querying data and reconciling relationships.
 
-Learning how to build a CMS is no small feat! We've compiled a variety of resources to help you along.
+[Learn more about Tina Cloud](/docs/tina-cloud)
 
-* Docs describe the main Tina concepts and how to use them to build your CMS.
-* [Guides](/guides "Tina Guides") take you through the steps involved in addressing key problems and specific use-cases.
-* The [Blog](/blog "Tina Blog") is where release notes, tips, and other announcements are posted.
-* Visit the [Packages Reference](/docs/packages) to find more tools and make building your CMS even easier.
+## Guides
 
-## Constructing The User Interface
+Our **Guides** section contains various step-by-step guides to show you how to use the TinaCMS toolkit.
 
-Tina lets you choose the user interface that best fits your workflow. You can use one of its default interfaces or construct your own. You can even build editing capabilities directly into your page!
-
-* Learn about the [Toolbar](/docs/ui#toolbar-configuration "Tina Toolbar") and [Sidebar](/docs/ui#sidebar-configuration "Tina Sidebar") UI components.
-* Take control of the appearance of your CMS using [Custom Styling](/docs/ui/styles "Styles")
-* Add features to your CMS using [Screen Plugins](/docs/plugins/screens "Screen Plugins") and [Toolbar Widgets](/docs/plugins/toolbar-widgets).
-* Wander off the beaten trail and create a totally custom UI _(Coming Soon)_
-
-## Tools for Managing Content
-
-Tina gives you the tools you need to manage content from the data source of your choosing. These docs will show you how to craft your ideal content editing experience.
-
-* **Editing Content:** [Creating Forms](/docs/plugins/forms), [Fields](/docs/plugins/fields),[ Custom Fields](/docs/plugins/fields/custom-fields), [Inline Editing](/docs/ui/inline-editing), [Working with Inline Blocks](/guides//general/inline-blocks/overview)
-* **Creating Content:** Using [Content Creators](/docs/plugins/content-creators)
-* **Deleting Content:** Using Form Actions. _(Coming Soon)_
-* **Media Management:** [Media Stores](/docs/media "Tina Media Store"), [Image Fields](/docs/plugins/fields/image "Image Field Plugin"), [Inline Images](/docs/ui/inline-editing/inline-image "Inline Images")
-* **Custom Fields:** [How to Make a Custom Field Component](/blog/custom-field-components)
-
-## Integrating with React Frameworks
-
-Tina is designed to work with just about any React framework. Once you're comfortable with the basics of TinaCMS, these guides will help you learn the specifics of building a CMS with Next.js or Gatsby.
-
-* [Next.js](/docs/integrations/nextjs)
-* [Gatsby](/docs/integrations/gatsby)
+[View the Guides](/guides)

--- a/content/docs/tina-cloud.md
+++ b/content/docs/tina-cloud.md
@@ -1,0 +1,24 @@
+---
+title: Tina Cloud
+---
+
+Tina Cloud is a multi-level backend solution for TinaCMS. Included in this solution is our expressive Content API and a Dashboard to easily manage sites and users.
+
+## Tina Cloud Dashboard
+
+An important distinction to make is that unlike a traditional CMS dashboard, the Tina Cloud dashboard is not used to edit your content. The difference of the Tina Cloud dashboard is that the content editing capabilities are setup by you, the developer, using our TinaCMS toolkit.
+
+Instead, the Tina Cloud dashboard is used to connect sites with your editors. Through the dashboard, you can setup an app. An app connects to your site's GitHub repository, and authorizes Tina Cloud to push and pull content directly from the repo. You can also authenticate certain users to edit your site through the dashboard's user management page. Together, this allows users to login directly to your site and start editing the content while also simutaneously updating the content within the GitHub repo.
+
+## Content API
+
+Tina Cloud's Content API unlocks a few powerful features for the Tina experience. Firstly, Tina's Content API authenticates directly with GitHub therefore removing the need for your users to possess GitHub accounts. They are given access through the dashboard, and therefore can login directly through your site to begin editing!
+
+The Content API also houses our powerful GraphQL Gateway API. The GraphQL API is important for a variety of reasons:
+
+- **Editing Environment Flexibility:**
+  The GraphQL API works regardless of the datasource, allowing for flexibility during development. It can connect to your local filesystem for optional local development, or can be run through the server during production.
+- **Control over Content**:
+  The GraphQL API returns useful data in a way that makes sense for Tina development. It returns the data for the page as well as the form configuration needed for Tina forms. So, you as the developer only need to define your content model once and not have to worry about mirroring the model between the data source and Tina. The Tina CLI also has helpful commands to autogenerate the GraphQL queries to be used in these API requests as well as the typescript types which match the data and forms.
+- **Link Resolution**:
+  The Content API leverages the power of GraphQL and thus can return data that is linked to another file, all within one request. You only need to query for what you need and nothing more.

--- a/content/docs/tina-cloud/cli.md
+++ b/content/docs/tina-cloud/cli.md
@@ -1,0 +1,94 @@
+---
+title: Tina Cloud CLI
+---
+
+The _Tina Cloud CLI_ can be used to set up your project with Tina Cloud configuration, and run a local version of the Tina Cloud content-api (using your file system's content).
+
+## Getting started
+
+The CLI can be installed as a dev dependency in your project.
+
+Npm:
+
+```bash
+npm install --save-dev tina-graphql-gateway-cli
+```
+
+Yarn:
+
+```bash
+yarn add --dev tina-graphql-gateway-cli
+```
+
+## Usage
+
+Arguments wrapped in `<>` in the command name are required.
+Arguments wrapped in `[]` in the command name are optional.
+
+## Help
+
+You can get help on any command with `-h` or `--help`.
+
+e.g:
+
+```bash
+yarn tina-gql schema:gen-query --help
+```
+
+This will describe how to use the schema:gen-query command.
+
+## Commands
+
+### tina-gql server:start \[options\]
+
+Start a GraphQL server using your Filesystem's content as the datasource. Your site will need to have a valid .tina configuration to define its schema.
+
+#### Options
+
+--port <port> Specify a port to run the server on. (default 4001)
+
+### tina-gql schema:types \[options\]
+
+Generate Typescript types based on your site's schema.
+
+#### Options
+
+--schema, -s Dump the graphql SDL
+
+### tina-gql schema:audit \[options\]
+
+Check for **.tina/front_matter/templates** folder for any issues.
+
+#### Options
+
+--path <tinaPath> Specify a relative path to the .tina folder (eg. my-site)
+
+### tina-gql schema:dump \[options\]
+
+Dump JSON schema into specified path
+
+#### Options
+
+--folder <folder> Dump the schema into the given path
+
+## Development
+
+To run this project locally in another directory, you can create a symlink by running
+
+```bash
+npm link
+```
+
+Then `tina-gql` can be run in another directory by running:
+
+```bash
+tina-gql <commands>
+```
+
+_Alternatively, the CLI can be added to a project instead of being used globally._
+
+To run the command locally in this project directory, you can run:
+
+```bash
+yarn tina-gql <commands>
+```

--- a/content/docs/tina-cloud/client.md
+++ b/content/docs/tina-cloud/client.md
@@ -1,0 +1,613 @@
+---
+title: Tina Cloud Client
+---
+
+The Tina Cloud Client allows you to interact with an automatically generated GraphQL API using TinaCMS. Included are multiple GraphQL adapters that give you a consistent GraphQL API regardless of your datasource.
+
+_For example, if your content is Git-backed, you might want to use your local content in development. While in your production Cloud Editing Environment, you can use our "Tina Teams" server to fetch your content. The API for both backends will be consistent, so you can easily switch between the two datasources without changing your site's code._
+
+If you like to work in TypeScript, the [tina-graphql-gateway-cli](https://github.com/tinacms/tina-graphql-gateway/tree/master/packages/cli) package can generate types using the same schema definition that the GraphQL adapters will use.
+
+## Prerequisites
+
+This guide assumes you have a working NextJS site. You can create one quickly with:
+
+```bash
+npx create-next-app --example blog-starter-typescript blog-starter-typescript-app
+```
+
+or
+
+```bash
+yarn create next-app --example blog-starter-typescript blog-starter-typescript-app
+```
+
+## Install the client package
+
+This package provides you with:
+
+- A `Client` class (which you can use as a TinaCMS API Plugin), that takes care of all interaction with the GraphQL server.
+- A `LocalClient` class - which talks to the local server if you've got one. Ideal for static builds and developement testing.
+- A `useGraphqlForms` hook, that you can use to hook into the Tina forms that let you edit your content.
+
+```bash
+npm install --save tina-graphql-gateway
+```
+
+or
+
+```bash
+yarn add tina-graphql-gateway
+```
+
+## CLI package
+
+You'll also likely want to install our CLI to help with development:
+
+```bash
+npm install --save-dev tina-graphql-gateway-cli
+```
+
+or
+
+```bash
+yarn add --dev tina-graphql-gateway-cli
+```
+
+This CLI performs a few functions:
+
+- Generates GraphQL and TypeScript types based on your content's schema.
+- Auditing your content's schema and checking for errors.
+- Running a GraphQL server using the built-in filesystem adapter.
+
+For full documentation of the CLI, see [here].(https://github.com/tinacms/tina-graphql-gateway/tree/main/packages/cli)
+
+## Implementation
+
+We'll show how to use this package in a NextJS site
+
+### Create Dummy Content
+
+Let's start by creating a simple dummy piece of content. Our goal will to be able to access and change this content through an auto-generated GraphQL API and Tina forms.
+
+**/\_posts/welcome.md**
+
+```md
+---
+title: This is my post
+---
+```
+
+### Configuration
+
+Before we can define the schema of our content, we need set up some configuration. Create a `.tina/` directory in your repository root, and then create a `schema.ts` file inside of this directory.
+
+**.tina/schema.ts**
+
+```ts
+import { defineSchema } from 'tina-graphql-gateway-cli'
+
+export default defineSchema({
+  collections: [
+    {
+      /*
+      Each collection references a list of files 
+      matching the pattern in `path`. In this case, 
+      all files in the `_posts` directory will be 
+      included in this collection.
+      */
+      path: '_posts',
+      label: 'Posts',
+      name: 'posts',
+
+      templates: [
+        {
+          /*
+          A collection will have one or more templates
+          that define the shape of its entities' data.
+          */
+          label: 'Post',
+          name: 'post',
+          fields: [
+            {
+              name: 'title',
+              label: 'Title',
+              type: 'text',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+})
+```
+
+### Sourcing your content
+
+Now that we have defined our content model, we can connect our site to the Tina.io Content API
+
+_Make sure your .tina directory is pushed to git_
+
+#### Creating a Tina.io app
+
+The Tina.io content API connects to your Github repository, and puts the content behind Tina.io's expressive content API.
+
+- Navigate to [Tina.io](https://auth.tinajs.dev/)
+- Create a realm
+- Create an app
+
+You will then see a client-id for your new app. We will use this shortly.
+
+#### Using the data within our Next.JS site
+
+First, install the TinaCMS dependencies:
+
+```bash
+npm install tinacms styled-components
+```
+
+or
+
+```bash
+yarn add tinacms styled-components
+```
+
+In your site root, add TinaCMS & register the `Client` like so:
+
+**\_app.tsx**
+
+```tsx
+import React from 'react'
+import { withTina } from 'tinacms'
+import { Client } from 'tina-graphql-gateway'
+import config from '../.forestry/config'
+
+function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}
+
+export default withTina(MyApp, {
+  apis: {
+    tina: new Client({
+      realm: 'your-realm-name', // this was set by you in the previous step
+      clientId: 'your-client-id', // this is visible in your Tina.io dashboard
+      // customContentApiUrl: "", // might be used to swap out or proxy through a custom backend service.
+      // tokenStorage: (Default Memory). Possible values: "MEMORY" | "LOCAL_STORAGE" | "CUSTOM".
+      // NOTE: If you choose to use LOCAL_STORAGE, you may be prone to CSRF vulnerabilities.
+      // getTokenFn: undefined, // This is only used when "tokenStorage" is set to "CUSTOM". Instead of grabbing the token from local storage, we can specify how its access token is retreived. You might want to use this if you are fetching content server-side.
+    }),
+  },
+  sidebar: true,
+})
+```
+
+We'll also want to wrap our main layout in the `TinaCloudProvider` to support authentication
+
+```tsx
+
+//...
+
+function MyApp({ Component, pageProps }) {
+
+  const client = useCMS().api.tina
+
+  return (<TinaCloudProvider
+    onLogin={(token: string) => {
+      const headers = new Headers()
+
+      //TODO - the token should could as a param from onLogin
+      headers.append('Authorization', 'Bearer ' + token)
+      fetch('/api/preview', {
+        method: 'POST',
+        headers: headers,
+      }).then(() => {
+        window.location.href = '/'
+      })
+
+    }}
+    onLogout={() => {console.log('exit edit mode')}}
+  ><Component {...pageProps} />)
+}
+
+//...
+
+```
+
+This Next implementation relies on a backend function to save its auth details.
+
+```tsx
+// /pages/api/preview.ts
+import Cookies from 'cookies'
+
+const preview = (req: any, res: any) => {
+  const token = (req.headers['authorization'] || '').split(' ')[1] || null
+
+  res.setPreviewData({})
+
+  const cookies = new Cookies(req, res)
+  cookies.set('tinaio_token', token, {
+    httpOnly: true,
+  })
+
+  res.end('Preview mode enabled')
+}
+
+export default preview
+```
+
+The last step is to add a way for the user to enter edit-mode. Let's create a `/login` page.
+
+```tsx
+// /pages/login.tsx
+import { useCMS } from 'tinacms'
+
+export default function Login(props) {
+  const cms = useCMS()
+
+  return (
+    <button onClick={() => cms.toggle()}>
+      {cms.enabled ? 'Exit Edit Mode' : 'Edit This Site'}
+    </button>
+  )
+}
+```
+
+Your users should at this point be able to login and view their content from Tina.io's API. We will also want the site to build outside of edit-mode, for your production content.
+
+#### Creating a local GraphQL server
+
+Now that we've defined our schema, let's use the CLI to setup a GraphQL server for our site to use locally, or during production builds.
+
+**Start your local GraphQL server by running:**
+
+```bash
+npx tina-gql server:start
+```
+
+or
+
+```bash
+yarn tina-gql server:start
+```
+
+**pages/welcome.tsx**
+
+```tsx
+import { useGraphqlForms, LocalClient } from "tina-graphql-gateway";
+// These are your generated types from CLI
+import type * as Tina from "../.tina/types";
+
+interface ContentQueryResponse {
+  getDocument: Tina.SectionDocumentUnion;
+}
+
+interface QueryVars {
+  relativePath: string;
+  section: string;
+}
+
+const query = (gql) => gql`
+  query ContentQuery($section: String!, $relativePath: String!) {
+    getDocument(section: $section, relativePath: $relativePath) {
+      __typename
+      ... on Pages_Document {
+        data {
+          ... on Page_Doc_Data {
+            name
+          }
+        }
+      }
+    }
+  }
+`;
+
+export async function getServerSideProps({ params }) {
+  const client = new LocalClient();
+
+  export const request = async (
+    client: Client,
+    variables: { section: string; relativePath: string }
+  ) => {
+    const queryVars = {
+      relativePath: "welcome.md",
+      section: "pages",
+    };
+    const content = await client.requestWithForm(query, {
+      variables: queryVars,
+    });
+
+    return { props: { content, queryVars } };
+  };
+}
+
+export default function Page(props: {
+  content: ContentQueryResponse;
+  queryVars: QueryVars;
+}) {
+  const [response, isLoading] = useGraphqlForms<ContentQueryResponse>({
+    query,
+    variables: props.queryVars,
+  });
+
+  // initialize with production content & hydrate with development content once loaded
+  const docData = isLoading ? props.content.getDocument : response.getDocument;
+
+  return <MyComponent {...docData} />;
+}
+```
+
+Now, if you navigate to [/pages/welcome](http://localhost:3000/pages/welcome) you should see your production content. Once you log-in, you should also be able to update your content using the TinaCMS sidebar.
+
+> TIP: If you have a GraphQL client like [Altair](https://altair.sirmuel.design/), you can explore your graph at `http://localhost:4001/graphql`
+
+Next steps:
+
+- Make changes to our data-model, and verify our templates with `$ tina-gql schema:audit`
+- Setup typescript types for your data-model
+
+## Token storage
+
+There are a few ways to store the authentication token:
+
+### Local storage (Default)
+
+Storing tokens in browser local storage persists the user session between refreshes & across browser tabs. One thing to note is; if an attacker is able to inject code in your site using a cross-site scripting (XSS) attack, your token would be vulernable.
+To add extra security, a CSRF token can be implemented by using a proxy.
+
+Within your client instantiation:
+
+```ts
+new Client({
+  // ...
+  identityProxy: '/api/auth/token',
+})
+```
+
+From your site's server (This example uses NextJS's API functions)
+
+```ts
+// pages/api/auth/token
+
+// ... Example coming soon
+```
+
+### In memory (Coming soon)
+
+This is our recommended token storage mechanism if possible. Storing tokens in memory means that the user session will not be persisted between refreshes or across browser tabs. This approach does not require a server to handle auth, and is the least vulnerable to attacks.
+
+## TypeScript and GraphQL Schema
+
+We can automatically generate TypeScript types based on your schema by running the following command with the Tina Cloud CLI:
+
+```bash
+yarn tina-gql schema:types
+```
+
+This will create a TypeScript file at `.tina/types.ts` and a GraphQL schema file at `.tina/schema.gql`. The GraphQL schema file is useful for VS Code users who have the [GraphQL extension](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql). You can configure it for your project by adding a `graphql.config.js` at the root of your project:
+
+```js
+// graphql.config.js
+module.exports = {
+  projects: {
+    app: {
+      schema: ['.tina/schema.gql'],
+      documents: 'pages/**/*.{graphql,js,ts,jsx,tsx}', // wherever you intend to use the GraphQL client
+    },
+  },
+}
+```
+
+# Conceptual Overview
+
+The goal of this package is to give developers the ability to automatically build Tina forms based on the data they're querying for. To that end this package is responsible for 2 things: Data fetching from the GraphQL API and connecting that data to a Tina form.
+
+## Data-fetching:
+
+```ts
+const query = gql => gql`
+  query ContentQuery($section: String!, $relativePath: String!) {
+    getDocument(section: $section, relativePath: $relativePath) {
+      __typename
+      ... on Authors_Document {
+        data {
+          __typename
+          ... on Author_Doc_Data {
+            name
+          }
+        }
+      }
+    }
+  }
+`
+const variables = {
+  relativePath: 'welcome.md',
+  section: 'pages',
+}
+const payload = await client.requestWithForm(query, {
+  variables,
+})
+```
+
+Note the function name `requestWithForm` - this will take your query and "hydrate" it with additional fields needed by Tina. We also expose a `request` function, which won't add any Tina form fields.
+
+> It may be desirable to support other GraphQL clients like Apollo in the future, there's not much stopping us from doing this, but for simplicity, we're using `fetch` and not doing any caching or normalization on the client.
+
+### Using the data on your site
+
+As you can see there's nothing particularly special about this process - you query for data, pass it to your components, and render it out as you would with any other Headless CMS with a GraphQL API. Maintaining this workflow is one of the goals of this project, we'd like for it to be just as capable as any other CMS in that sense. However since we have a 100% type-safe schema that represents all of your content models, it means we can take things a bit further...
+
+## Connecting to Tina forms
+
+When working with Tina, you'll inevitably face a fork in the road: save content to a CMS, or use a free-form data store like `.json` or `.md` files. The tradeoffs are many, but a few things jump out as big questions you'll need to answer:
+
+### Using free-form data stores
+
+Pros:
+
+- It's quick and easy to get started
+- The Tina form config is the single source of truth for the shape of my data.
+
+Cons:
+
+- How will I ensure my data is valid?
+- How will I connect pieces of content?
+- ... and many other questions which led to the existence of CMSs in the first place
+
+### Using a CMS
+
+Pros:
+
+- You get all of the power of a CMS while making it easy to maintain for your editors.
+
+Cons:
+
+- You need to duplicate your content model definitions as Tina forms, and you need to make sure they generate the same data types.
+- You'll need a form for each record you fetch, and in many CMSs this is abstracted away behind a GraphQL API (more on this below)
+
+We hope to offer the best of both options, using Tina forms while still having a single source of truth and the full power of a proper CMS all wrapped up under an expressive GraphQL API.
+
+So to continue on with the code samples from above, passing the query and variables into the `useGraphqlForms` hook will initialize a form for each node in the query:
+
+```ts
+import { useGraphqlForms, useDocumentCreatorPlugin } from 'tina-graphql-gateway'
+
+//...
+
+const [result, isLoading] = useGraphqlForms({
+  query: query,
+  variables: variables,
+})
+
+// adds a document creator plugin for adding new documents based on your section configuration
+useDocumentCreatorPlugin({
+  // When creating a new document, you'll likely want to redirect the user to it.
+  // `args` provides information about the file you've created and the section it belongs to.
+  onNewDocument: args => {
+    window.location.assign(myPathGenerator(args))
+  },
+})
+```
+
+The `result` variable here will have the identical data that you passed in from the `payload` variable, but as a side-effect we've generated Tina forms for each document node in your query and registered them with the CMS context.
+
+---
+
+## Why don't we use the `useForm` hook from `tinacms`?
+
+If you're familiar with TinaCMS you'll notice that this looks similar to the hook it provides, but there are some slight differences:
+
+With the TinaCMS hook:
+
+- We pass the form config as an argument
+- The sidebar isn't automatically registered
+- The values we get back are **form** values
+
+With the `tina-graphql-gateway` hook:
+
+- We don't need to set any form configuration (this is already done in your template definitions), instead we passed our query.
+- The sidebar is automatically registered
+
+The key benefit here is you'll receive the data you queried for, meaning you don't need to do anything special for your content to work with Tina.
+
+### Under the hood
+
+When the hook receives a result from `requestWithForm`, there are additional fields that reflect what you would pass into Tina's [form configuration](https://tina.io/docs/plugins/forms/#form-configuration). Instead of requiring you to provide this (and force you to deal with multiple sources of truth), we initialize the form for you with all of the fields being built automatically.
+
+### Keeping the benefits of GraphQL
+
+GraphQL APIs resolve content relationships (like a graph!), this capability leads to some friction when you're building the form yourself. If you expect to query across relationships:
+
+```graphql
+{
+  getDocument(...) {
+    ...on Post_Document {
+      data {
+        ...on Post_Doc_Data {
+          title
+          # author is a reference to a separate document
+          author {
+            id
+            ...on Author_Document {
+              data {
+                ...on Author_Doc_Data {
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+How would this look as forms in Tina? We'd need to know that `author` is actually referencing another node, and we'd need to split our response into multiple forms. The `post` form would need to treat the `author` field as a reference (perhaps a select field with all possible "authors"), while the `author` from would be where you can alter the author's data. And to make things more difficult, when the `post` form changes its `author` value, you'll have to refetch the author data from the server and recreate that form.
+
+```ts
+const postFormConfig = {
+  ...
+  fields: [
+    {
+      name: 'title',
+      label: 'Title',
+      component: 'text',
+    },
+    {
+      name: 'author',
+      label: 'Author',
+      component: 'select',
+      options: [
+        'path-to-author1.md',
+        'path-to-author2.md',
+      ]
+    }
+  ],
+  initialValues: {
+    title: payload.getDocument.data.title,
+    // changes to this value mean we need to reset the `authorForm` with new data from the server
+    author: payload.getDocument.data.author.id
+  },
+}
+const authorFormConfig = {
+  ...
+  fields: [
+    {
+      name: 'name',
+      label: 'Name',
+      component: 'text',
+    },
+  ],
+  initialValues: {
+    name: payload.getDocument.data.author.data.name
+  },
+}
+const [modifiedPostValues, postForm] = useForm(postFormConfig)
+const [modifiedAuthorValues, authorForm] = useForm(authorFormConfig)
+```
+
+But when the `postForm`'s `author` field changes, the author form would be for the wrong author! So we'll have to connect those manually and refetch the author data from the server on each change. As you can see this is pretty cumbersome, and it unwinds any benefit we had from GraphQL in the first place.
+
+We're referring to this as "The Author Problem", and it gets to the core of why we've found it useful to do the heavy lifting of Tina configuration automatically.
+
+### What about field customization?
+
+Since Tina gives you full control over your field components, you'll inevitably want to make some changes to provided field types or bring your own components entirely. This isn't currently possible but we're exploring where we'd like to put this logic. In general the `useForm` hook from `tina-gateway` should be able to compose anything the developer would like to provide while still orchestrating the form building automatically.
+
+### What if I don't like GraphQL?
+
+GraphQL is at the center of our solution, it's strict types are what allow us to generate a Tina form based on your `.tina` config, however using GraphQL for your website isn't for everyone - and we don't intend to make it mandatory. For now, the only way to work with the Content API is through GraphQL queries, but we hope to improve this package to the point that it's able to work without requiring the developer to write GraphQL if they don't want to.
+
+An example of how this might look:
+
+```ts
+client.query.author('path-to-author.md')
+// getting relational data
+client.query.post('path-to-post.md').include('author')
+// or making a mutation
+client.mutation.post('path-to-post.md', {
+  data: {
+    some: 'data',
+  },
+})
+```

--- a/content/docs/tina-cloud/dashboard.md
+++ b/content/docs/tina-cloud/dashboard.md
@@ -1,0 +1,27 @@
+---
+title: Tina Cloud Dashboard
+---
+
+The **Tina Cloud Dashboard** is the interface for managing the administrative aspects of content management. The dashboard allows you to create **organizations**, **apps**, and **users**.
+
+> Unlike most other Headless CMS providers, the Tina Cloud dashboard is not used for editing content. Content is edited directly on your website via a TinaCMS integration.
+
+## Apps
+
+**Apps** connect Tina Cloud with a GitHub repository. An app is the **connection point between your site and your users**, allowing authorized users to access and modify a site's content.
+
+To setup an app on the Tina Cloud dashboard, you must first authenticate with GitHub. A window will open asking you to give Tina.io access to your repositories. If you are not already logged in, your provider will prompt you for login credentials first. This authentication allows Tina Cloud to pull and push content to and from your GitHub respositiory.
+
+The next step is to choose the repository that houses your site's content. If you don't see your repository within the list of repositories on the dashboard, you may have to re-configure your Tina.io permissions within GitHub. Finally, give the app a name, or keep the default. This name will be shown to your users when they login to the app.
+
+Once this initial authorization is done, your users will be able to log in directly to an App from within your site without the need to authenticate with GitHub or use the Tina Cloud dashboard.
+
+## Organizations
+
+An organization connects users (developers, editors, content creators, etc.) and apps through the Tina Cloud dashboard.
+
+In order to use the Tina Cloud dashboard, you must first register an organization. To do so, navigate to the [Tina.io Registration Page](https://auth.tinajs.dev/register). Enter your organization name and your personal login credentials. Once your account is verified, you will be able to access the dashboard.
+
+From an organization level, you can add, edit and delete both apps and users.
+
+> When creating an organization, take note of your `organization-id` as this will be required when implementing your site(s).

--- a/content/docs/tinacms.md
+++ b/content/docs/tinacms.md
@@ -1,0 +1,48 @@
+---
+title: TinaCMS
+id: '/docs/tinacms'
+---
+
+Tina is a **toolkit for building visual editing** into your site. By creating a custom editing experience with Tina instead of opting for a conventional CMS, developers can give their teams a contextual, intuitive editing experience without sacrificing code quality.
+
+## First Steps
+
+Are you new to using Tina to build content management systems? Start with these resources to build your understanding of Tina and what's possible.
+
+- Go through the [Getting Started Tutorial](/docs/getting-started/introduction 'Getting Started').
+- Click **Edit this Site** at the bottom of the page to fork the [tinacms.org repository](https://github.com/tinacms/tinacms.org 'Tinacms.org Repository'), make changes, and then open a Pull Request!
+- Checkout [this video of a page builder](https://youtu.be/4qGz0cP_DSA 'Inline Editing Demo Video') created with TinaCMS.
+
+## Getting Help
+
+Have questions on how to use Tina to build your CMS?
+
+- Visit the [Tina Forum](https://community.tinacms.org 'Tina Forum') to engage with the core team and community.
+- Report bugs using [GitHub Issues](https://github.com/tinacms/tinacms/issues 'Tina Github Issues')
+- [FAQ](/docs/getting-started/faq)
+
+## Constructing The User Interface
+
+Tina lets you choose the user interface that best fits your workflow. You can use one of its default interfaces or construct your own. You can even build editing capabilities directly into your page!
+
+- Learn about the [Toolbar](/docs/ui#toolbar-configuration 'Tina Toolbar') and [Sidebar](/docs/ui#sidebar-configuration 'Tina Sidebar') UI components.
+- Take control of the appearance of your CMS using [Custom Styling](/docs/ui/styles 'Styles')
+- Add features to your CMS using [Screen Plugins](/docs/plugins/screens 'Screen Plugins') and [Toolbar Widgets](/docs/plugins/toolbar-widgets).
+- Wander off the beaten trail and create a totally custom UI _(Coming Soon)_
+
+## Tools for Managing Content
+
+Tina gives you the tools you need to manage content from the data source of your choosing. These docs will show you how to craft your ideal content editing experience.
+
+- **Editing Content:** [Creating Forms](/docs/plugins/forms), [Fields](/docs/plugins/fields),[ Custom Fields](/docs/plugins/fields/custom-fields), [Inline Editing](/docs/ui/inline-editing), [Working with Inline Blocks](/guides//general/inline-blocks/overview)
+- **Creating Content:** Using [Content Creators](/docs/plugins/content-creators)
+- **Deleting Content:** Using Form Actions. _(Coming Soon)_
+- **Media Management:** [Media Stores](/docs/media 'Tina Media Store'), [Image Fields](/docs/plugins/fields/image 'Image Field Plugin'), [Inline Images](/docs/ui/inline-editing/inline-image 'Inline Images')
+- **Custom Fields:** [How to Make a Custom Field Component](/blog/custom-field-components)
+
+## Integrating with React Frameworks
+
+Tina is designed to work with just about any React framework. Once you're comfortable with the basics of TinaCMS, these guides will help you learn the specifics of building a CMS with Next.js or Gatsby.
+
+- [Next.js](/docs/integrations/nextjs)
+- [Gatsby](/docs/integrations/gatsby)

--- a/content/toc-doc.json
+++ b/content/toc-doc.json
@@ -367,14 +367,19 @@
     "description": "Powerful Git-based content management for teams",
     "items": [
       {
+        "id": "/docs/tina-cloud",
+        "slug": "/docs/tina-cloud",
+        "title": "Overview"
+      },
+      {
         "id": "/docs/tina-cloud/dashboard",
         "slug": "/docs/tina-cloud/dashboard",
-        "title": "Using the Dashboard"
+        "title": "Dashboard"
       },
       {
         "id": "/docs/tina-cloud/client",
         "slug": "/docs/tina-cloud/client",
-        "title": "Using the Client"
+        "title": "Client"
       },
       {
         "id": "/docs/tina-cloud/CLI",

--- a/content/toc-doc.json
+++ b/content/toc-doc.json
@@ -1,275 +1,386 @@
 [
   {
-    "title": "Getting Started",
-    "id": "getting-started",
+    "category": "TinaCMS",
+    "description": "The JavaScript toolkit for building content management interfaces",
     "items": [
       {
-        "id": "/docs/getting-started/introduction",
-        "slug": "/docs/getting-started/introduction",
-        "title": "Introduction"
-      },
-      {
-        "id": "/docs/getting-started/cms-set-up",
-        "slug": "/docs/getting-started/cms-set-up",
-        "title": "Set Up the CMS"
-      },
-      {
-        "id": "/docs/getting-started/edit-content",
-        "slug": "/docs/getting-started/edit-content",
-        "title": "Edit Content"
-      },
-      {
-        "id": "/docs/getting-started/backends",
-        "slug": "/docs/getting-started/backends",
-        "title": "Backends"
-      },
-      {
-        "id": "/docs/getting-started/faq",
-        "slug": "/docs/getting-started/faq",
-        "title": "FAQ"
-      }
-    ]
-  },
-  {
-    "title": "CMS",
-    "id": "the-cms",
-    "items": [{ "id": "/docs/cms", "slug": "/docs/cms", "title": "Overview" }]
-  },
-  {
-    "title": "User Interface",
-    "id": "user-interface",
-    "items": [
-      {
-        "id": "/docs/ui",
-        "title": "Sidebar & Toolbar",
-        "slug": "/docs/ui"
-      },
-      {
-        "title": "Inline Editing",
-        "id": "inline-editing",
-        "slug": "/docs/ui/inline-editing",
+        "title": "Getting Started",
+        "id": "getting-started",
         "items": [
           {
-            "id": "/docs/ui/inline-editing/inline-text",
-            "title": "Inline Text",
-            "slug": "/docs/ui/inline-editing/inline-text"
+            "id": "/docs/getting-started/introduction",
+            "slug": "/docs/getting-started/introduction",
+            "title": "Introduction"
           },
           {
-            "id": "/docs/ui/inline-editing/inline-textarea",
-            "title": "Inline Textarea",
-            "slug": "/docs/ui/inline-editing/inline-textarea"
+            "id": "/docs/getting-started/cms-set-up",
+            "slug": "/docs/getting-started/cms-set-up",
+            "title": "Set Up the CMS"
           },
           {
-            "id": "/docs/ui/inline-editing/inline-wysiwyg",
-            "title": "Inline Wysiwyg",
-            "slug": "/docs/ui/inline-editing/inline-wysiwyg"
+            "id": "/docs/getting-started/edit-content",
+            "slug": "/docs/getting-started/edit-content",
+            "title": "Edit Content"
           },
           {
-            "id": "/docs/ui/inline-editing/inline-image",
-            "title": "Inline Image",
-            "slug": "/docs/ui/inline-editing/inline-image"
+            "id": "/docs/getting-started/backends",
+            "slug": "/docs/getting-started/backends",
+            "title": "Backends"
           },
           {
-            "id": "/docs/ui/inline-editing/inline-group",
-            "title": "Inline Group",
-            "slug": "/docs/ui/inline-editing/inline-group"
-          },
-          {
-            "id": "/docs/ui/inline-editing/inline-blocks",
-            "title": "Inline Blocks",
-            "slug": "/docs/ui/inline-editing/inline-blocks"
+            "id": "/docs/getting-started/faq",
+            "slug": "/docs/getting-started/faq",
+            "title": "FAQ"
           }
         ]
       },
       {
-        "id": "/docs/ui/alerts",
-        "title": "Alerts",
-        "slug": "/docs/ui/alerts"
+        "title": "CMS",
+        "id": "the-cms",
+        "items": [
+          { "id": "/docs/cms", "slug": "/docs/cms", "title": "Overview" }
+        ]
       },
       {
-        "id": "/docs/ui/styles",
-        "title": "Custom Styles",
-        "slug": "/docs/ui/styles"
-      }
-    ]
-  },
-  {
-    "id": "plugins",
-    "title": "Plugins",
-    "items": [
-      {
-        "title": "About Plugins",
-        "id": "forms",
-        "slug": "/docs/plugins"
-      },
-      {
-        "title": "Forms",
-        "id": "forms",
-        "slug": "/docs/plugins/forms"
-      },
-      {
-        "title": "Fields",
-        "id": "fields",
-        "slug": "/docs/plugins/fields",
+        "title": "User Interface",
+        "id": "user-interface",
         "items": [
           {
-            "id": "/docs/plugins/fields/text",
-            "slug": "/docs/plugins/fields/text",
-            "title": "Text"
+            "id": "/docs/ui",
+            "title": "Sidebar & Toolbar",
+            "slug": "/docs/ui"
           },
           {
-            "id": "/docs/plugins/fields/textarea",
-            "slug": "/docs/plugins/fields/textarea",
-            "title": "Text Area"
-          },
-
-          {
-            "id": "/docs/plugins/fields/number",
-            "slug": "/docs/plugins/fields/number",
-            "title": "Number"
-          },
-
-          {
-            "id": "/docs/plugins/fields/image",
-            "slug": "/docs/plugins/fields/image",
-            "title": "Image"
-          },
-          {
-            "id": "/docs/plugins/fields/color",
-            "slug": "/docs/plugins/fields/color",
-            "title": "Color"
-          },
-          {
-            "id": "/docs/plugins/fields/toggle",
-            "slug": "/docs/plugins/fields/toggle",
-            "title": "Toggle"
-          },
-          {
-            "id": "/docs/plugins/fields/radio-group",
-            "slug": "/docs/plugins/fields/radio-group",
-            "title": "Radio Group"
-          },
-          {
-            "id": "/docs/plugins/fields/select",
-            "slug": "/docs/plugins/fields/select",
-            "title": "Select"
-          },
-          {
-            "id": "/docs/plugins/fields/tags",
-            "slug": "/docs/plugins/fields/tags",
-            "title": "Tags"
+            "title": "Inline Editing",
+            "id": "inline-editing",
+            "slug": "/docs/ui/inline-editing",
+            "items": [
+              {
+                "id": "/docs/ui/inline-editing/inline-text",
+                "title": "Inline Text",
+                "slug": "/docs/ui/inline-editing/inline-text"
+              },
+              {
+                "id": "/docs/ui/inline-editing/inline-textarea",
+                "title": "Inline Textarea",
+                "slug": "/docs/ui/inline-editing/inline-textarea"
+              },
+              {
+                "id": "/docs/ui/inline-editing/inline-wysiwyg",
+                "title": "Inline Wysiwyg",
+                "slug": "/docs/ui/inline-editing/inline-wysiwyg"
+              },
+              {
+                "id": "/docs/ui/inline-editing/inline-image",
+                "title": "Inline Image",
+                "slug": "/docs/ui/inline-editing/inline-image"
+              },
+              {
+                "id": "/docs/ui/inline-editing/inline-group",
+                "title": "Inline Group",
+                "slug": "/docs/ui/inline-editing/inline-group"
+              },
+              {
+                "id": "/docs/ui/inline-editing/inline-blocks",
+                "title": "Inline Blocks",
+                "slug": "/docs/ui/inline-editing/inline-blocks"
+              }
+            ]
           },
           {
-            "id": "/docs/plugins/fields/list",
-            "slug": "/docs/plugins/fields/list",
-            "title": "List"
+            "id": "/docs/ui/alerts",
+            "title": "Alerts",
+            "slug": "/docs/ui/alerts"
           },
           {
-            "id": "/docs/plugins/fields/group",
-            "slug": "/docs/plugins/fields/group",
-            "title": "Group"
-          },
-          {
-            "id": "/docs/plugins/fields/group-list",
-            "slug": "/docs/plugins/fields/group-list",
-            "title": "Group List"
-          },
-          {
-            "id": "/docs/plugins/fields/blocks",
-            "slug": "/docs/plugins/fields/blocks",
-            "title": "Blocks"
-          },
-          {
-            "id": "/docs/plugins/fields/date",
-            "slug": "/docs/plugins/fields/date",
-            "title": "Date & Time"
-          },
-          {
-            "id": "/docs/plugins/fields/markdown",
-            "slug": "/docs/plugins/fields/markdown",
-            "title": "Markdown"
-          },
-          {
-            "id": "/docs/plugins/fields/html",
-            "slug": "/docs/plugins/fields/html",
-            "title": "HTML"
-          },
-          {
-            "id": "/docs/plugins/fields/custom-fields",
-            "slug": "/docs/plugins/fields/custom-fields",
-            "title": "Custom Fields"
+            "id": "/docs/ui/styles",
+            "title": "Custom Styles",
+            "slug": "/docs/ui/styles"
           }
         ]
       },
       {
-        "title": "Content Creators",
-        "id": "content-creator",
-        "slug": "/docs/plugins/content-creators"
+        "id": "plugins",
+        "title": "Plugins",
+        "items": [
+          {
+            "title": "About Plugins",
+            "id": "forms",
+            "slug": "/docs/plugins"
+          },
+          {
+            "title": "Forms",
+            "id": "forms",
+            "slug": "/docs/plugins/forms"
+          },
+          {
+            "title": "Fields",
+            "id": "fields",
+            "slug": "/docs/plugins/fields",
+            "items": [
+              {
+                "id": "/docs/plugins/fields/text",
+                "slug": "/docs/plugins/fields/text",
+                "title": "Text"
+              },
+              {
+                "id": "/docs/plugins/fields/textarea",
+                "slug": "/docs/plugins/fields/textarea",
+                "title": "Text Area"
+              },
+
+              {
+                "id": "/docs/plugins/fields/number",
+                "slug": "/docs/plugins/fields/number",
+                "title": "Number"
+              },
+
+              {
+                "id": "/docs/plugins/fields/image",
+                "slug": "/docs/plugins/fields/image",
+                "title": "Image"
+              },
+              {
+                "id": "/docs/plugins/fields/color",
+                "slug": "/docs/plugins/fields/color",
+                "title": "Color"
+              },
+              {
+                "id": "/docs/plugins/fields/toggle",
+                "slug": "/docs/plugins/fields/toggle",
+                "title": "Toggle"
+              },
+              {
+                "id": "/docs/plugins/fields/radio-group",
+                "slug": "/docs/plugins/fields/radio-group",
+                "title": "Radio Group"
+              },
+              {
+                "id": "/docs/plugins/fields/select",
+                "slug": "/docs/plugins/fields/select",
+                "title": "Select"
+              },
+              {
+                "id": "/docs/plugins/fields/tags",
+                "slug": "/docs/plugins/fields/tags",
+                "title": "Tags"
+              },
+              {
+                "id": "/docs/plugins/fields/list",
+                "slug": "/docs/plugins/fields/list",
+                "title": "List"
+              },
+              {
+                "id": "/docs/plugins/fields/group",
+                "slug": "/docs/plugins/fields/group",
+                "title": "Group"
+              },
+              {
+                "id": "/docs/plugins/fields/group-list",
+                "slug": "/docs/plugins/fields/group-list",
+                "title": "Group List"
+              },
+              {
+                "id": "/docs/plugins/fields/blocks",
+                "slug": "/docs/plugins/fields/blocks",
+                "title": "Blocks"
+              },
+              {
+                "id": "/docs/plugins/fields/date",
+                "slug": "/docs/plugins/fields/date",
+                "title": "Date & Time"
+              },
+              {
+                "id": "/docs/plugins/fields/markdown",
+                "slug": "/docs/plugins/fields/markdown",
+                "title": "Markdown"
+              },
+              {
+                "id": "/docs/plugins/fields/html",
+                "slug": "/docs/plugins/fields/html",
+                "title": "HTML"
+              },
+              {
+                "id": "/docs/plugins/fields/custom-fields",
+                "slug": "/docs/plugins/fields/custom-fields",
+                "title": "Custom Fields"
+              }
+            ]
+          },
+          {
+            "title": "Content Creators",
+            "id": "content-creator",
+            "slug": "/docs/plugins/content-creators"
+          },
+          {
+            "title": "Screens",
+            "id": "screens",
+            "slug": "/docs/plugins/screens"
+          },
+          {
+            "title": "Toolbar Widgets",
+            "id": "toolbar:widget",
+            "slug": "/docs/plugins/toolbar-widgets"
+          }
+        ]
       },
       {
-        "title": "Screens",
-        "id": "screens",
-        "slug": "/docs/plugins/screens"
+        "id": "events",
+        "title": "Events",
+        "items": [
+          {
+            "id": "/docs/events",
+            "slug": "/docs/events",
+            "title": "About Events"
+          }
+        ]
       },
       {
-        "title": "Toolbar Widgets",
-        "id": "toolbar:widget",
-        "slug": "/docs/plugins/toolbar-widgets"
-      }
-    ]
-  },
-  {
-    "id": "events",
-    "title": "Events",
-    "items": [
-      {
-        "id": "/docs/events",
-        "slug": "/docs/events",
-        "title": "About Events"
-      }
-    ]
-  },
-  {
-    "title": "Media",
-    "id": "media",
-    "items": [
-      {
-        "id": "/docs/media",
-        "slug": "/docs/media",
-        "title": "About Media"
-      }
-    ]
-  },
-  {
-    "id": "apis",
-    "title": "External APIs",
-    "items": [
-      {
-        "id": "/docs/api",
-        "slug": "/docs/apis",
-        "title": "About APIs"
-      }
-    ]
-  },
-  {
-    "title": "Integrations",
-    "id": "nextjs",
-    "items": [
-      {
-        "id": "/docs/integrations/nextjs",
-        "slug": "/docs/integrations/nextjs",
-        "title": "Next.js"
+        "title": "Media",
+        "id": "media",
+        "items": [
+          {
+            "id": "/docs/media",
+            "slug": "/docs/media",
+            "title": "About Media"
+          }
+        ]
       },
       {
-        "id": "/docs/integrations/gatsby",
-        "slug": "/docs/integrations/gatsby",
-        "title": "Gatsby"
+        "id": "apis",
+        "title": "External APIs",
+        "items": [
+          {
+            "id": "/docs/api",
+            "slug": "/docs/apis",
+            "title": "About APIs"
+          }
+        ]
+      },
+      {
+        "title": "Integrations",
+        "id": "nextjs",
+        "items": [
+          {
+            "id": "/docs/integrations/nextjs",
+            "slug": "/docs/integrations/nextjs",
+            "title": "Next.js"
+          },
+          {
+            "id": "/docs/integrations/gatsby",
+            "slug": "/docs/integrations/gatsby",
+            "title": "Gatsby"
+          }
+        ]
+      },
+      {
+        "title": "Release Notes",
+        "id": "releases",
+        "items": [
+          {
+            "id": "/docs/releases",
+            "href": "/docs/releases",
+            "title": "All Releases"
+          }
+        ]
+      },
+      {
+        "title": "Packages",
+        "id": "packages",
+        "items": [
+          {
+            "id": "/packages",
+            "slug": "/packages",
+            "title": "All Packages"
+          },
+          {
+            "id": "/packages/react-tinacms-date",
+            "slug": "/packages/react-tinacms-date",
+            "title": "react-tinacms-date"
+          },
+          {
+            "id": "/packages/react-tinacms-editor",
+            "slug": "/packages/react-tinacms-editor",
+            "title": "react-tinacms-editor"
+          },
+          {
+            "id": "/packages/react-tinacms-github",
+            "slug": "/packages/react-tinacms-github",
+            "title": "react-tinacms-github"
+          },
+          {
+            "id": "/packages/react-tinacms-inline",
+            "slug": "/packages/react-tinacms-inline",
+            "title": "react-tinacms-inline"
+          },
+          {
+            "id": "/packages/react-tinacms-strapi",
+            "slug": "/packages/react-tinacms-strapi",
+            "title": "react-tinacms-strapi"
+          },
+          {
+            "id": "/packages/next-tinacms-github",
+            "slug": "/packages/next-tinacms-github",
+            "title": "next-tinacms-github"
+          },
+          {
+            "id": "/packages/next-tinacms-json",
+            "slug": "/packages/next-tinacms-json",
+            "title": "next-tinacms-json"
+          },
+          {
+            "id": "/packages/next-tinacms-markdown",
+            "slug": "/packages/next-tinacms-markdown",
+            "title": "next-tinacms-markdown"
+          },
+          {
+            "id": "/packages/gatsby-plugin-tinacms",
+            "slug": "/packages/gatsby-plugin-tinacms",
+            "title": "gatsby-plugin-tinacms"
+          },
+          {
+            "id": "/packages/gatsby-tinacms-git",
+            "slug": "/packages/gatsby-tinacms-git",
+            "title": "gatsby-tinacms-git"
+          },
+          {
+            "id": "/packages/gatsby-tinacms-json",
+            "slug": "/packages/gatsby-tinacms-json",
+            "title": "gatsby-tinacms-json"
+          },
+          {
+            "id": "/packages/gatsby-tinacms-remark",
+            "slug": "/packages/gatsby-tinacms-remark",
+            "title": "gatsby-tinacms-remark"
+          }
+        ]
       }
     ]
   },
   {
-    "title": "Guides",
-    "id": "guides",
+    "category": "Tina Cloud",
+    "description": "Powerful Git-based content management for teams",
+    "items": [
+      {
+        "id": "/docs/tina-cloud/dashboard",
+        "slug": "/docs/tina-cloud/dashboard",
+        "title": "Using the Dashboard"
+      },
+      {
+        "id": "/docs/tina-cloud/client",
+        "slug": "/docs/tina-cloud/client",
+        "title": "Using the Client"
+      },
+      {
+        "id": "/docs/tina-cloud/CLI",
+        "slug": "/docs/tina-cloud/CLI",
+        "title": "Command Line Interface"
+      }
+    ]
+  },
+  {
+    "category": "Guides",
+    "description": "Learn to use Tina step-by-step",
     "items": [
       {
         "id": "/guides",
@@ -331,88 +442,6 @@
             "title": "Git Backend"
           }
         ]
-      }
-    ]
-  },
-  {
-    "title": "Release Notes",
-    "id": "releases",
-    "items": [
-      {
-        "id": "/docs/releases",
-        "href": "/docs/releases",
-        "title": "All Releases"
-      }
-    ]
-  },
-  {
-    "title": "Packages",
-    "id": "packages",
-    "items": [
-      {
-        "id": "/packages",
-        "slug": "/packages",
-        "title": "All Packages"
-      },
-      {
-        "id": "/packages/react-tinacms-date",
-        "slug": "/packages/react-tinacms-date",
-        "title": "react-tinacms-date"
-      },
-      {
-        "id": "/packages/react-tinacms-editor",
-        "slug": "/packages/react-tinacms-editor",
-        "title": "react-tinacms-editor"
-      },
-      {
-        "id": "/packages/react-tinacms-github",
-        "slug": "/packages/react-tinacms-github",
-        "title": "react-tinacms-github"
-      },
-      {
-        "id": "/packages/react-tinacms-inline",
-        "slug": "/packages/react-tinacms-inline",
-        "title": "react-tinacms-inline"
-      },
-      {
-        "id": "/packages/react-tinacms-strapi",
-        "slug": "/packages/react-tinacms-strapi",
-        "title": "react-tinacms-strapi"
-      },
-      {
-        "id": "/packages/next-tinacms-github",
-        "slug": "/packages/next-tinacms-github",
-        "title": "next-tinacms-github"
-      },
-      {
-        "id": "/packages/next-tinacms-json",
-        "slug": "/packages/next-tinacms-json",
-        "title": "next-tinacms-json"
-      },
-      {
-        "id": "/packages/next-tinacms-markdown",
-        "slug": "/packages/next-tinacms-markdown",
-        "title": "next-tinacms-markdown"
-      },
-      {
-        "id": "/packages/gatsby-plugin-tinacms",
-        "slug": "/packages/gatsby-plugin-tinacms",
-        "title": "gatsby-plugin-tinacms"
-      },
-      {
-        "id": "/packages/gatsby-tinacms-git",
-        "slug": "/packages/gatsby-tinacms-git",
-        "title": "gatsby-tinacms-git"
-      },
-      {
-        "id": "/packages/gatsby-tinacms-json",
-        "slug": "/packages/gatsby-tinacms-json",
-        "title": "gatsby-tinacms-json"
-      },
-      {
-        "id": "/packages/gatsby-tinacms-remark",
-        "slug": "/packages/gatsby-tinacms-remark",
-        "title": "gatsby-tinacms-remark"
       }
     ]
   }

--- a/content/toc-doc.json
+++ b/content/toc-doc.json
@@ -4,6 +4,11 @@
     "description": "The JavaScript toolkit for building content management interfaces",
     "items": [
       {
+        "title": "Overview",
+        "id": "/docs/tinacms",
+        "slug": "/docs/tinacms"
+      },
+      {
         "title": "Getting Started",
         "id": "getting-started",
         "items": [


### PR DESCRIPTION
> _Note to curious community members: Tina Cloud is currently in private beta. We are currently working with a small number of users to test out the system. Expect more information on Tina Cloud in the coming weeks!_

This PR introduces documentation for the Tina Cloud service, and a new navigation hierarchy that creates space and logical separation for it. This is heavily assisted by the work @jamespohalloran and @ashleyjanedoiron have done on a prior iteration of Tina Cloud docs. Several things have changed since those docs were written, rendering certain parts no longer correct, and other parts no longer necessary.

The previous iteration divided documentation into three parts:

1. Tina Basics
2. TinaCMS
3. Tina Cloud

Ultimately I felt that the ideas in "Tina Basics" are fundamentally shaped by the TinaCMS toolkit, and creating two separate categories in this way creates a lot of cognitive overhead for newcomers to Tina. Additionally, on a technical note, the previous iteration treated each section as its own area of the site, with its own separate `/docs` route handler. I felt this would introduce some technical debt that would make things harder to untangle later, and instead opted to run everything through the same `/docs` handler such that, for example, the Tina Cloud docs would be available at `/docs/tina-cloud` instead of `/tina-cloud/docs`.

This iteration still has three sections, but they are:

1. TinaCMS Toolkit
2. Tina Cloud
3. Guides

These three categories are tied together with brief descriptions of how they will be useful to developers reading the docs.

Understanding the fundamentals of the TinaCMS Toolkit is a prerequisite to using Tina Cloud effectively. I think it will help reduce the cognitive load for both doc writers and readers if we treat the TinaCMS docs as the springboard into the world of Tina, instead of inserting a higher-level knowledge abstraction to tie things together.


## todos

These docs, as they are currently, are by no means complete or comprehensive. I expect there will be many further modifications this PR before it is merged, as we continue testing Tina Cloud

- [ ] fix navigation behavior in guides
- [ ] condense the two tina cloud guides into a single end-to-end guide
- [ ] evaluate whether ISR would be appropriate for tina-graphql-gateway docs