### PR TITLE
docs: Add command line quickstart option

### DIFF
--- a/content/guides/tina-cloud/starter/overview.md
+++ b/content/guides/tina-cloud/starter/overview.md
@@ -3,6 +3,8 @@ title: Overview
 last_edited: '2021-07-23T14:56:22.352Z'
 ---
 
+> Would you rather try out Tina locally using the command line?<br /> `$ npx create-next-app --example https://github.com/tinacms/tina-cloud-starter`
+
 This guide involves a simple Next.js application configured with TinaCMS.
 
 Not only can you visually edit content in real-time, but since this starter is powered by Tina's GraphQL API, TinaCMS forms are automatically generated for you, all you need to do is to define your content schema ✨.


### PR DESCRIPTION
When a user clicks "quickstart" form the home page, give them an option to start locally, rather than having to sign up. 
I thought the create-next-app approach might work better than a clone / install / yarn dev approach, because when the user eventually connects to Tina Cloud, they can just push up what they have rather than needing to change the remote from tinacms/tina-cloud-starter to <users-account>/tina-cloud-starter.

<img width="857" alt="Screen Shot 2021-09-03 at 9 26 13 AM" src="https://user-images.githubusercontent.com/3323181/132005560-a758840b-ca90-4caa-adf3-c58a0966bf41.png">
