### PR TITLE
docs: Fixing schema to make docs usable if you follow along

### DIFF
--- a/content/docs/tina-cloud/cli.md
+++ b/content/docs/tina-cloud/cli.md
@@ -81,7 +81,7 @@ export default defineSchema({
     },
     {
       label: 'Authors',
-      name: 'author',
+      name: 'authors',
       path: 'content/authors',
       templates: [
         {


### PR DESCRIPTION
This fixes #870 

The schema for the authors section of the defineSchema is missing an s in the name element which causes an error and without prior knowledge is friction for a new user of Tina Cloud .