### PR TITLE
Vercel integration documentation

### DIFF
--- a/pages/docs/tina-cloud/vercel-integration.tsx
+++ b/pages/docs/tina-cloud/vercel-integration.tsx
@@ -8,7 +8,7 @@ import {
   RichTextWrapper,
 } from 'components/layout'
 import { NextSeo } from 'next-seo'
-import { LastModified } from './terms-of-service'
+import { LastModified } from '../../terms-of-service'
 import Link from 'next/link'
 
 export default () => (

--- a/pages/vercel-integration.tsx
+++ b/pages/vercel-integration.tsx
@@ -21,9 +21,7 @@ export default () => (
           <LastModified>Last Modified: August 9, 2021</LastModified>
           Our integration lets you easily deploy your sites to Vercel through the Tina dashboard.
           <br />
-          We will act on your behalf to create a project, configure environment variables, and trigger a deployment.
-          <br />
-          Once the project is created, feel free to revoke our integration's access, as it's only used for getting the project set up.
+          We will act on your behalf to create a project, configure environment variables, and trigger a deployment for the project we create.
         </Wrapper>
       </Section>
     </RichTextWrapper>

--- a/pages/vercel-integration.tsx
+++ b/pages/vercel-integration.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import styled from 'styled-components'
+import {
+  Layout,
+  Hero,
+  Wrapper,
+  Section,
+  RichTextWrapper,
+} from 'components/layout'
+import { NextSeo } from 'next-seo'
+import { LastModified } from './terms-of-service'
+import Link from 'next/link'
+
+export default () => (
+  <Layout>
+    <NextSeo title={'Vercel Integration'} description={'Vercel Integration'} />
+    <Hero>Vercel Integration</Hero>
+    <RichTextWrapper>
+      <Section>
+        <Wrapper>
+          <LastModified>Last Modified: August 9, 2021</LastModified>
+          Our integration lets you easily deploy your sites to Vercel through the Tina dashboard.
+          <br />
+          We will act on your behalf to create a project, configure environment variables, and trigger a deployment.
+          <br />
+          Once the project is created, feel free to revoke our integration's access, as it's only used for getting the project set up.
+        </Wrapper>
+      </Section>
+    </RichTextWrapper>
+  </Layout>
+)


### PR DESCRIPTION
Adds a documentation page for our Vercel integration explaining what it's used for.

This is pretty bare-bones right now, as it a pretty simple use. Totally open to content suggestions and moving the page somewhere else. I'm not sure if we have a great spot to put this right now so I just added it to /pages as a one off.

And it isn't required to have a docs page for this but I think it's really nice to explain what we are using it for to the user.

Closes https://github.com/tinacms/teams-serverless/issues/735