### PR TITLE
Updated `getStaticPropsForTina` usage in Docs

### DIFF
--- a/content/docs/tinacms-context.md
+++ b/content/docs/tinacms-context.md
@@ -21,8 +21,10 @@ const getStaticProps = async () => {
     query: `
       query GetPostDocument($relativePath: String!) {
         getPostDocument(relativePath: $relativePath) {
-          title
-          body
+          data {
+            title
+            body
+          }
         }
       }
     `,
@@ -32,8 +34,10 @@ const getStaticProps = async () => {
   })
 
   return {
-    ...tinaProps,
-    myOtherProp: 'some-other-data',
+    props: {
+      ...tinaProps,
+      myOtherProp: 'some-other-data',
+    },
   }
 }
 ```


### PR DESCRIPTION
Mitch pointed out that the example usage of `getStaticPropsForTina` in the documentation is not correct.

More than likely, a change was made to its usage and the documentation was not updated.