### PR TITLE
fix: alpha to beta

### DIFF
--- a/content/blog/announcement-tina-cloud-is-officially-in-alpha.md
+++ b/content/blog/announcement-tina-cloud-is-officially-in-alpha.md
@@ -4,7 +4,7 @@ date: '2021-06-01T20:00:00-04:00'
 author: James Perkins
 last_edited: '2021-06-17T12:45:15.979Z'
 ---
-The team at Tina is pleased to announce that [Tina Cloud](/cloud/) is officially in public Alpha. Everyone is encouraged to [register a free account](https://auth.tina.io/register) on our headless GitHub-backed CMS and start committing. We have been working incredibly hard behind the scenes to get our vision in the hands of developers and content teams.
+The team at Tina is pleased to announce that [Tina Cloud](/) is officially in public Alpha. Everyone is encouraged to [register a free account](https://app.tina.io/register) on our headless GitHub-backed CMS and start committing. We have been working incredibly hard behind the scenes to get our vision in the hands of developers and content teams.
 
 Tina Cloud brings the power of Tina's open-source content editor with [a GraphQL API that allows you to interact with your Markdown files stored in your repository](/blog/using-graphql-with-the-filesystem/). Also, with Tina Cloud, you can allow _any_ team member to edit content — even if they don’t have a GitHub account.
 
@@ -32,7 +32,7 @@ Tina cloud isn't complete yet, some key features  are currently being shaped up:
 
 ## How can I get started?
 
-The first thing to do is to [signup for Tina Cloud](https://auth.tina.io/register), once you're in, we have a few ways for you to get started and get up and running in minutes.
+The first thing to do is to [signup for Tina Cloud](https://app.tina.io/register), once you're in, we have a few ways for you to get started and get up and running in minutes.
 
 * [Tina Cloud Starter](https://github.com/tinacms/tina-cloud-starter): A basic implementation of Tina Cloud aimed at getting your up and running in a few minutes.
 * [Tina Cloud Next.js blog starter](/guides/tina-cloud/existing-site/overview/) - A guide to add Tina Cloud on top of the default Next.js blog starter and work directly through our CMS.

--- a/content/docs/tina-cloud/alpha-faq.md
+++ b/content/docs/tina-cloud/alpha-faq.md
@@ -1,28 +1,27 @@
 ---
-title: Tina Cloud Alpha FAQ
+title: Tina Cloud FAQ
 ---
 
-## What is the Tina Cloud Alpha release?
+## What is the Tina Cloud Beta release?
 
-The Tina Cloud Alpha release gives early adopters the chance to test visual content editing and our Git-backed content API!
+The Tina Cloud Beta release gives early adopters the chance to test visual content editing and our Git-backed content API!
 
 Tina Cloud brings together Tina's open-source content editor with a GraphQL API that talks to content stored in your repository (ie. Markdown and soon JSON).
 
 ## Where do I start?
 
-- Have a look at the updated [Tina Cloud docs](https://tina.io/docs/)
-- Try the [Next.js starter site](https://github.com/tinacms/tina-cloud-starter) (fork it, then follow the readme)
-- Follow the Tina Cloud [getting started guide](https://tina.io/guides/tina-cloud/existing-site/overview/)
-- [Sign up to Tina Cloud](https://auth.tina.io/register)!
+- Have a look at the updated [Tina Cloud docs](/docs/)
+- Try the [Next.js starter site](https://github.com/tinacms/tina-cloud-starter) 
+- Follow the Tina Cloud [getting started guide](/tina-cloud/starter/overview/)
+- [Sign up to Tina Cloud](https://app.tina.io/register)!
 - [Find us on Discord](https://discord.com/invite/zumN63Ybpf)
 
 ## What do I need to know about working with the Alpha release of Tina Cloud?
 
-Since this is an Alpha release you should expect to run into bugs occasionally or be required to update your code because of API improvements.
+Since this is a Beta release you should expect to run into bugs occasionally or be required to update your code because of API improvements.
 
 These features are not (yet) included in Tina Cloud and you might miss them:
 
-- A media management solution
 - A multi-branch workflow
 - The GraphQL API for your content is not yet queryable with read-only tokens. That means it’s only used while editing content with Tina.
 
@@ -45,8 +44,6 @@ The [Next.js starter](https://github.com/tinacms/tina-cloud-starter) can get you
 
 ## What is the pricing for Tina Cloud?
 
-There will be no cost for small teams to use Tina Cloud while it is in Alpha.
+Tina Cloud remains free until we go public. We are still working out our pricing model, and will offer a forever free plan for personal use.
 
-A fair use policy will be coming soon.
-
-We will contact you if we believe your use case may eventually fit within our post-beta paid plans.
+We will contact you if your use case fits within our paid plans for larger teams.

--- a/content/docs/tina-init-tutorial.md
+++ b/content/docs/tina-init-tutorial.md
@@ -212,10 +212,10 @@ Visit [http://localhost:3000/product-listing](http://localhost:3000/product-list
 
 To hook up this demo to Tina Cloud and save content to Github instead of the file system you can do the following.
 
-1.  Register at https://auth.tina.io
+1.  Register at https://app.tina.io
 2.  Update .env file to include:
 
 ```
-NEXT_PUBLIC_TINA_CLIENT_ID= get this from the app you create at auth.tina.io
+NEXT_PUBLIC_TINA_CLIENT_ID= get this from the app you create at app.tina.io
 NEXT_PUBLIC_USE_LOCAL_CLIENT=0
 ```

--- a/now.json
+++ b/now.json
@@ -21,6 +21,7 @@
   },
   "redirects": [
     { "source": "/cloud/", "destination": "/" },
+    { "source": "/docs/tina-cloud/alpha-faq/", "destination": "/docs/tina-cloud/faq/" },
     { "source": "/blog/first", "destination": "/blog/announcing-tinacms" },
     {
       "source": "/blog/introducing-tina-grande-%F0%9F%8E%89",


### PR DESCRIPTION
We're now in beta, our default URL has changed to app.tina.io

@jamespohalloran can we just call it Tina Cloud FAQ instead of Alpha FAQ?