### PR TITLE
Make some changes to the walkthrough after going through it

### DIFF
--- a/content/guides/tina-cloud/starter/connect-to-tina-cloud.md
+++ b/content/guides/tina-cloud/starter/connect-to-tina-cloud.md
@@ -3,20 +3,31 @@ title: Working with TinaCMS
 last_edited: '2021-07-27T10:00:00.000Z'
 ---
 
-Open your project locally and in the `env.local` file set:
+Open your project locally and in the `env.development` file set:
 
 - `NEXT_PUBLIC_USE_LOCAL_CLIENT` to `0`.
-- `NEXT_PUBLIC_TINA_CLIENT_ID` to the Client ID copied from an earlier step and found in your app's Overview section.
+
+```
+# env.development
+NEXT_PUBLIC_USE_LOCAL_CLIENT=0
+```
 
 Restart your server and run `yarn dev` again.
 
-To edit the site, navigate to <a href="http://localhost:3000/admin" target="_blank">http://localhost:3000/admin</a>. This activates the edit mode.
+In the `env.local` file set your client ID:
 
-![](https://raw.githubusercontent.com/tinacms/tina-cloud-starter/main/public/uploads/tina-cloud-authorization.png)
+```
+# env.local
+NEXT_PUBLIC_TINA_CLIENT_ID=to the Client ID copied from an earlier step and found in your app's Overview section
+```
+
+> Tip: `.env.development` only runs when in Next.js development mode.
+
+Make sure you're in edit mode by selecting the "Edit with Tina" button in the lower-left corner.
 
 This time a modal asks you to authenticate through TinaCMS. Upon success, Tina will send your edits to the TinaCMS server, and subsequently to GitHub.
 
-> To enter **edit mode**, navigate to the `admin` route of the site.
+![](https://raw.githubusercontent.com/tinacms/tina-cloud-starter/main/public/uploads/tina-cloud-authorization.png)
 
 ## Edit content
 
@@ -38,8 +49,7 @@ Now that Tina Cloud editing is working correctly, we can deploy the site so that
 Connect to your GitHub repository and set the same environment variables as the ones in your `env.local` file:
 
 ```
-NEXT_PUBLIC_TINA_CLIENT_ID= <YOUR_CLIENT_ID>
-NEXT_PUBLIC_USE_LOCAL_CLIENT=0
+NEXT_PUBLIC_TINA_CLIENT_ID=<YOUR_CLIENT_ID>
 ```
 
 Add the deployment URL to your app's Site Urls. To do this, go to your app's **Configuration** page.
@@ -57,7 +67,6 @@ Connect to your GitHub repository, click on **advanced** to set the same environ
 
 ```
 NEXT_PUBLIC_TINA_CLIENT_ID= <YOUR_CLIENT_ID>
-NEXT_PUBLIC_USE_LOCAL_CLIENT=0
 ```
 
 Set the **build command** to `yarn build`,
@@ -76,38 +85,9 @@ log in to Tina, and making some edits. Your changes should be saved to your GitH
 
 ## Media Management _(Optional)_
 
-Currently Tina Cloud only supports the <a href="https://github.com/tinacms/tinacms/tree/main/packages/next-tinacms-cloudinary" target="_blank">Cloudinary media store</a>. To add it, first uncomment two lines in your `_app.js`:
+Currently Tina Cloud only supports the <a href="https://github.com/tinacms/tinacms/tree/main/packages/next-tinacms-cloudinary" target="_blank">Cloudinary media store</a>. We've gone ahead and added it to your TinaCMS setup in `_app.js`, but you'll need to provide environment variables for it to work with your Cloudinary account
 
-```diff
-import "../styles.css";
-import dynamic from "next/dynamic";
-import { TinaEditProvider } from "tinacms/dist/edit-state";
-import { Layout } from "../components/layout";
-const TinaCMS = dynamic(() => import("tinacms"), { ssr: false });
--// import { TinaCloudCloudinaryMediaStore } from "next-tinacms-cloudinary";
-+ import { TinaCloudCloudinaryMediaStore } from "next-tinacms-cloudinary";
-
-const NEXT_PUBLIC_TINA_CLIENT_ID = process.env.NEXT_PUBLIC_TINA_CLIENT_ID;
-const NEXT_PUBLIC_USE_LOCAL_CLIENT =
-  process.env.NEXT_PUBLIC_USE_LOCAL_CLIENT || true;
-
-const App = ({ Component, pageProps }) => {
-  return (
-    <>
-      <TinaEditProvider
-        editMode={
-          <TinaCMS
-            branch="main"
-            clientId={NEXT_PUBLIC_TINA_CLIENT_ID}
-            isLocalClient={Boolean(Number(NEXT_PUBLIC_USE_LOCAL_CLIENT))}
--            // mediaStore={TinaCloudCloudinaryMediaStore}
-+             mediaStore={TinaCloudCloudinaryMediaStore}
-            {...pageProps}
-          >
-...
-```
-
-Next update your `.env.local` file with a couple of new environment variables that you can get from your [Cloudinary dashboard](https://cloudinary.com/console/).
+To do that, update your `.env.local` file with a couple of new environment variables that you can get from your [Cloudinary dashboard](https://cloudinary.com/console/).
 
 ```env
 # These are used in conjunction with a Cloudinary account for media asset management
@@ -119,7 +99,6 @@ CLOUDINARY_API_SECRET=<Get this from your Cloudinary account>
 Now restart your development server to be able to access your Cloudinary media library in Tina 🤩.
 
 <!-- Not sure why but when this comment is here the video autoplay works. When it is not here it does not work -->
-
 
 <video autoplay muted loop>
   <source src="/img/tina-starter/Media_video.mp4" type="video/mp4" />

--- a/content/guides/tina-cloud/starter/local.md
+++ b/content/guides/tina-cloud/starter/local.md
@@ -21,17 +21,9 @@ yarn install
 
 ## Run the project locally
 
-Copy the sample `.env.local.sample` file and run the local development server:
-
-```
-cp .env.local.sample .env.local
-```
-
 ```
 yarn dev
 ```
-
-> In your .env.local file `NEXT_PUBLIC_USE_LOCAL_CLIENT` should be set to `1`, other values can be ignored for now. We will start by investigating how TinaCMS works locally.
 
 This command starts the GraphQL server and the Next.js application in development mode. It also regenerates your schema types for TypeScript and GraphQL so changes to your `.tina` config are reflected immediately.
 
@@ -43,8 +35,10 @@ Open <a href="http://localhost:3000" target="_blank">http://localhost:3000</a> i
 
 ## Edit content locally
 
-Navigate to <a href="http://localhost:3000/admin" target="_blank">http://localhost:3000/admin</a> to enter edit mode.
+To enter edit mode, click the "Edit with Tina" button in the lower left corner. You'll be put into edit mode and redirected back to the page you were on.
 
-Click on the pencil in the lower left-hand corner to open Tina's sidebar which displays a variety of forms with fields you can edit and see updates live on the page. Since we're working locally, clicking save results in changes to your local filesystem.
+Next, click on the pencil in the lower left-hand corner to open Tina's sidebar which displays a variety of forms with fields you can edit and see updates live on the page. Since we're working locally, clicking save results in changes to your local filesystem.
 
 ![tina-cloud-starter](/img/tina-cloud-starter.jpg)
+
+Make some changes, build your own components and experience contextual editing with Tina. As fun as this is, you'll likely want to collaborate with others and view changes on a publicly available URL. To do that, in the next step we'll connect to Tina Cloud.


### PR DESCRIPTION
Walkthrough led me to a few snags, I've updated the starter in [this PR](https://github.com/tinacms/tina-cloud-starter/pull/127) to address them from that end.

Our change to use `.env.development` is related to most of these updates

- [x] cp env as a first step is redundant now with .env.development
- [x] Click edit button instead of "go to admin"
- [x] Not much info before telling them to set up with Tina cloud, probably just needs a summary section
- [x] Setting with Tina cloud now you need to change the `.env.development` instead
- [x] I think we should remove cloudinary stuff from .env.local
- [x] Vercel deploy won't need NEXT_PUBLIC_USE_LOCAL_CLIENT