### PR TITLE
docs: API reference overview

### DIFF
--- a/content/docs/tinacms-reference.md
+++ b/content/docs/tinacms-reference.md
@@ -1,24 +1,25 @@
 ---
 title: Overview
-id: '/docs/tinacms-context'
+id: /docs/tinacms-context
+last_edited: '2021-07-30T16:08:34.541Z'
 ---
-
 ## Next.js API
 
-Enable live-editing on your Next.js site with TinaCMS. [Learn more](/docs/tinacms-context)
+Enable live editing on your Next.js site with TinaCMS. [Learn more](/docs/tinacms-context)
 
 ## Tina Schema & CLI
 
-Learn how to model your content with `defineSchema` api and run it on top of your local filesystem with the CLI. [Learn more](/docs/cli-overview)
+Learn how to model your content with our `defineSchema` API and run it on top of your local filesystem with the [Tina CLI](/docs/cli-overview).
 
 ## The GraphQL API
 
-Power your site with a GraphQL API over Git-backed content. [Learn more](/docs/graphql)
+Power your site with a [GraphQL API over Git-backed content](/docs/graphql).
 
 ## Working with Media
 
-TinaCMS works with Cloudinary in a few easy steps. [Learn more](/docs/media-cloudinary/)
+TinaCMS currently works with [Cloudinary](/docs/media-cloudinary/), connect to your account in a few easy steps.
 
 ## The Tina CMS Toolkit
 
-TinaCMS is powered by the TinaCMS toolkit. Check out the docs to build integrations with a backend of any kind. [Learn more](docs/tinacms/)
+TinaCMS is powered by the [TinaCMS toolkit](/docs/toolkit/).   
+Check out the docs to [build integrations with external APIs](/docs/apis/).


### PR DESCRIPTION
- Fix a 404
- Use text links instead of generic "learn more" links for better a11y.