### PR TITLE
Point to the new register link on homepage

### DIFF
--- a/content/pages/cloud.json
+++ b/content/pages/cloud.json
@@ -35,7 +35,7 @@
           "variant": "orange",
           "label": "Sign up",
           "icon": "arrowRight",
-          "url": "http://app.tina.io/register"
+          "url": "https://app.tina.io/register"
         },
         {
           "variant": "ghost",

--- a/content/pages/cloud.json
+++ b/content/pages/cloud.json
@@ -35,7 +35,7 @@
           "variant": "orange",
           "label": "Sign up",
           "icon": "arrowRight",
-          "url": "https://auth.tina.io/register"
+          "url": "http://app.tina.io/register"
         },
         {
           "variant": "ghost",


### PR DESCRIPTION
... and make @mittonface happier

![](https://media.giphy.com/media/tHcmzX4i1JX5Cp0BZf/giphy.gif)

We're changing the way people signup on Tina Cloud, you should now use https://app.tina.io/register.