### PR TITLE
Remove outdated content from search

### DIFF
--- a/components/search/indices.tsx
+++ b/components/search/indices.tsx
@@ -2,5 +2,4 @@ export const searchIndices = [
   { name: `Tina-Docs-Next`, title: `Docs`, hitComp: `DocHit` },
   { name: `Tina-Guides-Next`, title: `Guides`, hitComp: `GuideHit` },
   { name: `Tina-Blogs-Next`, title: `Blog`, hitComp: `BlogHit` },
-  { name: `Tina-Package-Docs`, title: `Packages`, hitComp: `PackageHit` },
 ]

--- a/data-api/fetchBlogs.ts
+++ b/data-api/fetchBlogs.ts
@@ -3,7 +3,7 @@ const fg = require('fast-glob')
 var fs = require('fs')
 var path = require('path')
 
-export default async function fetchBlogs() {
+export async function fetchBlogs() {
   const directory = path.resolve('./content/blog')
   const files = await fg(directory + '/**/*.md')
 
@@ -23,4 +23,12 @@ export default async function fetchBlogs() {
       content: post.content,
     }
   })
+}
+
+export async function fetchRelevantBlogs() {
+  const blogs = await fetchBlogs()
+  return blogs.filter(
+    post =>
+      new Date(post.data.date).getTime() >= new Date('2021-04-01').getTime()
+  )
 }

--- a/indices/createIndices.ts
+++ b/indices/createIndices.ts
@@ -3,7 +3,7 @@ require('dotenv').config()
 import algoliasearch, { SearchIndex } from 'algoliasearch'
 import { stripMarkdown } from '../utils/blog_helpers'
 import fetchDocs from '../data-api/fetchDocs'
-import fetchBlogs from '../data-api/fetchBlogs'
+import { fetchRelevantBlogs as fetchBlogs } from '../data-api/fetchBlogs'
 import fetchGuides from '../data-api/fetchGuides'
 
 const MAX_BODY_LENGTH = 200

--- a/pages/rss.xml.tsx
+++ b/pages/rss.xml.tsx
@@ -1,7 +1,7 @@
 import { NextPageContext } from 'next'
 
 import { formatExcerpt, orderPosts } from '../utils'
-import fetchBlogs from '../data-api/fetchBlogs'
+import { fetchRelevantBlogs as fetchBlogs } from '../data-api/fetchBlogs'
 
 export default function FeedPage() {
   // xml is passed to the browser and written via getInitialProps


### PR DESCRIPTION
- Remove package docs from search results
- Only index new packages 

We were showing a lot of irrelevant info in the search results, which I suspect may have lead people to outdated paths
<img width="658" alt="Screen Shot 2021-11-18 at 12 54 43 PM" src="https://user-images.githubusercontent.com/3323181/142460623-30e489e4-ba57-4480-8672-2365f712f607.png">