### PR TITLE
Change main CTA to docs

### DIFF
--- a/content/pages/home.json
+++ b/content/pages/home.json
@@ -13,7 +13,7 @@
           "variant": "orange",
           "label": "Get Started",
           "icon": "",
-          "url": "https://app.tina.io/quickstart"
+          "url": "https://tina.io/docs/setup-overview/"
         }
       ],
       "videoSrc": "v1629294438/tina-io/Beta_Launch_Demo"


### PR DESCRIPTION
There is a Vercel bug being exposed from within the quickstart, where the framework is being set to "other".
The Vercel team has been investigating, but it could have a big impact on the user's first experience. I'm proposing (for now) we instead direct them to the docs path instead of the quickstart from our main CTA