### PR TITLE
Updates docs for DateFieldPlugin

### DIFF
--- a/components/home/Actions.tsx
+++ b/components/home/Actions.tsx
@@ -19,6 +19,7 @@ export const Actions = ({ items, align = 'left' }) => {
           if (external) {
             link = (
               <a
+                key={`action-${label}`}
                 href={url}
                 className={`action ${variant}`}
                 target="_blank"
@@ -29,7 +30,11 @@ export const Actions = ({ items, align = 'left' }) => {
             )
           } else {
             link = (
-              <a href={url} className={`action ${variant}`}>
+              <a
+                key={`action-${label}`}
+                href={url}
+                className={`action ${variant}`}
+              >
                 {label} {icon === 'arrowRight' && <IconRight />}
               </a>
             )

--- a/components/home/Browser.tsx
+++ b/components/home/Browser.tsx
@@ -50,7 +50,7 @@ export function BrowserBlock({ data, index }) {
           <div className="cardGroup noSpacingMobile">
             {items.map(item => {
               return (
-                <>
+                <React.Fragment key={`item-${item.headline}`}>
                   <Divider type="mobile" />
                   <div
                     className={[
@@ -75,7 +75,7 @@ export function BrowserBlock({ data, index }) {
                       </div>
                     )}
                   </div>
-                </>
+                </React.Fragment>
               )
             })}
           </div>

--- a/components/home/Navbar.tsx
+++ b/components/home/Navbar.tsx
@@ -91,9 +91,7 @@ export function NavbarBlock({ data, index }) {
             <Link href="/">
               <a className="logomark navLogo">
                 <TinaIcon />
-                <h1 className="wordmark">
-                  Tina
-                </h1>
+                <h1 className="wordmark">Tina</h1>
               </a>
             </Link>
             <nav className="navWrapper navNav">
@@ -102,7 +100,7 @@ export function NavbarBlock({ data, index }) {
                   const { link, label } = item
 
                   return (
-                    <li className="navLi">
+                    <li key={`link-${label}`} className="navLi">
                       <Link href={link}>{label}</Link>
                     </li>
                   )

--- a/content/docs/plugins/fields/date.md
+++ b/content/docs/plugins/fields/date.md
@@ -11,7 +11,7 @@ consumes:
 
 The `date` field represents a date and time picker. It can be used for data values that are valid date strings.
 
-> **Prior to v0.40.1, `DateFieldPlugin` was not a default plugin.** See the [react-tinacms-date](/packages/react-tinacms-date) docs for instructions on how to use the `date` field for previous versions.
+> **Prior to v0.41.0, `DateFieldPlugin` was not a default plugin.** See the [react-tinacms-date](/packages/react-tinacms-date) docs for instructions on how to use the `date` field for previous versions.
 
 ![tinacms-date-field](/img/fields/date.jpg)
 

--- a/content/docs/plugins/fields/date.md
+++ b/content/docs/plugins/fields/date.md
@@ -3,14 +3,64 @@ title: Date & Time Field
 prev: /docs/plugins/fields/blocks
 next: /docs/plugins/fields/markdown
 consumes:
-  - file: /packages/tinacms/src/plugins/fields/DateFieldPlugin.tsx
+  - file: /packages/@tinacms/fields/src/plugins/DateFieldPlugin.tsx
     details: Documents how to use the date field plugin
-  - file: /packages/tinacms/src/plugins/fields/dateFormat.ts
+  - file: /packages/@tinacms/fields/src/plugins/dateFormat.ts
     details: References date formatting specifics
 ---
 
 The `date` field represents a date and time picker. It can be used for data values that are valid date strings.
 
-> **The `DateFieldPlugin` is not a default plugin.** See the [react-tinacms-date](/packages/react-tinacms-date) docs for instructions on how to use the `date` field in your website.
+> **Prior to v0.40.1, `DateFieldPlugin` was not a default plugin.** See the [react-tinacms-date](/packages/react-tinacms-date) docs for instructions on how to use the `date` field for previous versions.
 
 ![tinacms-date-field](/img/fields/date.jpg)
+
+## Options
+
+This field plugin uses [`react-datetime`](https://www.npmjs.com/package/react-datetime) under the hood.
+
+```typescript
+interface DateConfig extends FieldConfig, DatetimepickerProps {
+  component: 'date'
+  name: string
+  label?: string
+  description?: string
+  dateFormat?: boolean | string // Extra properties from react-datetime
+  timeFormat?: boolean | string // Moment date format
+}
+```
+
+| Option        | Description                                                                                                                                                                                                                                                                                                                                                                                                               |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `component`   | The name of the plugin component. Always `'date'`.                                                                                                                                                                                                                                                                                                                                                                        |
+| `name`        | The path to some value in the data being edited.                                                                                                                                                                                                                                                                                                                                                                          |
+| `label`       | A human readable label for the field. Defaults to the `name`. _(Optional)_                                                                                                                                                                                                                                                                                                                                                |
+| `description` | Description that expands on the purpose of the field or prompts a specific action. _(Optional)_                                                                                                                                                                                                                                                                                                                           |
+| `dateFormat`  | Defines the format for the date. It accepts any [Moment.js date format](https://momentjs.com/docs/#/displaying/format/) (not in localized format). If true the date will be displayed using the defaults for the current locale. See [react-datetime docs](https://github.com/YouCanBookMe/react-datetime) for more details. _(Optional)_                                                                                 |
+| `timeFormat`  | Defines the format for the time. It accepts any [Moment.js time format](https://momentjs.com/docs/#/displaying/format/) (not in localized format). If true the time will be displayed using the defaults for the current locale. If false the timepicker is disabled and the component can be used as datepicker. See [react-datetime docs](https://github.com/YouCanBookMe/react-datetime) for more details._(Optional)_ |
+
+### FieldConfig
+
+This interfaces only shows the keys unique to the date field.
+
+Visit the [Field Config](https://tinacms.org/docs/plugins/fields) docs for a complete list of options.
+
+### DatetimepickerProps
+
+Any extra properties added to the the `date` field definition will be passed along to the [`react-datettime`](https://www.npmjs.com/package/react-datetime) component. [Moment.js](https://momentjs.com/docs/#/displaying/format/) format is used. See the full list of options [here](https://www.npmjs.com/package/react-datetime#api).
+
+## Example: Add "Created At" to Form
+
+```javascript
+const formConfig = {
+  fields: [
+    {
+      name: 'created_at',
+      label: 'Created At',
+      component: 'date',
+      dateFormat: 'MMMM DD YYYY',
+      timeFormat: false,
+    },
+  ],
+}
+```

--- a/public/consumers.json
+++ b/public/consumers.json
@@ -233,11 +233,11 @@
   ],
   "/content/docs/fields/date.md": [
     {
-      "file": "/packages/tinacms/src/plugins/fields/DateFieldPlugin.tsx",
+      "file": "/packages/@tinacms/fields/src/plugins/DateFieldPlugin.tsx",
       "details": "Documents how to use the date field plugin"
     },
     {
-      "file": "/packages/tinacms/src/plugins/fields/dateFormat.ts",
+      "file": "/packages/@tinacms/fields/src/plugins/dateFormat.ts",
       "details": "References date formatting specifics"
     }
   ],


### PR DESCRIPTION
Because the `DateFieldPlugin` is being moved back into core, we're not longer suggesting users add the `react-tinacms-date` package.

I've moved the README for that package into the core docs, formatted similarly to other field pages.

**Developer's Note:**
`_app.txs` and `package.json` for this repo currently use the `react-tinacms-date` package.  I wasn't sure if it should be part of this PR or not, but we'll want to remove those dependencies once TinaCMS Core has the `DateFieldPlugin`.

Closes https://github.com/tinacms/tinacms/issues/1808