### PR TITLE
remove inpage links on sidebar for cloud section

### DIFF
--- a/content/toc-doc.json
+++ b/content/toc-doc.json
@@ -277,63 +277,17 @@
       {
         "id": "/docs/tina-cloud/dashboard",
         "slug": "/docs/tina-cloud/dashboard",
-        "title": "Dashboard"
+        "title": "Tina Cloud Dashboard"
       },
       {
-        "id": "/docs/tina-cloud/cli",
-        "slug": "/docs/tina-cloud/cli",
-        "title": "Tina Cloud CLI",
-        "items": [
-          {
-            "id": "/docs/tina-cloud/cli/#defineschema",
-            "slug": "/docs/tina-cloud/cli/#defineschema",
-            "title": "Defining a schema",
-            "items": [
-              {
-                "id": "/docs/tina-cloud/cli/#collections",
-                "slug": "/docs/tina-cloud/cli/#collections",
-                "title": "Collections"
-              },
-              {
-                "id": "/docs/tina-cloud/cli/#templates",
-                "slug": "/docs/tina-cloud/cli/#templates",
-                "title": "Templates"
-              },
-              {
-                "id": "/docs/tina-cloud/cli/#fields",
-                "slug": "/docs/tina-cloud/cli/#fields",
-                "title": "Fields"
-              }
-            ]
-          },
-          {
-            "id": "/docs/tina-cloud/cli/#run-the-local-graphql-server",
-            "slug": "/docs/tina-cloud/cli/#run-the-local-graphql-server",
-            "title": "Local server"
-          }
-        ]
+        "id": "/docs/tina-cloud/cli/",
+        "slug": "/docs/tina-cloud/cli/",
+        "title": "Tina Cloud CLI"
       },
       {
-        "id": "/docs/tina-cloud/client",
-        "slug": "/docs/tina-cloud/client",
-        "title": "Tina Cloud client",
-        "items": [
-          {
-            "id": "/docs/tina-cloud/client/#usegraphqlforms",
-            "href": "/docs/tina-cloud/client/#usegraphqlforms",
-            "title": "useGraphQLForms"
-          },
-          {
-            "id": "/docs/tina-cloud/client/#usedocumentcreatorplugin",
-            "href": "/docs/tina-cloud/client/#usedocumentcreatorplugin",
-            "title": "useDocumentCreatorPlugin"
-          },
-          {
-            "id": "/docs/tina-cloud/client/#authentication-with-tina-cloud",
-            "href": "/docs/tina-cloud/client/#authentication-with-tina-cloud",
-            "title": "Authentication"
-          }
-        ]
+        "id": "/docs/tina-cloud/client/",
+        "slug": "/docs/tina-cloud/client/",
+        "title": "Tina Cloud Client"
       }
     ]
   },


### PR DESCRIPTION
In the Tina Cloud section of the docs, the sidebar had dropdowns that contained in page links (not inter page links) - the same links that were already present on the Table of Contents on the right hand side of the page. 

To keep consistent, removed in page links on the sidebar. Looks a little too sparse now in my opinion but we might gain more hierarchy once we work on more Tina Cloud docs. 

<img width="1680" alt="Screen Shot 2021-07-08 at 4 42 44 PM" src="https://user-images.githubusercontent.com/76000553/124981556-161a8c00-e00c-11eb-9667-81544b1e8249.png">
