### PR TITLE
chore: add documentation links for next-tinacms-cloudinary

### DIFF
--- a/content/packages.json
+++ b/content/packages.json
@@ -3,50 +3,60 @@
     {
       "readme": "https://api.github.com/repos/tinacms/tinacms/contents/packages/react-tinacms-date/README.md",
       "name": "react-tinacms-date",
+      "monorepo": "tinacms/tinacms",
       "link": "https://github.com/tinacms/tinacms/tree/master/packages/react-tinacms-date"
     },
     {
       "readme": "https://api.github.com/repos/tinacms/tinacms/contents/packages/react-tinacms-editor/README.md",
       "name": "react-tinacms-editor",
+      "monorepo": "tinacms/tinacms",
       "link": "https://github.com/tinacms/tinacms/tree/master/packages/react-tinacms-editor"
     },
     {
       "readme": "https://api.github.com/repos/tinacms/tinacms/contents/packages/react-tinacms-github/README.md",
       "name": "react-tinacms-github",
+      "monorepo": "tinacms/tinacms",
       "link": "https://github.com/tinacms/tinacms/tree/master/packages/react-tinacms-github"
     },
     {
       "readme": "https://api.github.com/repos/tinacms/tinacms/contents/packages/react-tinacms-inline/README.md",
       "name": "react-tinacms-inline",
+      "monorepo": "tinacms/tinacms",
       "link": "https://github.com/tinacms/tinacms/tree/master/packages/react-tinacms-inline"
     },
     {
       "readme": "https://api.github.com/repos/tinacms/tinacms/contents/packages/react-tinacms-strapi/README.md",
       "name": "react-tinacms-strapi",
+      "monorepo": "tinacms/tinacms",
       "link": "https://github.com/tinacms/tinacms/tree/master/packages/react-tinacms-strapi"
     },
     {
       "name": "next-tinacms-cloudinary",
+      "monorepo": "tinacms/tina-graphql-gateway",
       "readme": "https://api.github.com/repos/tinacms/tina-graphql-gateway/contents/packages/next-tinacms-cloudinary/README.md",
       "link": "https://github.com/tinacms/tina-graphql-gateway/tree/main/packages/next-tinacms-cloudinary"
     },
     {
       "name": "next-tinacms-github",
+      "monorepo": "tinacms/tinacms",
       "readme": "https://api.github.com/repos/tinacms/tinacms/contents/packages/next-tinacms-github/README.md",
       "link": "https://github.com/tinacms/tinacms/tree/master/packages/next-tinacms-github"
     },
     {
       "name": "next-tinacms-json",
+      "monorepo": "tinacms/tinacms",
       "readme": "https://api.github.com/repos/tinacms/tinacms/contents/packages/next-tinacms-json/README.md",
       "link": "https://github.com/tinacms/tinacms/tree/master/packages/next-tinacms-json"
     },
     {
       "name": "next-tinacms-markdown",
+      "monorepo": "tinacms/tinacms",
       "readme": "https://api.github.com/repos/tinacms/tinacms/contents/packages/next-tinacms-markdown/README.md",
       "link": "https://github.com/tinacms/tinacms/tree/master/packages/next-tinacms-markdown"
     },
     {
       "name": "@tinacms/alerts",
+      "monorepo": "tinacms/tinacms",
       "link": "https://github.com/tinacms/tinacms/tree/master/packages/%40tinacms/alerts"
     }
   ]

--- a/content/packages.json
+++ b/content/packages.json
@@ -26,6 +26,11 @@
       "link": "https://github.com/tinacms/tinacms/tree/master/packages/react-tinacms-strapi"
     },
     {
+      "name": "next-tinacms-cloudinary",
+      "readme": "https://api.github.com/repos/tinacms/tina-graphql-gateway/contents/packages/next-tinacms-cloudinary/README.md",
+      "link": "https://github.com/tinacms/tina-graphql-gateway/tree/main/packages/next-tinacms-cloudinary"
+    },
+    {
       "name": "next-tinacms-github",
       "readme": "https://api.github.com/repos/tinacms/tinacms/contents/packages/next-tinacms-github/README.md",
       "link": "https://github.com/tinacms/tinacms/tree/master/packages/next-tinacms-github"

--- a/content/toc-doc.json
+++ b/content/toc-doc.json
@@ -241,6 +241,11 @@
             "title": "react-tinacms-strapi"
           },
           {
+            "id": "/packages/next-tinacms-cloudinary",
+            "slug": "/packages/next-tinacms-cloudinary",
+            "title": "next-tinacms-cloudinary"
+          },
+          {
             "id": "/packages/next-tinacms-github",
             "slug": "/packages/next-tinacms-github",
             "title": "next-tinacms-github"

--- a/utils/docs/getPackageProps.ts
+++ b/utils/docs/getPackageProps.ts
@@ -44,6 +44,7 @@ export async function getPackageProps(
 
   interface GithubPackage {
     name: string
+    monorepo: string
     readme: string
     link: string
   }
@@ -72,12 +73,17 @@ export async function getPackageProps(
     }
   }
 
-  const latestTag = await axios
-    .get('https://api.github.com/repos/tinacms/tinacms/releases/latest')
-    .then((res: any) => res.data.tag_name)
-  const currentDoc = await axios.get(
-    `${currentPackage.readme}?ref=${latestTag}`
-  )
+  let currentDocUrl = currentPackage.readme
+  try {
+    const latestTag = await axios
+      .get(
+        `https://api.github.com/repos/${currentPackage.monorepo}/releases/latest`
+      )
+      .then((res: any) => res.data.tag_name)
+    currentDocUrl += `?ref=${latestTag}`
+  } catch {}
+
+  const currentDoc = await axios.get(currentDocUrl)
 
   const content = b64DecodeUnicode(currentDoc.data.content)
 


### PR DESCRIPTION
Adds links to the ```next-tinacms-cloudinary``` package to the Tina docs

