### PR TITLE
added tina-init-tutorial.md

### DIFF
--- a/components/layout/DocsLayout.tsx
+++ b/components/layout/DocsLayout.tsx
@@ -12,10 +12,11 @@ interface DocsLayoutProps {
   navItems: any
   guide?: false | { category: string }
   children: any
+  showLayout?: boolean
 }
 
 export const DocsLayout = React.memo(
-  ({ children, navItems, guide = false }: DocsLayoutProps) => {
+  ({ children, navItems, guide = false, showLayout = true }: DocsLayoutProps) => {
     const router = useRouter()
     return (
       <>
@@ -25,10 +26,10 @@ export const DocsLayout = React.memo(
           }}
         />
         <DocsLayoutDiv>
-          <DocumentationNavigation navItems={navItems} guide={guide} />
+          {showLayout && <DocumentationNavigation navItems={navItems} guide={guide} />}
           <DocsTextWrapper>{children}</DocsTextWrapper>
           <FeedbackForm />
-          <Footer light />
+          {showLayout && <Footer light />}
         </DocsLayoutDiv>
       </>
     )

--- a/content/docs/tina-init-tutorial.md
+++ b/content/docs/tina-init-tutorial.md
@@ -2,13 +2,15 @@ Hello! and thanks for bootstrapping a Tina App! Before you do anything click on 
 
 ## Next steps
 
-### Wrap your App in "Edit State" (**Can probably skip this as CLI did this for you**)
+### Wrap your App in "Edit State" 
+
+**NOTE:** If you bootstrapped this application with the CLI it probably took care of this for you and you can skip to the [Make a page editable](#make-a-page-editable) Step.
 
 To do this add the following to your pages/_app.js. (or create this file if it is not present in your project)
 
 **_app.js**
 
-```tsx
+```tsx,copy
 import dynamic from "next/dynamic";
 
 import { EditProvider, setEditing, useEditState } from "tina-graphql-gateway";
@@ -73,9 +75,9 @@ To make a page editable we need to do three things
 
 #### Update schema.ts
 
-lets update our schema.ts to include product listings. We will do so by added an "pages collection" with a product listing template. When added to our existing blog collection it looks like this. We also need a place to store the authors in the file system. So lets create a folder "content/pages".
+lets update our schema.ts to include product listings. We will do so by adding a "pages collection" with a product listing template. When adding to our existing blog collection it looks like this. We also need a place to store the authors in the file system. So lets create a folder `content/pages`.
 
-```tsx
+```tsx,copy
 import { defineSchema } from "tina-graphql-gateway-cli";
 
 export default defineSchema({
@@ -133,7 +135,7 @@ export default defineSchema({
 ```
 
 
-Lets also create a file to query. In the folder we just created (content/pages) add a file called "product-listing.md"
+Lets also create a file to query. In the folder we just created (`content/pages`) add a file called `product-listing.md`
 
 ```md
 ---
@@ -144,9 +146,9 @@ _template: product
 
 #### Make a new Next.js page and a graphql Query
 
-Start by making a new file called pages/product-listing.tsx that contains the following
+Start by making a new file called `pages/product-listing.tsx` that contains the following
 
-```tsx
+```tsx,copy
 import { LocalClient } from "tina-graphql-gateway";
 import { Pages_Document } from "../.tina/__generated__/types";
 import { AsyncReturnType } from "./demo/blog/[filename]";
@@ -199,13 +201,13 @@ export const getStaticProps = async () => {
 };
 ```
 
-We are doing a couple of things here. A graphql query was written that looks for the content/pages/product-listing.md file
+We are doing a couple of things here. A graphql query was written that looks for the `content/pages/product-listing.md` file
 
 The query is being statically exported so it can be accessed by the TinaWrapper.
 
 The code was updated to display the list of products.
 
-Visit [http://localhost:3000/product-listing{" "}](http://localhost:3000/product-listing) {" "} to see what you just created. Click the "edit this site" button in the top to edit.
+Visit [http://localhost:3000/product-listing](http://localhost:3000/product-listing)to see what you just created. Click the "edit this site" button in the top to edit.
 
 #### Tina Cloud
 
@@ -218,4 +220,4 @@ To hook up this demo to Tina Cloud and save content to Github instead of the fil
 NEXT_PUBLIC_ORGANIZATION_NAME= get this from the organization you create at auth.tina.io
 NEXT_PUBLIC_TINA_CLIENT_ID= get this from the app you create at auth.tina.io
 NEXT_PUBLIC_USE_LOCAL_CLIENT=0
-å```
+```

--- a/content/docs/tina-init-tutorial.md
+++ b/content/docs/tina-init-tutorial.md
@@ -1,0 +1,221 @@
+Hello! and thanks for bootstrapping a Tina App! Before you do anything click on "toggle edit state" button and a pencil icon in the bottom left hand corner will appear. You can now edit this content in real time! Click save and notice that you have update the Hello world blog post in the local file system.
+
+## Next steps
+
+### Wrap your App in "Edit State" (**Can probably skip this as CLI did this for you**)
+
+To do this add the following to your pages/_app.js. (or create this file if it is not present in your project)
+
+**_app.js**
+
+```tsx
+import dynamic from "next/dynamic";
+
+import { EditProvider, setEditing, useEditState } from "tina-graphql-gateway";
+
+// InnerApp that handles rendering edit mode or not
+function InnerApp({ Component, pageProps }) {
+  const { edit } = useEditState();
+  if (edit) {
+    // Dynamically load Tina only when in edit mode so it does not affect production
+    // see https://nextjs.org/docs/advanced-features/dynamic-import#basic-usage
+    const TinaWrapper = dynamic(() => import("../components/tina-wrapper"));
+    return (
+      <>
+        <TinaWrapper {...pageProps}>
+          {(props) => <Component {...props} />}
+        </TinaWrapper>
+      </>
+    );
+  }
+  return <Component {...pageProps} />;
+}
+
+// Our app is wrapped with edit provider
+function App(props) {
+  return (
+    <EditProvider>
+      <ToggleButton />
+      <InnerApp {...props} />
+    </EditProvider>
+  );
+}
+const ToggleButton = () => {
+  const { edit, setEdit } = useEditState();
+  return (
+    <button
+      onClick={() => {
+        setEdit(!edit);
+      }}
+    >
+      Toggle Edit State
+    </button>
+  );
+};
+
+export default App;
+```
+
+Please restart your dev server (CTR + C and yarn dev) and now you will have access to the `useEditState` hook anywhere in your app. You will also notice that we are lazy loading the tina-wrapper component. This is so that no Tina code will load in your production bundle.
+
+Next you can delete the editProvider and TinaWrapper from 'pages/demo/blog/[filename].ts' by deleting the default export and adding
+```tsx
+export default BlogPage;
+```
+
+### Make a page editable
+
+To make a page editable we need to do three things
+
+1.  Update our schema.ts
+2.  Update our query
+3.  Update our code
+
+#### Update schema.ts
+
+lets update our schema.ts to include product listings. We will do so by added an "pages collection" with a product listing template. When added to our existing blog collection it looks like this. We also need a place to store the authors in the file system. So lets create a folder "content/pages".
+
+```tsx
+import { defineSchema } from "tina-graphql-gateway-cli";
+
+export default defineSchema({
+  collections: [
+    {
+      label: "Pages",
+      name: "pages",
+      path: "content/pages",
+      templates: [
+        {
+          label: "Product listing page",
+          name: "product",
+          fields: [
+            {
+              type: "group-list",
+              label: "Products",
+              name: "products",
+              fields: [
+                {
+                  type: "text",
+                  label: "Item ID",
+                  name: "id",
+                },
+                {
+                  type: "textarea",
+                  label: "Description",
+                  name: "description",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      label: "Blog Posts",
+      name: "posts",
+      path: "content/posts",
+      templates: [
+        {
+          label: "Article",
+          name: "article",
+          fields: [
+            {
+              type: "text",
+              label: "Title",
+              name: "title",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});
+```
+
+
+Lets also create a file to query. In the folder we just created (content/pages) add a file called "product-listing.md"
+
+```md
+---
+_template: product
+---
+```
+
+
+#### Make a new Next.js page and a graphql Query
+
+Start by making a new file called pages/product-listing.tsx that contains the following
+
+```tsx
+import { LocalClient } from "tina-graphql-gateway";
+import { Pages_Document } from "../.tina/__generated__/types";
+import { AsyncReturnType } from "./demo/blog/[filename]";
+
+const ProductListingPage = (
+  props: AsyncReturnType<typeof getStaticProps>["props"]
+) => {
+  console.log(props);
+  return (
+    <div>
+      <ol>
+        {props.data.getPagesDocument?.data?.products?.map((product) => (
+          <li key={product.id}>
+            id: {product.id}, description: {product.description}
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+};
+
+export default ProductListingPage;
+
+const query = `#graphql
+query ProuctPageQuery {
+  getPagesDocument(relativePath: "content/pages/product-listing.md"){
+    data {
+      __typename ... on  Product_Doc_Data{
+        products {
+          id
+          description
+        }
+      }
+    }
+  }
+}
+`;
+const client = new LocalClient();
+
+export const getStaticProps = async () => {
+  return {
+    props: {
+      data: await client.request<{ getPagesDocument: Pages_Document }>(query, {
+        variables: {},
+      }),
+      variables: {},
+      query,
+    },
+  };
+};
+```
+
+We are doing a couple of things here. A graphql query was written that looks for the content/pages/product-listing.md file
+
+The query is being statically exported so it can be accessed by the TinaWrapper.
+
+The code was updated to display the list of products.
+
+Visit [http://localhost:3000/product-listing{" "}](http://localhost:3000/product-listing) {" "} to see what you just created. Click the "edit this site" button in the top to edit.
+
+#### Tina Cloud
+
+To hook up this demo to Tina Cloud and save content to Github instead of the file system you can do the following.
+
+1.  Register at https://auth.tina.io
+2.  Update .env file to include:
+
+```
+NEXT_PUBLIC_ORGANIZATION_NAME= get this from the organization you create at auth.tina.io
+NEXT_PUBLIC_TINA_CLIENT_ID= get this from the app you create at auth.tina.io
+NEXT_PUBLIC_USE_LOCAL_CLIENT=0
+å```

--- a/content/docs/tina-init-tutorial.md
+++ b/content/docs/tina-init-tutorial.md
@@ -75,7 +75,7 @@ To make a page editable we need to do three things
 
 #### Update schema.ts
 
-lets update our schema.ts to include product listings. We will do so by adding a "pages collection" with a product listing template. When adding to our existing blog collection it looks like this. We also need a place to store the authors in the file system. So lets create a folder `content/pages`.
+let's update our schema.ts to include product listings. We will do so by adding a "pages collection" with a product listing template. When adding to our existing blog collection it looks like this. We also need a place to store the authors in the file system. So let's create a folder `content/pages`.
 
 ```tsx,copy
 import { defineSchema } from "tina-graphql-gateway-cli";
@@ -135,7 +135,7 @@ export default defineSchema({
 ```
 
 
-Lets also create a file to query. In the folder we just created (`content/pages`) add a file called `product-listing.md`
+let's also create a file to query. In the folder we just created (`content/pages`) add a file called `product-listing.md`
 
 ```md
 ---

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -25,9 +25,10 @@ export function DocTemplate(props) {
   if (props.notFound) {
     return <Error statusCode={404} />
   }
-
+  
   const router = useRouter()
   const isCloudDocs = router.asPath.includes('tina-cloud')
+  const noLayout = router.query.layout === 'false'
 
   // Registers Tina Form
   const [data, form] = useGithubMarkdownForm(props.file, formOptions)
@@ -56,7 +57,7 @@ export function DocTemplate(props) {
           images: [openGraphImage(frontmatter.title, '| TinaCMS Docs')],
         }}
       />
-      <DocsLayout navItems={props.docsNav}>
+      <DocsLayout navItems={props.docsNav} showLayout={!noLayout}>
         <DocsGrid>
           <DocGridHeader>
             <DocsPageTitle>


### PR DESCRIPTION
This is the getting started tutorial for Tina init.

This will not be linked on our site but will be used in an i frame in the users app. 

Link: https://tinacms-site-next-git-feat-tina-init-tutorial-tinacms.vercel.app/docs/tina-init-tutorial/?layout=false

This also adds the ability to remove the layout when in the docs with a query param. (tina.io/docs/some-doc-page/?layout=false). This will only render the doc page and not the nav, header, footer, etc.