### PR TITLE
Change references from Apps to Projects

### DIFF
--- a/content/blog/tina-cloud-a-headless-cms-backed-by-git.md
+++ b/content/blog/tina-cloud-a-headless-cms-backed-by-git.md
@@ -37,7 +37,7 @@ To overcome these limitations, Tina Cloud provides a GraphQL interface to your r
 
 ### Bring visual editing to the whole team with Tina Cloud
 
-The best websites result from collaboration between engineers, designers, writers, and marketers. These people need the ability to work from a single source of truth and Tina Cloud offers a simple **dashboard** for admins to manage sites and collaborators.![Tina Cloud Dashboard: Apps Tab](/img/blog/tina-cloud-dashboard.png 'Tina Cloud Dashboard: Apps Tab')
+The best websites result from collaboration between engineers, designers, writers, and marketers. These people need the ability to work from a single source of truth and Tina Cloud offers a simple **dashboard** for admins to manage sites and collaborators.![Tina Cloud Dashboard: Projects Tab](/img/blog/tina-cloud-dashboard.png 'Tina Cloud Dashboard: Projects Tab')
 
 Tina Cloud provides user management, authentication, and basic roles for your editing team. Give your team members access, even if they don’t have a GitHub account. ✨
 

--- a/content/docs/tina-cloud.md
+++ b/content/docs/tina-cloud.md
@@ -8,7 +8,7 @@ Tina Cloud is a multi-level backend solution for TinaCMS. Included in this solut
 
 ## Tina Cloud Dashboard
 
-The Tina Cloud dashboard is used to connect sites with your editors. Through the dashboard, you can setup an app. An app connects to your site's GitHub repository, and authorizes Tina Cloud to push and pull content directly from the repository. You can also authenticate certain users to edit your site through the dashboard's user management page. Together, this allows users to login directly to your site and start editing the content while also simultaneously updating the content within the GitHub repository.
+The Tina Cloud dashboard is used to connect sites with your editors. Through the dashboard, you can setup a project. A project connects to your site's GitHub repository, and authorizes Tina Cloud to push and pull content directly from the repository. You can also authenticate certain users to edit your site through the dashboard's user management page. Together, this allows users to login directly to your site and start editing the content while also simultaneously updating the content within the GitHub repository.
 
 An important distinction to make is that unlike a traditional CMS dashboard, the Tina Cloud dashboard is not used to edit your content. The difference of the Tina Cloud dashboard is that the content editing capabilities are setup by you, the developer, using our TinaCMS toolkit.
 

--- a/content/docs/tina-cloud/dashboard.md
+++ b/content/docs/tina-cloud/dashboard.md
@@ -22,19 +22,19 @@ To create an account navigate to the <a href="https://app.tina.io/register" targ
 
 #### 1. Connecting a GitHub repository
 
-When setting up an app, the first step will prompt for authentication with GitHub. A modal window asks for permission to give Tina.io access to your GitHub repositories. This authentication allows Tina Cloud to push and pull content to and from your GitHub repository.
+When setting up a project, the first step will prompt for authentication with GitHub. A modal window asks for permission to give Tina.io access to your GitHub repositories. This authentication allows Tina Cloud to push and pull content to and from your GitHub repository.
 
 #### 2. Choosing a repository
 
 The next step is to choose the repository that houses your site's content. If you don't see your repository within the list of repositories on the dashboard, you may have to re-configure your Tina.io permissions within GitHub.
 
-#### 3. Configuring an app
+#### 3. Configuring a project
 
-On the last step of app creation, we ask you to enter a bit of configuration.
+On the last step of project creation, we ask you to enter a bit of configuration.
 
-##### App Name
+##### Project Name
 
-This name is shown to your users when they login to the app. The default is the repository name.
+This name is shown to your users when they login to the project. The default is the repository name.
 
 ##### Development Environments
 
@@ -50,11 +50,11 @@ If Tina Cloud is configured on your production site, this value might be somethi
 
 > Only the URL origin is needed, so there is no need to include the path to any specific pages.
 
-#### 4. Using your app
+#### 4. Using your project
 
-Once your app is created, you will see it listed on your Projects page.
+Once your project is created, you will see it listed on your Projects page.
 
-An app's Overview page gives you an important value: your app's unique **Client ID**. This value is used by Tina Cloud to connect to your site's repository. You will need to use this as an environment variable when setting up your site to use Tina.
+A project's Overview page gives you an important value: your project's unique **Client ID**. This value is used by Tina Cloud to connect to your site's repository. You will need to use this as an environment variable when setting up your site to use Tina.
 
 ## Users
 

--- a/content/docs/tina-cloud/dashboard.md
+++ b/content/docs/tina-cloud/dashboard.md
@@ -4,7 +4,7 @@ id: '/docs/tina-cloud/dashboard'
 next: '/docs/tina-cloud/using-app'
 ---
 
-The **Tina Cloud Dashboard** is the interface for managing the administrative aspects of your content management. The dashboard allows you to create **apps**, and setup your **users**.
+The **Tina Cloud Dashboard** is the interface for managing the administrative aspects of your content management. The dashboard allows you to create **projects**, and setup your **users**.
 
 ![tina-cloud-dashboard](/img/cloud-dashboard.jpg)
 
@@ -12,11 +12,11 @@ The **Tina Cloud Dashboard** is the interface for managing the administrative as
 
 To create an account navigate to the <a href="https://app.tina.io/register" target="_blank">Tina.io Registration Page</a> and enter some personal login credentials. Once your account is verified, you will be able to login and access the dashboard.
 
-## Apps
+## Projects
 
-**Apps** connect Tina Cloud with a GitHub repository. An app is the **connection point between your site and your users**, allowing authorized users to access and modify a site's content.
+**Projects** connect Tina Cloud with a GitHub repository. A project is the **connection point between your site and your users**, allowing authorized users to access and modify a site's content.
 
-> If it is your first time accessing the Tina Cloud dashboard, you will be given two options for setting up your first app. You can fork our <a href="https://github.com/tinacms/tina-cloud-starter" target="_blank">pre-built Next.js starter</a> which gets you up and running with Tina quickly and easily. Alternatively, you can connect to your own GitHub repository.
+> If it is your first time accessing the Tina Cloud dashboard, you will be given two options for setting up your first project. You can fork our <a href="https://github.com/tinacms/tina-cloud-starter" target="_blank">pre-built Next.js starter</a> which gets you up and running with Tina quickly and easily. Alternatively, you can connect to your own GitHub repository.
 
 ### Setup
 
@@ -52,7 +52,7 @@ If Tina Cloud is configured on your production site, this value might be somethi
 
 #### 4. Using your app
 
-Once your app is created, you will see it listed on your Apps page.
+Once your app is created, you will see it listed on your Projects page.
 
 An app's Overview page gives you an important value: your app's unique **Client ID**. This value is used by Tina Cloud to connect to your site's repository. You will need to use this as an environment variable when setting up your site to use Tina.
 
@@ -66,7 +66,7 @@ The **User** section of the Tina Cloud dashboard allows external users to be inv
 
 When creating a new user in the dashboard, the permission section will require a role selection for the user. The role breakdown is as follows:
 
-An **Admin** has complete access to the Tina Cloud dashboard. This user can add, edit and delete Tina Cloud apps. This user can also setup additional user accounts or edit existing user accounts.
+An **Admin** has complete access to the Tina Cloud dashboard. This user can add, edit and delete Tina Cloud projects. This user can also setup additional user accounts or edit existing user accounts.
 
 An **Editor** can login to the Tina Cloud dashboard but is only authorized to view the sites that are configured and navigate to them.
 

--- a/content/docs/tina-cloud/faq.md
+++ b/content/docs/tina-cloud/faq.md
@@ -2,6 +2,7 @@
 title: Tina Cloud FAQ
 last_edited: '2021-08-10T18:02:19.898Z'
 ---
+
 ## What's the difference between Tina Cloud and TinaCMS?
 
 TinaCMS is our original open source toolkit that enables developers to create a live editing experience on a site.
@@ -10,11 +11,11 @@ Tina Cloud brings together Tina's open-source content editor with a GraphQL API 
 
 ## Where do I start?
 
-* Have a look at the updated [Tina Cloud docs](https://tina.io/docs/)
-* Try the [Next.js starter site](https://github.com/tinacms/tina-cloud-starter) (fork it, then follow the readme)
-* Follow the Tina Cloud [getting started guide](https://tina.io/guides/tina-cloud/starter/overview)
-* [Sign up to Tina Cloud](https://app.tina.io/register)!
-* [Find us on Discord](https://discord.com/invite/zumN63Ybpf)
+- Have a look at the updated [Tina Cloud docs](https://tina.io/docs/)
+- Try the [Next.js starter site](https://github.com/tinacms/tina-cloud-starter) (fork it, then follow the readme)
+- Follow the Tina Cloud [getting started guide](https://tina.io/guides/tina-cloud/starter/overview)
+- [Sign up to Tina Cloud](https://app.tina.io/register)!
+- [Find us on Discord](https://discord.com/invite/zumN63Ybpf)
 
 ## What do I need to know about working with the current release of Tina Cloud?
 
@@ -22,25 +23,25 @@ Since this is an early release you should expect to run into bugs occasionally o
 
 These features are not (yet) included in Tina Cloud and you might miss them:
 
-* A multi-branch workflow
-* The GraphQL API for your content is not yet queryable with read-only tokens. That means it’s only used while editing content with Tina.
+- A multi-branch workflow
+- The GraphQL API for your content is not yet queryable with read-only tokens. That means it’s only used while editing content with Tina.
 
 ## What technical considerations should I make when working with Tina Cloud?
 
 You'll find success with Tina Cloud if your project includes:
 
-* [Next.js](https://nextjs.org/) - The flexibility of this fantastic React framework lowers the bar to build with Tina Cloud.
-* GitHub - The first Git provider that Tina Cloud integrates with. Other Git providers may be available in the future.
-* Static, file-based builds - The Tina Cloud client collects your filesystem content at build time. The ability to fetch content from our cloud API during builds will come soon.
+- [Next.js](https://nextjs.org/) - The flexibility of this fantastic React framework lowers the bar to build with Tina Cloud.
+- GitHub - The first Git provider that Tina Cloud integrates with. Other Git providers may be available in the future.
+- Static, file-based builds - The Tina Cloud client collects your filesystem content at build time. The ability to fetch content from our cloud API during builds will come soon.
 
 The [Next.js starter](https://github.com/tinacms/tina-cloud-starter) can get you up and running quickly with the above considerations. Give it a try and let us know how we can make developing with Tina easier.
 
 ## How can I share an idea or get help using Tina Cloud?
 
-* If you haven't checked yet, the [docs](/docs/) may have the answer you are looking for!
-* Connect with us on [Discord](https://discord.com/invite/zumN63Ybpf).
-* We can help you at support@tina.io. Email us if you would like to schedule a chat!
-* Chat with us from your Tina Cloud dashboard (there's a chat widget at the bottom of the screen on the left side).
+- If you haven't checked yet, the [docs](/docs/) may have the answer you are looking for!
+- Connect with us on [Discord](https://discord.com/invite/zumN63Ybpf).
+- We can help you at support@tina.io. Email us if you would like to schedule a chat!
+- Chat with us from your Tina Cloud dashboard (there's a chat widget at the bottom of the screen on the left side).
 
 ## What is the pricing for Tina Cloud?
 
@@ -56,8 +57,8 @@ When a user logs in from your site, we will pop open a login window. When login 
 
 The most common reasons for this issue are:
 
-* The Site URL is not properly set for the Tina app. The main window's base URL will need to match the Tina app's Site URL setup in the Tina Cloud Dashboard.
-* The Client ID setup in your site's environment variables does not match the Client ID in your app's settings on the Tina Cloud dashboard.
-* The user attempting to login to Tina Cloud does not have access to edit this site. Ensure that this user is authorized on the Tina Cloud dashboard.
+- The Site URL is not properly set for the Tina project. The main window's base URL will need to match the Tina project's Site URL setup in the Tina Cloud Dashboard.
+- The Client ID setup in your site's environment variables does not match the Client ID in your project's settings on the Tina Cloud dashboard.
+- The user attempting to login to Tina Cloud does not have access to edit this site. Ensure that this user is authorized on the Tina Cloud dashboard.
 
 > Make sure to include `https` in the Site URL eg: https://forestry.io or if you are testing locally, it might be something like http://localhost:3000

--- a/content/docs/tina-cloud/using-app.md
+++ b/content/docs/tina-cloud/using-app.md
@@ -1,8 +1,8 @@
 ---
-title: Using an app
+title: Using your project
 ---
 
-Once you've created an app within the **Tina Cloud Dashboard** it's ready to be used within your site. By doing so, your app's editors will be able to save content to your app's repository, right from your sire.
+Once you've created a project within the **Tina Cloud Dashboard** it's ready to be used within your site. By doing so, your project's editors will be able to save content to your project's repository, right from your sire.
 
 ## Switching <TinaCMS> to production mode.
 
@@ -36,7 +36,7 @@ Switching this to false, means that we'll talk to Tina Cloud's hosted API instea
 
 ### clientId
 
-This is your identifier for your Tina Cloud app. It can be retrieved by going to app.tina.io, and looking at your app's configuration.
+This is your identifier for your Tina Cloud project. It can be retrieved by going to app.tina.io, and looking at your project's configuration.
 
 ### branch
 

--- a/content/guides/tina-cloud/add-tinacms-to-existing-site/deployment.md
+++ b/content/guides/tina-cloud/add-tinacms-to-existing-site/deployment.md
@@ -13,14 +13,14 @@ While the fully local development workflow is the recommended way for developers
 
 1. Visit [app.tina.io](https://app.tina.io/register), to sign in.
 2. Commit the project to your GitHub account.
-3. Create a Tina Cloud app that connects to the GitHub repository you've just commited. For now, set `http://localhost:3000` as your callback URL. Once your app is created, click on the app to get to the app settings and copy the client ID. For more details on how to work with the Tina Cloud dashboard head over to the [dashboard documentation](/docs/tina-cloud/dashboard/).
+3. Create a Tina Cloud project that connects to the GitHub repository you've just commited. For now, set `http://localhost:3000` as your callback URL. Once your project is created, click on the project to get to the project settings and copy the client ID. For more details on how to work with the Tina Cloud dashboard head over to the [dashboard documentation](/docs/tina-cloud/dashboard/).
 
 ## Connect your local project with TinaCMS Backend
 
 Create an `env.local` file in the root of your project set:
 
 - `NEXT_PUBLIC_USE_LOCAL_CLIENT` to `0`.
-- `NEXT_PUBLIC_TINA_CLIENT_ID` to the Client ID displayed in your Tina Cloud App.
+- `NEXT_PUBLIC_TINA_CLIENT_ID` to the Client ID displayed in your Tina Cloud Project.
 
 Restart your server and run `yarn tina-dev` again.
 

--- a/content/guides/tina-cloud/starter/connect-to-tina-cloud.md
+++ b/content/guides/tina-cloud/starter/connect-to-tina-cloud.md
@@ -18,7 +18,7 @@ In the `env.local` file set your client ID:
 
 ```
 # env.local
-NEXT_PUBLIC_TINA_CLIENT_ID=to the Client ID copied from an earlier step and found in your app's Overview section
+NEXT_PUBLIC_TINA_CLIENT_ID=to the Client ID copied from an earlier step and found in your project's Overview section
 ```
 
 > Tip: `.env.development` only runs when in Next.js development mode.
@@ -34,7 +34,7 @@ This time a modal asks you to authenticate through TinaCMS. Upon success, Tina w
 Make some edits through the sidebar and click save.
 Changes are saved in your GitHub repository.
 
-> Hint: To exit edit mode, navigate to the `/exit-admin` route.  If you are running on `localhost`, it is `http://localhost:3000/exit-admin`.
+> Hint: To exit edit mode, navigate to the `/exit-admin` route. If you are running on `localhost`, it is `http://localhost:3000/exit-admin`.
 
 Now that Tina Cloud editing is working correctly, we can deploy the site so that other team members can make edits too.
 
@@ -54,7 +54,7 @@ Connect to your GitHub repository and set the same environment variables as the 
 NEXT_PUBLIC_TINA_CLIENT_ID=<YOUR_CLIENT_ID>
 ```
 
-Add the deployment URL to your app's Site Urls. To do this, go to your app's **Configuration** page.
+Add the deployment URL to your project's Site Urls. To do this, go to your project's **Configuration** page.
 
 🎉 Congratulations, your site is now live!
 
@@ -76,7 +76,7 @@ Set the **publish directory**. To `.next/` .
 
 Once you're done, click "Deploy site".
 
-Add the deployment URL to your app's Site Urls. To do this, go to your app's **Configuration** page.
+Add the deployment URL to your project's Site Urls. To do this, go to your project's **Configuration** page.
 
 You can test that everything is configured correctly by navigating to `[your deployment URL]/`, navigate to the `admin` route,
 log in to Tina, and making some edits. Your changes should be saved to your GitHub repository.

--- a/content/guides/tina-cloud/starter/create-account.md
+++ b/content/guides/tina-cloud/starter/create-account.md
@@ -11,8 +11,8 @@ you'll likely want other editors and collaborators to be able to make changes on
 ## Create an Account
 
 1. Visit <a href="https://app.tina.io/register" target="_blank">app.tina.io</a>, create an account, and signin.
-2. On the landing page, you'll notice that there is an onboarding route for the Tina Cloud Starter. Click '**Fork Starter in Github**' to have the dashboard walk you through the configuration needed to setup this starter as a TinaCMS app.
-3. Once you create the app, click into that app's **Overview** section and copy the unique **Client ID**. You'll need this later on in this tutorial.
+2. On the landing page, you'll notice that there is an onboarding route for the Tina Cloud Starter. Click '**Fork Starter in Github**' to have the dashboard walk you through the configuration needed to setup this starter as a TinaCMS project.
+3. Once you create the project, click into that project's **Overview** section and copy the unique **Client ID**. You'll need this later on in this tutorial.
 
 ![tina-cloud-dashboard](/img/cloud-starter-dashboard.png)
 
@@ -20,8 +20,8 @@ you'll likely want other editors and collaborators to be able to make changes on
 
 ### Site Urls
 
-When creating an app, you will notice there is a section titled **Development Environment**. This section can be found in your app's **Configuration** page. This is where you enter the site urls where you will be using TinaCMS. This will most likely be `http://localhost:3000` and your production url.
+When creating an project, you will notice there is a section titled **Development Environment**. This section can be found in your project's **Configuration** page. This is where you enter the site urls where you will be using TinaCMS. This will most likely be `http://localhost:3000` and your production url.
 
 _Note: You do not need to specify a specific route._
 
-For more information about the dashboard and setting up an app, click <a href="/docs/tina-cloud/dashboard" target="_blank">here</a>.
+For more information about the dashboard and setting up an project, click <a href="/docs/tina-cloud/dashboard" target="_blank">here</a>.

--- a/content/toc-doc.json
+++ b/content/toc-doc.json
@@ -61,7 +61,7 @@
       {
         "id": "/docs/tina-cloud/using-app/",
         "slug": "/docs/tina-cloud/using-app/",
-        "title": "Using an app"
+        "title": "Using a project"
       },
       {
         "id": "/docs/tina-cloud/faq/",


### PR DESCRIPTION
Change references from 'Apps' to 'Projects' when referencing the Tina Cloud dashboard. 