### PR TITLE
Update Media APIs for tinacms/tinacms#1859

### DIFF
--- a/content/docs/cms.md
+++ b/content/docs/cms.md
@@ -13,9 +13,8 @@ consumes:
     description: Shows sidebar state interface
   - file: /packages/react-toolbar/toolbar.ts
     description: Shows Toolbar state interface
-last_edited: '2020-07-31T16:18:02.673Z'
+last_edited: '2021-06-22T19:01:05.703Z'
 ---
-
 The CMS object in Tina is a container for attaching and accessing [Plugins](/docs/plugins), [APIs](/docs/apis), and the [Event Bus](/docs/events). On its own, the CMS does very little; however, since it's the central integration point for everything that Tina does, it's extremely important!
 
 > Reference [Step 1](/docs/getting-started/cms-set-up) of the Introductory Tutorial for an example on setting up the CMS.
@@ -128,6 +127,9 @@ interface TinaCMSConfig {
   media?: {
     store: MediaStore
   }
+  mediaOptions?: {
+    pageSize?: number
+  }
 }
 
 interface SidebarConfig {
@@ -147,18 +149,19 @@ interface ToolbarConfig {
 }
 ```
 
----
+***
 
-| key         | usage                                                                            |
-| ----------- | -------------------------------------------------------------------------------- |
-| **enabled** | Controls whether the CMS is enabled or disabled. _Defaults to_ `false`           |
-| **plugins** | Array of plugins to be added to the CMS object.                                  |
-| **apis**    | Object containing APIs to be registered to the CMS                               |
+| key | usage |
+| --- | --- |
+| **enabled** | Controls whether the CMS is enabled or disabled. _Defaults to_ `false` |
+| **plugins** | Array of plugins to be added to the CMS object. |
+| **apis** | Object containing APIs to be registered to the CMS |
 | **sidebar** | Enables and configures behavior of the [sidebar](/docs/ui#sidebar-configuration) |
-| **toolbar** | Configures behavior of the [toolbar](/docs/ui#toolbar-configuration)             |
-| **media**   | Configures [media](/docs/media).                                                 |
+| **toolbar** | Configures behavior of the [toolbar](/docs/ui#toolbar-configuration) |
+| **media** | Configures [media](/docs/media). |
+| **pageSize** | Sets how many media objects are displayed at a time in the media manager. |
 
----
+***
 
 > Learn more about [sidebar & toolbar options](/docs/cms/ui).
 
@@ -205,13 +208,13 @@ interface TinaCMS {
 }
 ```
 
-| property      | description                                                                                   |
-| ------------- | --------------------------------------------------------------------------------------------- |
-| `enabled`     | Returns the enabled state. When `true`, content _can_ be edited.                              |
-| `disabled`    | Returns the disabled state. When `true`, content _cannot_ be edited.                          |
-| `registerApi` | Registers a new [external API](/docs/apis#adding-an-api) with the CMS.                        |
-| `enable`      | [Enables](/docs/cms#disabling--enabling-the-cms) the CMS so content can be edited.            |
-| `disable`     | [Disables](/docs/cms#disabling--enabling-the-cms) the CMS so content can no longer be edited. |
-| `toggle`      | [Toggles](/docs/cms#disabling--enabling-the-cms) the enabled/disabled state of the CMS .      |
+| property | description |
+| --- | --- |
+| `enabled` | Returns the enabled state. When `true`, content _can_ be edited. |
+| `disabled` | Returns the disabled state. When `true`, content _cannot_ be edited. |
+| `registerApi` | Registers a new [external API](/docs/apis#adding-an-api) with the CMS. |
+| `enable` | [Enables](/docs/cms#disabling--enabling-the-cms) the CMS so content can be edited. |
+| `disable` | [Disables](/docs/cms#disabling--enabling-the-cms) the CMS so content can no longer be edited. |
+| `toggle` | [Toggles](/docs/cms#disabling--enabling-the-cms) the enabled/disabled state of the CMS . |
 
 > Use the `useCMS` hook to [access the CMS](/docs/cms#accessing-the-cms-object) and execute these methods as needed.

--- a/content/docs/media.md
+++ b/content/docs/media.md
@@ -2,9 +2,8 @@
 title: Media
 prev: /docs/plugins/content-creators
 next: /docs/apis
-last_edited: '2020-10-07T18:15:58.042Z'
+last_edited: '2021-06-22T18:59:17.909Z'
 ---
-
 **Media** in Tina refers to a set of APIs to allow packages to interact with a central store of files.
 
 ## Media Store
@@ -13,10 +12,10 @@ A **Media Store** handles media files for the CMS. Media Stores provide a set of
 
 > ### Supported Media Stores
 >
-> - [`GithubMediaStore`](/packages/react-tinacms-github): Saves and sources media to/from your Git repository through the GitHub API.
-> - [`NextGithubMediaStore`](/packages/next-tinacms-github#nextgithubmediastore): Configures media sourced from GitHub specifically for Next.js projects.
-> - [`StrapiMediaStore`](/packages/react-tinacms-strapi/): Handles media stored in a Strapi instance.
-> - [`GitMediaStore`](/guides/nextjs/git/adding-backend): Saves media to your Git repository by writing to the local system and commiting directly.
+> * [`GithubMediaStore`](/packages/react-tinacms-github): Saves and sources media to/from your Git repository through the GitHub API.
+> * [`NextGithubMediaStore`](/packages/next-tinacms-github#nextgithubmediastore): Configures media sourced from GitHub specifically for Next.js projects.
+> * [`StrapiMediaStore`](/packages/react-tinacms-strapi/): Handles media stored in a Strapi instance.
+> * [`GitMediaStore`](/guides/nextjs/git/adding-backend): Saves media to your Git repository by writing to the local system and commiting directly.
 
 ### Creating a Media Store
 
@@ -45,10 +44,7 @@ interface Media {
 
 interface MediaList {
   items: Media[]
-  limit: number
-  offset: number
-  nextOffset?: number
-  totalCount: number
+  nextOffset?: string | number
 }
 
 interface MediaUploadOptions {
@@ -59,58 +55,55 @@ interface MediaUploadOptions {
 interface MediaListOptions {
   directory?: string
   limit?: number
-  offset?: number
+  offset?: string | number
 }
 ```
 
 #### Media Store
 
-| Key          | Description                                                                                                                                                           |
-| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `accept`     | The [input accept string](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept) that describes what kind of files the Media Store will accept. |
-| `persist`    | Uploads a set of files to the Media Store and returns a Promise containing the Media objects for those files.                                                         |
-| `previewSrc` | Given a `src` string, it returns a url for previewing that content. This is helpful in cases where the file may not be available in production yet.                   |
-| `list`       | Lists all media in a specific directory. Used in the media manager.                                                                                                   |
-| `delete`     | Deletes a media object from the store.                                                                                                                                |
+| Key | Description |
+| --- | --- |
+| `accept` | The [input accept string](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept) that describes what kind of files the Media Store will accept. |
+| `persist` | Uploads a set of files to the Media Store and returns a Promise containing the Media objects for those files. |
+| `previewSrc` | Given a `src` string, it returns a url for previewing that content. This is helpful in cases where the file may not be available in production yet. |
+| `list` | Returns a list of media objects from the media provider. Used in the media manager. |
+| `delete` | Deletes a media object from the store. |
 
 #### Media
 
 This represents an individual file in the `MediaStore`.
 
-| Key          | Description                                                    |
-| ------------ | -------------------------------------------------------------- |
-| `type`       | Indicates whether the object represents a file or a directory. |
-| `id`         | A unique identifier for the media item.                        |
-| `directory`  | The path to the file in the store. e.g. `public/images`        |
-| `filename`   | The name of the file. e.g.`boat.jpg`                           |
-| `previewSrc` | _Optional:_ A url that provides an image preview of the file.  |
+| Key | Description |
+| --- | --- |
+| `type` | Indicates whether the object represents a file or a directory. |
+| `id` | A unique identifier for the media item. |
+| `directory` | The path to the file in the store. e.g. `public/images` |
+| `filename` | The name of the file. e.g.`boat.jpg` |
+| `previewSrc` | _Optional:_ A url that provides an image preview of the file. |
 
 #### Media List
 
 This represents a paginated query to the `MediaStore` and its results.
 
-| Key          | Description                                                                 |
-| ------------ | --------------------------------------------------------------------------- |
-| `items`      | An array of `Media` objects.                                                |
-| `limit`      | The number of records returned by the current query.                        |
-| `offset`     | A number representing the beginning of the current record set.              |
-| `nextOffset` | _Optional:_ A number representing the beginning of the next set of records. |
-| `totalCount` | The total number of records available.                                      |
+| Key | Description |
+| --- | --- |
+| `items` | An array of `Media` objects. |
+| `nextOffset` | _Optional:_ A key representing the beginning of the next set of records. This will be fed back into your `list` function if the user requests more records from the media library UI. |
 
 #### Media Upload Options
 
-| Key         | Description                                                                       |
-| ----------- | --------------------------------------------------------------------------------- |
-| `directory` | The directory where the file should be uploaded.                                  |
-| `file`      | The [File](https://developer.mozilla.org/en-US/docs/Web/API/File) to be uploaded. |
+| Key | Description |
+| --- | --- |
+| `directory` | The directory where the file should be uploaded. |
+| `file` | The [File](https://developer.mozilla.org/en-US/docs/Web/API/File) to be uploaded. |
 
 #### Media List Options
 
-| Key         | Description                                                                                            |
-| ----------- | ------------------------------------------------------------------------------------------------------ |
-| `directory` | _Optional:_ The current directory to list media from.                                                  |
-| `limit`     | _Optional:_ The number of records that should be returned.                                             |
-| `offset`    | _Optional:_ A number representing how far into the list the store should begin returning records from. |
+| Key | Description |
+| --- | --- |
+| `directory` | _Optional:_ The current directory to list media from. |
+| `limit` | _Optional:_ The number of records that should be returned. |
+| `offset` | _Optional:_ A key representing how far into the list the store should begin returning records from. |
 
 ### Adding a Media Store
 
@@ -166,6 +159,11 @@ this.cms = new TinaCMS({
     git: client,
   },
   media: new MyGitMediaStore(client),
+  mediaOptions: {
+    // Optional. Configure how many records to retrieve at a time.
+    // Passed into a Media Store's *list* function as the *limit*.
+    pageSize: 17
+  }
 })
 ```
 


### PR DESCRIPTION
We are switching the media library UI from numbered pagination to "cursor-based", where the only controls are buttons to move forward and backward in the list. This is a **less-opinionated** approach and makes the media library compatible with asset managers like Cloudinary, which don't give you arithmetical control over the entire collection but instead provide a cursor that allows you to navigate further into the set.

This is a **breaking change** for users with custom media stores. They will need to update their media stores to satisfy the updated interfaces. These changes should be trivial, and I will be writing a brief upgrade guide to be added to the release notes when the updates are published. Users that are using the first-party `GithubMediaStore`, `GitMediaStore`, `StrapiMediaStore` and any respective subclasses that do not override `list` shouldn't need to do anything other than update those packages.

The relevant TinaCMS PR is here: https://github.com/tinacms/tinacms/pull/1859

This PR **should not be merged until these changes are released.** Expected version bump will be `0.41.1` -> `0.42.0`