### PR TITLE
Make the full docs nav viewable when nested

### DIFF
--- a/components/DocumentationNavigation/DocsLeftSidebar.tsx
+++ b/components/DocumentationNavigation/DocsLeftSidebar.tsx
@@ -28,8 +28,6 @@ export const DocsLeftSidebar = styled.div<{ open: boolean }>`
     background-attachment: local, scroll;
     background-repeat: no-repeat;
     background-size: 100% 1rem, 100% 1rem;
-    overflow-x: hidden;
-    overflow-y: auto;
     margin-right: -1px;
   }
 

--- a/components/DocumentationNavigation/DocsNavigationList.tsx
+++ b/components/DocumentationNavigation/DocsNavigationList.tsx
@@ -7,11 +7,6 @@ import { NavSection } from './NavSection'
 import { useRouter } from 'next/router'
 import { matchActualTarget } from 'utils'
 
-export interface DocsSectionProps extends DocsNavProps {
-  BackLink: () => JSX.Element
-  category: string
-}
-
 export const NavListContext = createContext({ current: null })
 
 const getCategoryMatch = (navItems, currentPath) => {
@@ -62,87 +57,77 @@ export const DocsNavigationList = ({ navItems, guide }: DocsNavProps) => {
     )
   }, [currentCategory])
 
-  const DocsIndexLink = React.useCallback(
-    () => (
-      <Link href="/docs">
-        <IndexLink>← Docs Index</IndexLink>
-      </Link>
-    ),
-    []
-  )
-  const GuidesIndexLink = React.useCallback(
-    () => (
-      <Link href="/guides">
-        <IndexLink>← Guides Index</IndexLink>
-      </Link>
-    ),
-    []
-  )
-
   return (
     <>
       <MobileMainNav>
         <DocsLinkNav />
       </MobileMainNav>
-      {currentCategoryData ? (
-        <DocsNavigationSection
-          navItems={currentCategoryData.items}
-          guide={guide}
-          BackLink={guide ? GuidesIndexLink : DocsIndexLink}
-          category={currentCategoryData.category}
-        />
-      ) : (
-        <DocsCategoryList
-          navItems={navItems}
-          onSelect={setCurrentCategory}
-          activeCategory={activeCategory}
-        />
-      )}
+      <DocsNavigationContainer>
+        {navItems.map(categoryData => (
+          <>
+            <DocsCategoryHeading
+              categoryData={categoryData}
+              onSelect={setCurrentCategory}
+              isActive={categoryData.category == activeCategory}
+            />
+            {categoryData.category == activeCategory && (
+              <DocsNavigationSection
+                navItems={categoryData.items}
+                guide={guide}
+              />
+            )}
+          </>
+        ))}
+      </DocsNavigationContainer>
     </>
   )
+
+  // return (
+  //   <>
+  //     <MobileMainNav>
+  //       <DocsLinkNav />
+  //     </MobileMainNav>
+  //     {currentCategoryData ? (
+  //       <DocsNavigationSection
+  //         navItems={currentCategoryData.items}
+  //         guide={guide}
+  //         BackLink={guide ? GuidesIndexLink : DocsIndexLink}
+  //         category={currentCategoryData.category}
+  //       />
+  //     ) : (
+  //       <DocsCategoryList
+  //         navItems={navItems}
+  //         onSelect={setCurrentCategory}
+  //         activeCategory={activeCategory}
+  //       />
+  //     )}
+  //   </>
+  // )
 }
 
-const DocsCategoryList = ({ navItems, onSelect, activeCategory }) => {
+const DocsCategoryHeading = ({ categoryData, onSelect, isActive }) => {
   return (
-    <div style={{ padding: '1rem 0' }}>
-      {navItems.map(categoryData => {
-        return (
-          <Link href={categoryData.slug} passHref>
-            <CategoryAnchor
-              onClick={e => {
-                if (activeCategory === categoryData.category) {
-                  e.preventDefault()
-                  onSelect(categoryData.category)
-                }
-              }}
-            >
-              {categoryData.category} <AnchorIcon>→</AnchorIcon>
-              <CategoryDescription>
-                {categoryData.description}
-              </CategoryDescription>
-            </CategoryAnchor>
-          </Link>
-        )
-      })}
-    </div>
+    <Link href={categoryData.slug || '/'} passHref>
+      <CategoryAnchor
+        onClick={e => {
+          if (isActive) {
+            e.preventDefault()
+            onSelect(categoryData.category)
+          }
+        }}
+      >
+        {categoryData.category} {isActive && <AnchorIcon>→</AnchorIcon>}
+      </CategoryAnchor>
+    </Link>
   )
 }
 
-const DocsNavigationSection = ({
-  navItems,
-  guide,
-  BackLink,
-  category,
-}: DocsSectionProps) => {
+const DocsNavigationSection = ({ navItems }: DocsNavProps) => {
   const navListRef = useRef<HTMLUListElement>(null)
 
   return (
     <NavListContext.Provider value={navListRef}>
       <ul ref={navListRef}>
-        <NavListHeader>
-          {BackLink && <BackLink />}
-          <CategoryHeader>{category}</CategoryHeader>
-        </NavListHeader>
         {navItems &&
           navItems.map(section => (
             <NavSection key={section.id} {...section} collapsible={false} />
@@ -176,6 +161,11 @@ const MobileMainNav = styled.div`
   @media (min-width: 1200px) {
     display: none;
   }
+`
+
+const DocsNavigationContainer = styled.div`
+  overflow-y: auto;
+  overflow-x: hidden;
 `
 
 const Breadcrumbs = styled.li`

--- a/components/DocumentationNavigation/NavSection.tsx
+++ b/components/DocumentationNavigation/NavSection.tsx
@@ -163,7 +163,6 @@ const NavSectionTitle = styled.span<NavSectionTitleProps>`
   text-decoration: none;
   transition: all 180ms ease-out;
   font-family: var(--font-tuner);
-  font-size: 1.125rem;
 
   ${props =>
     props.currentPage &&

--- a/now.json
+++ b/now.json
@@ -21,7 +21,10 @@
   },
   "redirects": [
     { "source": "/cloud/", "destination": "/" },
-    { "source": "/docs/tina-cloud/alpha-faq/", "destination": "/docs/tina-cloud/faq/" },
+    {
+      "source": "/docs/tina-cloud/alpha-faq/",
+      "destination": "/docs/tina-cloud/faq/"
+    },
     { "source": "/blog/first", "destination": "/blog/announcing-tinacms" },
     {
       "source": "/blog/introducing-tina-grande-%F0%9F%8E%89",
@@ -254,7 +257,8 @@
     {
       "source": "/guides/nextjs/github-open-authoring/(.*)",
       "destination": "/guides/experimental/github/$1"
-    },{
+    },
+    {
       "source": "/guides/tinacms/github/(.*)",
       "destination": "/guides/experimental/github/$1"
     },
@@ -279,7 +283,7 @@
       "destination": "/guides/experimental/github/$1"
     },
     {
-      "source":"/guides/nextjs/tina-with-strapi/(.*)",
+      "source": "/guides/nextjs/tina-with-strapi/(.*)",
       "destination": "/guides/experimental/tina-with-strapi/$1"
     },
     {
@@ -289,9 +293,14 @@
     {
       "source": "/guides/nextjs/adding-tina/(.*)",
       "destination": "/guides/tina-cloud/add-tinacms-to-existing-site/overview/"
-    },{
+    },
+    {
       "source": "/packages/next-tinacms-cloudinary/(.*)",
       "destination": "/docs/media-cloudinary/"
+    },
+    {
+      "source": "/docs/",
+      "destination": "docs/tina-cloud/"
     }
   ]
 }

--- a/pages/guides/[category]/[guide]/[step].tsx
+++ b/pages/guides/[category]/[guide]/[step].tsx
@@ -27,6 +27,7 @@ import { InlineGithubForm } from 'components/layout/InlineGithubForm'
 import { NavSectionProps } from 'components/DocumentationNavigation'
 import { openGraphImage } from 'utils/open-graph-image'
 import * as ga from '../../../../utils/ga'
+import { getDocsNav } from 'utils/docs/getDocProps'
 
 interface GuideTemplateProps {
   tocItems: string
@@ -34,6 +35,7 @@ interface GuideTemplateProps {
   guideMeta: GitFile
   markdownFile: GitFile
   allGuides: NavSectionProps[]
+  docsNav: any
 }
 
 type GitFile = {
@@ -48,6 +50,7 @@ export default function GuideTemplate({
   guideMeta,
   markdownFile,
   allGuides,
+  docsNav,
 }: GuideTemplateProps) {
   const isBrowser = typeof window !== `undefined`
   const contentRef = React.useRef<HTMLDivElement>(null)
@@ -169,7 +172,7 @@ export default function GuideTemplate({
           ],
         }}
       />
-      <DocsLayout navItems={guideNav} guide={breadcrumb}>
+      <DocsLayout navItems={docsNav} guide={breadcrumb}>
         <DocsGrid>
           <DocGridHeader>
             <DocsPageTitle>
@@ -203,13 +206,12 @@ export const getStaticProps: GetStaticProps = async function(ctx) {
     ctx.previewData
   )
 
+  const slug = `content/guides/${category}/${guide}/${step}.md`
   const {
     props: { preview, file: markdownFile, tocItems },
-  } = await getMarkdownPreviewProps(
-    `content/guides/${category}/${guide}/${step}.md`,
-    ctx.preview,
-    ctx.previewData
-  )
+  } = await getMarkdownPreviewProps(slug, ctx.preview, ctx.previewData)
+
+  const docsNav = await getDocsNav(preview, slug)
 
   return {
     props: {
@@ -220,6 +222,7 @@ export const getStaticProps: GetStaticProps = async function(ctx) {
       },
       guideMeta,
       markdownFile,
+      docsNav,
       allGuides: await getGuideNavProps(),
       tocItems,
     },


### PR DESCRIPTION
This still needs a lot of work, but wanted to get people's thoughts before I moved further. 

I find currently, it's easy to get lost in the docs, as there's not much context of where you are. 

I think if we can show the full nested context from the sidebar will help.

Notes:
- Guides pages currently blow up 
- We should probably do some considerable refactoring of the nav if we want to move forward. It's clear it's gone through quite a few iterations. 