### PR TITLE
add quick start guide to doc toc

### DIFF
--- a/content/toc-doc.json
+++ b/content/toc-doc.json
@@ -1,5 +1,17 @@
 [
   {
+    "category": "Quick Start Guide",
+    "slug": "/guides/tina-cloud/starter/overview",
+    "description": "Get a website running with Tina Cloud in no time!",
+    "items": [
+      {
+        "id": "/guides/tina-cloud/starter/overview",
+        "slug": "/guides/tina-cloud/starter/overview",
+        "title": "Tina Cloud Starter"
+      }
+    ]
+  },
+  {
     "category": "TinaCMS",
     "slug": "/docs/tinacms",
     "description": "The JavaScript toolkit for building content management interfaces",


### PR DESCRIPTION
This adds the 'Quick Start Guide' (Tine Cloud Starter Guide) to the docs index sidebar to further emphasis it as an easy path for new users.

The next step is to move the guide so it's not in the guides section, and the '<- Guides Index' link becomes a link back to the docs index. Given our template structure I'm not sure how to accomplish this with minimal code duplication; input would be great!

<img width="648" alt="Screen Shot 2021-05-27 at 4 20 41 PM" src="https://user-images.githubusercontent.com/5075484/119884864-7dbac300-bf07-11eb-9222-bc26bfa729b3.png">
