### PR TITLE
Remove 'Guides' from root navigation

### DIFF
--- a/content/docs-navigation.json
+++ b/content/docs-navigation.json
@@ -12,12 +12,6 @@
     "external": false
   },
   {
-    "id": "guides",
-    "label": "Guides",
-    "href": "/guides",
-    "external": false
-  },
-  {
     "id": "blog",
     "label": "Blog",
     "href": "/blog",

--- a/content/navigation.json
+++ b/content/navigation.json
@@ -6,12 +6,6 @@
     "external": false
   },
   {
-    "id": "guides",
-    "label": "Guides",
-    "href": "/guides",
-    "external": false
-  },
-  {
     "id": "blog",
     "label": "Blog",
     "href": "/blog",

--- a/content/pages/cloud.json
+++ b/content/pages/cloud.json
@@ -17,10 +17,6 @@
           "label": "Docs"
         },
         {
-          "link": "/guides",
-          "label": "Guides"
-        },
-        {
           "link": "/blog",
           "label": "Blog"
         },

--- a/content/pages/home.json
+++ b/content/pages/home.json
@@ -17,10 +17,6 @@
           "label": "Docs"
         },
         {
-          "link": "/guides",
-          "label": "Guides"
-        },
-        {
           "link": "/blog",
           "label": "Blog"
         },


### PR DESCRIPTION
Remove 'Guides' from site navigation. Will rework Docs section to include Guides subsection. 

