### PR TITLE
Add version select

### DIFF
--- a/components/DocumentationNavigation/DocumentationNavigation.tsx
+++ b/components/DocumentationNavigation/DocumentationNavigation.tsx
@@ -28,11 +28,13 @@ export function DocumentationNavigation({ navItems }: DocsNavProps) {
         onClick={() => setMobileNavIsOpen(!mobileNavIsOpen)}
       />
       <DocsLeftSidebar open={mobileNavIsOpen}>
-        <DocsSidebarHeader>
-          <DocsDesktopTinaIcon docs />
-          <VersionSelect />
+        <DocsSidebarHeaderWrapper>
+          <DocsSidebarHeader>
+            <DocsDesktopTinaIcon docs />
+            <VersionSelect />
+          </DocsSidebarHeader>
           <Search collapse expanded={true} indices={searchIndices} />
-        </DocsSidebarHeader>
+        </DocsSidebarHeaderWrapper>
         {router.isFallback ? (
           <FallbackPlaceholder />
         ) : (
@@ -83,7 +85,6 @@ const MobileNavLogo = styled(TinaIcon)`
 const DocsDesktopTinaIcon = styled(TinaIcon)`
   position: relative;
   display: none;
-  margin-bottom: 1rem;
 
   @media (min-width: 840px) {
     display: block;
@@ -91,6 +92,17 @@ const DocsDesktopTinaIcon = styled(TinaIcon)`
 `
 
 const DocsSidebarHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+
+  ${DocsDesktopTinaIcon} {
+    margin-right: 1rem;
+  }
+`
+
+const DocsSidebarHeaderWrapper = styled.div`
   flex: 0 0 auto;
   background-color: white;
   background: linear-gradient(to bottom, white, var(--tina-color-grey-1));
@@ -98,10 +110,6 @@ const DocsSidebarHeader = styled.div`
   padding: 1rem 1rem 1.25rem 1rem;
   border-bottom: 1px solid var(--tina-color-grey-2);
   position: relative;
-
-  ${DocsDesktopTinaIcon} {
-    margin-left: 0.25rem;
-  }
 
   ${HitsWrapper} {
     right: auto;

--- a/components/DocumentationNavigation/DocumentationNavigation.tsx
+++ b/components/DocumentationNavigation/DocumentationNavigation.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import React, { useState } from 'react'
 import { Overlay } from '../ui/Overlay'
 import { DocsLeftSidebar } from './DocsLeftSidebar'
 import { DocsNavigationList } from './DocsNavigationList'
@@ -11,6 +11,7 @@ import { FallbackPlaceholder } from 'components/fallback-placeholder'
 import Search from '../search'
 import { HitsWrapper } from 'components/search/styles'
 import { searchIndices } from 'components/search/indices'
+import { VersionSelect } from './VersionSelect'
 
 export interface DocsNavProps {
   navItems: any
@@ -29,6 +30,7 @@ export function DocumentationNavigation({ navItems }: DocsNavProps) {
       <DocsLeftSidebar open={mobileNavIsOpen}>
         <DocsSidebarHeader>
           <DocsDesktopTinaIcon docs />
+          <VersionSelect />
           <Search collapse expanded={true} indices={searchIndices} />
         </DocsSidebarHeader>
         {router.isFallback ? (

--- a/components/DocumentationNavigation/VersionSelect.tsx
+++ b/components/DocumentationNavigation/VersionSelect.tsx
@@ -19,37 +19,58 @@ export const VersionSelect = () => {
       v => typeof window !== 'undefined' && v.url == window.location.origin
     ) || VERSIONS[0]
   return (
-    <SelectContainer>
-      <SelectWrapper>
-        <select
-          aria-label="Version"
-          onChange={e => {
-            window.location.href = e.target.value
-          }}
-          value={selectedVersion.url}
-        >
-          {VERSIONS.map(version => (
-            <option
-              arial-label={`vLatest`}
-              aria-current={selectedVersion.id == version.id}
-              value={version.url}
-              key={version.id}
-            >
-              {version.label}
-            </option>
-          ))}
-        </select>
-      </SelectWrapper>{' '}
-    </SelectContainer>
+    <SelectWrapper>
+      <select
+        aria-label="Version"
+        onChange={e => {
+          window.location.href = e.target.value
+        }}
+        value={selectedVersion.url}
+      >
+        {VERSIONS.map(version => (
+          <option
+            arial-label={`vLatest`}
+            aria-current={selectedVersion.id == version.id}
+            value={version.url}
+            key={version.id}
+          >
+            {version.label}
+          </option>
+        ))}
+      </select>
+    </SelectWrapper>
   )
 }
 
-const SelectContainer = styled.div`
-  margin-bottom: 1rem;
-  text-align: right;
-`
-
 const SelectWrapper = styled.div`
-  display: inline-block;
+  display: block;
+  flex-grow: 1;
   position: relative;
+
+  @media (min-width: 840px) {
+    display: inline-block;
+    flex-grow: 0;
+  }
+
+  select {
+    position: relative;
+    font-size: 0.875rem;
+    padding: 0.375rem 0.75rem;
+    background-color: white;
+    border: 1px solid var(--tina-color-grey-1);
+    color: var(--tina-color-grey-7);
+    display: flex;
+    width: 100%;
+    align-items: center;
+    transition: filter 250ms ease;
+    border-radius: 100px;
+    box-shadow: 3px 3px 4px var(--tina-color-grey-2), -4px -4px 6px white;
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    appearance: none;
+    background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23007CB2%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E');
+    background-repeat: no-repeat;
+    background-position: right 0.7em top 50%;
+    background-size: 0.65em auto;
+  }
 `

--- a/components/DocumentationNavigation/VersionSelect.tsx
+++ b/components/DocumentationNavigation/VersionSelect.tsx
@@ -8,7 +8,7 @@ const VERSIONS = [
   },
   {
     id: 'v-pre-beta',
-    url: 'https://tinacms-site-next-burxzt849-tinacms.vercel.app',
+    url: 'https://pre-beta.tina.io',
     label: 'v.Pre-Beta',
   },
 ]

--- a/components/DocumentationNavigation/VersionSelect.tsx
+++ b/components/DocumentationNavigation/VersionSelect.tsx
@@ -1,0 +1,54 @@
+import styled from 'styled-components'
+
+const VERSIONS = [
+  {
+    id: 'v-latest',
+    url: 'https://tina.io',
+    label: 'v.Latest',
+  },
+  {
+    id: 'v-pre-beta',
+    url: 'https://tinacms-site-next-burxzt849-tinacms.vercel.app',
+    label: 'v.Pre-Beta',
+  },
+]
+
+export const VersionSelect = () => {
+  const selectedVersion =
+    VERSIONS.find(
+      v => typeof window !== 'undefined' && v.url == window.location.origin
+    ) || VERSIONS[0]
+  return (
+    <SelectContainer>
+      <SelectWrapper>
+        <select
+          aria-label="Version"
+          onChange={e => {
+            window.location.href = e.target.value
+          }}
+          value={selectedVersion.url}
+        >
+          {VERSIONS.map(version => (
+            <option
+              arial-label={`vLatest`}
+              aria-current={selectedVersion.id == version.id}
+              value={version.url}
+              key={version.id}
+            >
+              {version.label}
+            </option>
+          ))}
+        </select>
+      </SelectWrapper>{' '}
+    </SelectContainer>
+  )
+}
+
+const SelectContainer = styled.div`
+  margin-bottom: 1rem;
+`
+
+const SelectWrapper = styled.div`
+  display: inline-block;
+  position: relative;
+`

--- a/components/DocumentationNavigation/VersionSelect.tsx
+++ b/components/DocumentationNavigation/VersionSelect.tsx
@@ -46,6 +46,7 @@ export const VersionSelect = () => {
 
 const SelectContainer = styled.div`
   margin-bottom: 1rem;
+  text-align: right;
 `
 
 const SelectWrapper = styled.div`


### PR DESCRIPTION
Add a version select dropdown, so that users will be able to browse older site deployments.

This will allow us to have a cleaner split between the "legacy" docs, and the current promoted path on tina.io

TODO:
- [x] Use proper domain for our beta version
- [x] Get @spbyrne 's stamp of approval

![Screen Shot 2021-11-17 at 12 21 22 PM](https://user-images.githubusercontent.com/5075484/142239547-f80e7c10-6cc0-4c62-aeda-cfb7b240a542.png)

![Screen Shot 2021-11-17 at 12 21 40 PM](https://user-images.githubusercontent.com/5075484/142239592-c8daecad-ff16-44e7-9f1c-7d936b05cc10.png)

