### PR TITLE
docs: remove getStaticPropsForTina from intro doc

### DIFF
--- a/content/docs/features/data-fetching.md
+++ b/content/docs/features/data-fetching.md
@@ -31,7 +31,7 @@ const getStaticProps = async () => {
     relativePath: 'hello-world.md',
   }
 
-  let data
+  let data = {}
   try {
     data = await staticRequest({
       query,

--- a/content/docs/features/data-fetching.md
+++ b/content/docs/features/data-fetching.md
@@ -4,7 +4,7 @@ id: '/docs/features/data-fetching'
 next: '/docs/tinacms-context'
 ---
 
-With Tina, your content is stored in Git along with your codebase. Instead of using something like `fs.readfile` to access your content, Tina provides an API to query your content through GraphQL, based on your defined content models.
+With Tina, your content is stored in Git along with your codebase. Tina provides an API to query your content through GraphQL, based on your defined content models.
 
 ## `staticRequest`
 

--- a/content/docs/features/data-fetching.md
+++ b/content/docs/features/data-fetching.md
@@ -4,7 +4,7 @@ id: '/docs/features/data-fetching'
 next: '/docs/tinacms-context'
 ---
 
-With Tina, your content is stored in Git along with your codebase. Instead of using something `fs.readfile` to access your content, Tina provides an API to query your content through GraphQL, based on your defined content models.
+With Tina, your content is stored in Git along with your codebase. Instead of using something like `fs.readfile` to access your content, Tina provides an API to query your content through GraphQL, based on your defined content models.
 
 ## `staticRequest`
 
@@ -54,6 +54,8 @@ const getStaticProps = async () => {
 
 > Note: for now, TinaCMS only supports static data fetching, so you must use `getStaticProps` (and `getStaticPaths` for dynamic pages). We'll be opening up more capabilities in the near future!
 
+### Example: Fetching content through getStaticPaths
+
 You'll likely want to query the Tina data layer for [dynamic routes](https://nextjs.org/docs/basic-features/data-fetching#getstaticpaths-static-generation).
 
 ```js
@@ -86,6 +88,6 @@ export const getStaticPaths = async () => {
 
 ### Do I need to use `staticRequest`?
 
-Absolutely not. These are helper functions which emphasize that static requests should only be made against your _local_ server. The `@tinacms/cli` runs a GraphQL server at `http://localhost:4001`, so feel free to use any HTTP client you'd like.
+Absolutely not. This is a helper function which emphasizes that static requests should only be made against your _local_ server. The `staticRequest` helper function makes the request against `http://localhost:4001`, which is where `@tinacms/cli` runs its GraphQL server. Feel free to use any HTTP client you'd like.
 
 Note, however, that it's important to return an object from `getStaticProps` which has `data`, `query`, and `variables` properties so the client-side TinaCMS container can make everything editable on your page.

--- a/content/docs/features/data-fetching.md
+++ b/content/docs/features/data-fetching.md
@@ -4,22 +4,20 @@ id: '/docs/features/data-fetching'
 next: '/docs/tinacms-context'
 ---
 
-There are essentially two touch points you'll need set up in order for Tina to work with your Next.js application or website.
+With Tina, your content is stored in Git along with your codebase. Instead of using something `fs.readfile` to access your content, Tina provides an API to query your content through GraphQL, based on your defined content models.
 
-1. Load data from the TinaCMS GraphQL API from `getStaticProps`
-2. Conditionally wrap your app in the TinaCMS context
+## `staticRequest`
 
-## `getStaticPropsForTina`
+`staticRequest` is a helper function, which makes a request to your locally-running GraphQL server.
 
-TinaCMS is easiest to work with when you provide a predictable shape to the props you return from `getStaticProps`. `getStaticPropsForTina` enforces this shape for you:
+### Example: Fetching content through getStaticProps
 
 ```tsx
 // pages/home.js
-import { getStaticPropsForTina } from 'tinacms'
+import { staticRequest } from 'tinacms'
 
 const getStaticProps = async () => {
-  const tinaProps = await getStaticPropsForTina({
-    query: `
+  const query = `
       query GetPostDocument($relativePath: String!) {
         getPostDocument(relativePath: $relativePath) {
           data {
@@ -28,37 +26,35 @@ const getStaticProps = async () => {
           }
         }
       }
-    `,
-    variables: {
-      relativePath: 'hello-world.md',
-    },
-  })
+    `
+  const variables = {
+    relativePath: 'hello-world.md',
+  }
+
+  let data
+  try {
+    data = await staticRequest({
+      query,
+      variables,
+    })
+  } catch {
+    // swallow errors related to document creation
+  }
 
   return {
     props: {
-      ...tinaProps,
-      myOtherProp: 'some-other-data',
+      query,
+      variables,
+      data,
+      //myOtherProp: 'some-other-data',
     },
   }
 }
 ```
 
-```ts
-type getStaticPropsForTina = (args: {
-  query: string
-  variables?: object
-}) => Promise<{
-  query: string
-  variables?: object
-  data: object
-}>
-```
-
 > Note: for now, TinaCMS only supports static data fetching, so you must use `getStaticProps` (and `getStaticPaths` for dynamic pages). We'll be opening up more capabilities in the near future!
 
-## `staticRequest`
-
-You'll likely want to query the GraphQL API for [dynamic routes](https://nextjs.org/docs/basic-features/data-fetching#getstaticpaths-static-generation). `staticRequest` is a simple helper function which wraps the built-in `fetch` API:
+You'll likely want to query the Tina data layer for [dynamic routes](https://nextjs.org/docs/basic-features/data-fetching#getstaticpaths-static-generation).
 
 ```js
 export const getStaticPaths = async () => {
@@ -88,8 +84,8 @@ export const getStaticPaths = async () => {
 
 ## FAQ
 
-### Do I need to use `getStaticPropsForTina` and `staticRequest`?
+### Do I need to use `staticRequest`?
 
 Absolutely not. These are helper functions which emphasize that static requests should only be made against your _local_ server. The `@tinacms/cli` runs a GraphQL server at `http://localhost:4001`, so feel free to use any HTTP client you'd like.
 
-Note, however, that it's important to return an object from `getStaticProps` which has `data`, `query`, and `variables` properties so TinaCMS can make everything editable on your page.
+Note, however, that it's important to return an object from `getStaticProps` which has `data`, `query`, and `variables` properties so the client-side TinaCMS container can make everything editable on your page.

--- a/content/docs/schema-advanced.md
+++ b/content/docs/schema-advanced.md
@@ -1,128 +1,131 @@
 ---
 title: Advanced Usage Example
 ---
+
 The purpose of this example is to demonstrate how to create and use a more complicated `schema` (which utilizes simple and complex `object` fields), write a `getDocument` GraphQL query, and utilize the query's result in rendering.
 ​
+
 ## Schema
+
 ​
 The schema defines a `recipe` collection which consists of some standard fields (`name`, `photo`, `description`) and more advanced fields (`meta`, `sections`).
 ​
+
 ```ts, copy
 // .tina/schema.ts
-import { defineSchema } from "@tinacms/cli";
-​
+import { defineSchema } from '@tinacms/cli'
 export default defineSchema({
   collections: [
     {
-      name: "recipe",
-      label: "Recipes",
-      path: "content/recipes",
+      name: 'recipe',
+      label: 'Recipes',
+      path: 'content/recipes',
       fields: [
         {
-          name: "datePublished",
-          label: "Published On",
-          type: "datetime",
+          name: 'datePublished',
+          label: 'Published On',
+          type: 'datetime',
           ui: {
-            dateFormat: "MMM D, YYYY",
+            dateFormat: 'MMM D, YYYY',
           },
         },
         {
-          type: "string",
-          name: "name",
-          label: "Name",
+          type: 'string',
+          name: 'name',
+          label: 'Name',
         },
         {
-          type: "image",
-          name: "photo",
-          label: "Photo",
+          type: 'image',
+          name: 'photo',
+          label: 'Photo',
         },
         {
-          type: "string",
-          name: "description",
-          label: "Description",
+          type: 'string',
+          name: 'description',
+          label: 'Description',
           isBody: true,
           ui: {
-            component: "textarea",
+            component: 'textarea',
           },
         },
         {
-          type: "object",
-          name: "meta",
-          label: "Meta",
+          type: 'object',
+          name: 'meta',
+          label: 'Meta',
           fields: [
             {
-              name: "prep",
-              label: "Prep Time (in minutes)",
-              type: "string",
+              name: 'prep',
+              label: 'Prep Time (in minutes)',
+              type: 'string',
             },
             {
-              name: "cook",
-              label: "Cook Time (in minutes)",
-              type: "string",
+              name: 'cook',
+              label: 'Cook Time (in minutes)',
+              type: 'string',
             },
             {
-              name: "servings",
-              label: "Servings",
-              type: "string",
+              name: 'servings',
+              label: 'Servings',
+              type: 'string',
             },
           ],
         },
         {
-          type: "object",
-          name: "sections",
-          label: "Sections",
+          type: 'object',
+          name: 'sections',
+          label: 'Sections',
           list: true,
           templates: [
             {
-              name: "ingredients",
-              label: "Ingredients",
+              name: 'ingredients',
+              label: 'Ingredients',
               fields: [
                 {
-                  name: "items",
-                  label: "Items",
-                  type: "string",
+                  name: 'items',
+                  label: 'Items',
+                  type: 'string',
                   list: true,
                 },
                 {
-                  name: "details",
-                  label: "Details",
-                  type: "string",
+                  name: 'details',
+                  label: 'Details',
+                  type: 'string',
                   ui: {
-                    component: "textarea",
+                    component: 'textarea',
                   },
                 },
               ],
             },
             {
-              name: "directions",
-              label: "Directions",
+              name: 'directions',
+              label: 'Directions',
               fields: [
                 {
-                  name: "steps",
-                  label: "Steps",
-                  type: "string",
+                  name: 'steps',
+                  label: 'Steps',
+                  type: 'string',
                   list: true,
                 },
                 {
-                  name: "details",
-                  label: "Details",
-                  type: "string",
+                  name: 'details',
+                  label: 'Details',
+                  type: 'string',
                   ui: {
-                    component: "textarea",
+                    component: 'textarea',
                   },
                 },
               ],
             },
             {
-              name: "nutrition",
-              label: "Nutrition",
+              name: 'nutrition',
+              label: 'Nutrition',
               fields: [
                 {
-                  name: "details",
-                  label: "Details",
-                  type: "string",
+                  name: 'details',
+                  label: 'Details',
+                  type: 'string',
                   ui: {
-                    component: "textarea",
+                    component: 'textarea',
                   },
                 },
               ],
@@ -132,10 +135,13 @@ export default defineSchema({
       ],
     },
   ],
-});
+})
 ```
+
 ​
+
 ## Query
+
 ​
 To retrieve a single `recipe`, you would use a query like this one.
 ​
@@ -143,56 +149,68 @@ Notice that, for `sections`, we are using `__typename` to deobfuscate the availa
 ​
 Because `meta` does not have any `templates`, you do not need to deobfuscate and can access its properties directly.
 ​
+
 ```ts, copy
 // pages/recipe/[filename].tsx
-import { getStaticPropsForTina, gql } from "tinacms";
-​
+import { staticRequest, gql } from 'tinacms'
 export const getStaticProps = async ({ params }) => {
-  const recipe = await getStaticPropsForTina({
-    query: gql`
-      query GetRecipeDocument($relativePath: String!) {
-        getRecipeDocument(relativePath: $relativePath) {
-          data {
-            datePublished
-            name
-            photo
-            description
-            meta {
-              prep
-              cook
-              servings
+  const query = `
+    query GetRecipeDocument($relativePath: String!) {
+      getRecipeDocument(relativePath: $relativePath) {
+        data {
+          datePublished
+          name
+          photo
+          description
+          meta {
+            prep
+            cook
+            servings
+          }
+          sections {
+            __typename
+            ... on RecipeSectionsIngredients {
+              items
+              details
             }
-            sections {
-              __typename
-              ... on RecipeSectionsIngredients {
-                items
-                details
-              }
-              ... on RecipeSectionsDirections {
-                steps
-                details
-              }
-              ... on RecipeSectionsNutrition {
-                details
-              }
+            ... on RecipeSectionsDirections {
+              steps
+              details
+            }
+            ... on RecipeSectionsNutrition {
+              details
             }
           }
         }
       }
-    `,
-    variables: { relativePath: `${params.filename}.md` },
-  });
-​
+    }
+  `
+
+  const variables = { relativePath: `${params.filename}.md` }
+
+  let recipe = {}
+  try {
+    recipe = await staticRequest({
+      query,
+      variables,
+    })
+  } catch {
+    // swallow errors related to document creation
+  }
   return {
     props: {
-      ...recipe,
+      query,
+      variables,
+      data: recipe,
     },
-  };
-};
+  }
+}
 ```
+
 ​
 This query will return an `Object` in the shape of:
 ​
+
 ```ts, copy
 {
   "data": {
@@ -228,13 +246,17 @@ This query will return an `Object` in the shape of:
   }
 }
 ```
+
 ​
+
 ## Rendering
+
 ​
 The important step here is correctly retrieve the queried `data` out of `props`. The common pattern is `data: { query: { data: document }}`.
 ​
 Notice that `sections` is iterated via `map()` utilizing the `__typename` to determine how each `section` should be rendered.
 ​
+
 ```tsx, copy
 // pages/recipe/[filename].tsx
 const RecipePage = (props) => {
@@ -243,7 +265,7 @@ const {
       getRecipeDocument: { data: recipe },
     },
   }  = props;
-  
+
 const { datePublished, name, photo, description, meta, sections } = recipe;
 ​
   /**
@@ -253,7 +275,7 @@ const { datePublished, name, photo, description, meta, sections } = recipe;
    *
    * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString
    */
-  
+
   const localDatePublished = React.useMemo(() => {
   if (datePublished) {
     return new Date(datePublished).toLocaleDateString(undefined, {
@@ -295,19 +317,19 @@ const { datePublished, name, photo, description, meta, sections } = recipe;
       {sections && sections.map((section) => {
         if (section.__typename === "RecipeSectionsIngredients") {
           return (
-            <RecipeIngredients key={`${name}.${section.__typename}`} 
+            <RecipeIngredients key={`${name}.${section.__typename}`}
             {...section} />
           )
         }
         if (section.__typename === "RecipeSectionsDirections") {
           return (
-            <RecipeDirections key={`${name}.${section.__typename}`} 
+            <RecipeDirections key={`${name}.${section.__typename}`}
             {...section} />
           )
         }
         if (section.__typename === "RecipeSectionsNutrition") {
           return (
-            <RecipeNutrition key={`${name}.${section.__typename}`} 
+            <RecipeNutrition key={`${name}.${section.__typename}`}
             {...section} />
           )
         }

--- a/content/guides/tina-cloud/add-tinacms-to-existing-site/markdown-plugin.md
+++ b/content/guides/tina-cloud/add-tinacms-to-existing-site/markdown-plugin.md
@@ -2,6 +2,7 @@
 title: Adding Markdown editors
 last_edited: '2021-08-13T18:34:29.221Z'
 ---
+
 ## Using Markdown plugins:
 
 One of the amazing features of Tina is ability to extend the project through plugins. The NextJS blog starter uses remark to render the Markdown files into HTML, so it would be useful for our content team to be able to edit using a markdown editor, plus we can add the functionality back.
@@ -159,7 +160,7 @@ import PostTitle from '../../components/post-title'
 import Head from 'next/head'
 import { CMS_NAME } from '../../lib/constants'
 import markdownToHtml from '../../lib/markdownToHtml'
-import { staticRequest, getStaticPropsForTina } from 'tinacms'
+import { staticRequest } from 'tinacms'
 import { useEffect, useState } from 'react'
 
 export default function Post({ data, slug, preview }) {
@@ -216,8 +217,8 @@ export default function Post({ data, slug, preview }) {
 export const getStaticProps = async ({ params }) => {
   const { slug } = params
   const variables = { relativePath: `${slug}.md` }
-  const tinaProps = await getStaticPropsForTina({
-    query: `
+
+  const query = `
       query BlogPostQuery($relativePath: String!) {
         getPostsDocument(relativePath: $relativePath) {
           data {
@@ -236,13 +237,23 @@ export const getStaticProps = async ({ params }) => {
           }
         }
       }
-    `,
-    variables: variables,
-  })
+    `
+
+  let data = {}
+  try {
+    data = await staticRequest({
+      query,
+      variables,
+    })
+  } catch {
+    // swallow errors related to document creation
+  }
 
   return {
     props: {
-      ...tinaProps,
+      query,
+      variables,
+      data,
       slug,
     },
   }

--- a/content/guides/tina-cloud/add-tinacms-to-existing-site/next-changes.md
+++ b/content/guides/tina-cloud/add-tinacms-to-existing-site/next-changes.md
@@ -2,6 +2,7 @@
 title: Making our pages editable with Tina
 last_edited: '2021-08-13T18:33:15.008Z'
 ---
+
 ## Overview
 
 Currently, the Next Blog Starter grabs content from the file system. But since Tina comes with a GraphQL API on top of the filesystem, we’re going to query that instead. Using the GraphQL API will allow you to use the power of TinaCMS, you will be able to retrieve the content and also edit and save the content directly.
@@ -135,13 +136,13 @@ The `getStaticProps` query is going to deliver all the content to the blog, whic
 
 We need to query the following things from our content api:
 
-* Title
-* Excerpt
-* Date
-* Cover Image
-* OG Image data
-* Author Data
-* Body content
+- Title
+- Excerpt
+- Date
+- Cover Image
+- OG Image data
+- Author Data
+- Body content
 
 ### Creating our Query
 
@@ -205,12 +206,10 @@ export const getStaticProps = async ({ params }) => {
 }
 ```
 
-We'll use a new helper function called `getStaticPropsForTina`, which does exactly like it sounds like it might do. It will return not only the _data_ from your query, but also the query string and variables themselves. This is necessary for Tina to enable realtime editing on your page.
-
-Add `getStaticPropsForTina` to the imports at the top of your file, your import should look like:
+We'll also want to call `staticRequest` to load our data for our specific page. You'll also notice that we will return the query & variables from getStaticProps. We'll be using these values within the TinaCMS frontend.
 
 ```js, copy
-import { staticRequest, getStaticPropsForTina } from 'tinacms'
+import { staticRequest } from 'tinacms'
 ```
 
 So the full query should look like this:
@@ -219,33 +218,36 @@ So the full query should look like this:
 export const getStaticProps = async ({ params }) => {
   const { slug } = params
   const variables = { relativePath: `${slug}.md` }
-  const tinaProps = await getStaticPropsForTina({
-    query: `
-      query BlogPostQuery($relativePath: String!) {
-        getPostsDocument(relativePath: $relativePath) {
-          data {
-            title
-            excerpt
-            date
-            coverImage
-            author {
-              name
-              picture
-            }
-            ogImage {
-              url
-            }
-            body
+  const query = `
+    query BlogPostQuery($relativePath: String!) {
+      getPostsDocument(relativePath: $relativePath) {
+        data {
+          title
+          excerpt
+          date
+          coverImage
+          author {
+            name
+            picture
           }
+          ogImage {
+            url
+          }
+          body
         }
       }
-    `,
+    }
+  `
+  const data = await staticRequest({
+    query: query,
     variables: variables,
   })
 
   return {
     props: {
-      ...tinaProps, // {data: {...}, query: '...', variables: {...}}
+      query,
+      variables,
+      data,
       slug,
     },
   }

--- a/content/guides/tina-cloud/starter/structure.md
+++ b/content/guides/tina-cloud/starter/structure.md
@@ -2,6 +2,7 @@
 title: Tina Cloud Starter structure
 last_edited: '2021-08-23T01:43:21.819Z'
 ---
+
 From here, you're ready to start building your own project. This section explains a bit about how this project is structured, and how to modify it to make it your own.
 
 ## Starter structure
@@ -33,7 +34,7 @@ With Tina Cloud there's no need to build forms manually like you would with Tina
 This is set up for you in `./.tina/schema.ts`, let's break down what this function is doing:
 
 ```ts
-import { defineSchema } from "tina-graphql-gateway-cli";
+import { defineSchema } from 'tina-graphql-gateway-cli'
 ```
 
 Head over to the [reference](/docs/tinacms-reference/) documentation to learn more about [defining a schema](/docs/schema/) or [querying with GraphQL](/docs/graphql/)
@@ -70,7 +71,7 @@ By default we've toggle the `showEditButton` to `true`. You'll likely want to re
 
 ### `pages/posts/[filename].tsx`
 
-The posts are stored in the `content/posts` directory of this repository, and their routes are built with `getStaticPaths` dynamically at build time. You'll notice a couple of helper functions like `getStaticPropsForTina` and `staticRequest`. These are helper functions to make sure you're returning data from the local GraphQL server in a shape that Tina understands. Feel free to bring your own http client if you'd like. Read more about these helpers in the [Next.JS APIs documentation](/docs/tinacms-context/)
+The posts are stored in the `content/posts` directory of this repository, and their routes are built with `getStaticPaths` dynamically at build time. You'll notice that we use the `staticRequest` helper to query our content. Feel free to bring your own http client if you'd like. Read more about these helpers in the [Next.JS APIs documentation](/docs/tinacms-context/).
 
 ### Creating your own pages
 


### PR DESCRIPTION
Partially addresses https://github.com/tinacms/tinacms/issues/2108 (We still would need to update a few other docs, and update our starter, but wanted to push this up to get opinions.)

As noted in that issue, I think having a separate API for talking to our content-api within getStaticProps vs getStaticPaths adds unnecessary complexity. I feel like using the `staticRequest` function within getStaticProps & getStaticPaths reads better, but thoughts?

https://tinacms-site-next-git-rm-getstaticpropsfortina-tinacms.vercel.app/docs/features/data-fetching/