### PR TITLE
Adds LOCAL_CLIENT check to Media Cloudinary

### DIFF
--- a/content/docs/media-cloudinary.md
+++ b/content/docs/media-cloudinary.md
@@ -82,6 +82,10 @@ export default createMediaHandler({
   api_secret: process.env.CLOUDINARY_API_SECRET,
   authorized: async (req, _res) => {
     try {
+      if (process.env.NEXT_PUBLIC_USE_LOCAL_CLIENT) {
+        return true
+      }
+
       const user = await isAuthorized(req)
 
       return user && user.verified


### PR DESCRIPTION
While dogfooding, I encountered an error message when implementing the Cloudinary MediaStore locally (clientId is `null`).

Fortunately, I knew this was being triggered by the `authorized` method and just had it return `true`.  But, I thought it might be best to only short circuit `authorized` when local (and preserve the test otherwise).

This simply changes the suggested code snippet when setting up the API routes.