### PR TITLE
Update main cta links

### DIFF
--- a/components/cloud-beta-disclaimer.tsx
+++ b/components/cloud-beta-disclaimer.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 
 export const CloudDisclaimer = () => (
   <blockquote>
-    Tina Cloud is in public beta. <Link href="/guides/tina-cloud/starter/overview/">Get Started</Link>
+    Tina Cloud is in public beta.{' '}
+    <Link href="/docs/setup-overview/">Get Started</Link>
   </blockquote>
 )

--- a/content/blog/tina-is-in-beta.md
+++ b/content/blog/tina-is-in-beta.md
@@ -4,7 +4,8 @@ date: '2021-08-18T20:00:00-04:00'
 author: James Perkins
 last_edited: '2021-08-18T10:00:06.367Z'
 ---
-The team at Tina has been working hard since June 2nd when we launched Tina Cloud alpha. We took all your feedback and thoughts and iterated to make huge improvements to the product. The alpha release contained the core product yet we knew we had some features we wanted to add immediately, including a simplified integration path. 
+
+The team at Tina has been working hard since June 2nd when we launched Tina Cloud alpha. We took all your feedback and thoughts and iterated to make huge improvements to the product. The alpha release contained the core product yet we knew we had some features we wanted to add immediately, including a simplified integration path.
 
 We are pleased to announce that Tina is in beta, and all of the core functionality is in place for your team to have a great content editing experience on Next.js sites! If you are excited as we are you can get started by [signing up](https://app.tina.io/register). But first, I'd love for you to stick around and hear about the team's vision, lessons learned, and what we have added. If you are new to Tina, here is a quick demo:
 
@@ -12,41 +13,38 @@ We are pleased to announce that Tina is in beta, and all of the core functionali
 
 ## A quick Message from Scott our CEO
 
-The Tina Beta is a big milestone! All the core functionality is in place for teams to edit content on their Next.js sites. We’re just scratching the surface of what’s possible when you add an amazing content editing experience to content stored in your Git repo. Our goal is to 10x the experience for both developers and content editors. 
+The Tina Beta is a big milestone! All the core functionality is in place for teams to edit content on their Next.js sites. We’re just scratching the surface of what’s possible when you add an amazing content editing experience to content stored in your Git repo. Our goal is to 10x the experience for both developers and content editors.
 
-## Lessons Learned 
+## Lessons Learned
 
 We learned a lot during the alpha stage, which allowed us to drive the product forward.
 
 - It took users a lot longer than we expected to make their first commit using Tina. At the beginning on average, it was over 8 hours. This signaled to us that even our starter took too long to set up.
-- You had a lot of questions after using our starter, mostly surrounding content modeling, and our documentation didn't answer them. 
+- You had a lot of questions after using our starter, mostly surrounding content modeling, and our documentation didn't answer them.
 - Tina could be used in Production on large sites, and both developers and content writers loved it.
-- Creating a [Discord](https://discord.gg/njvZZYHj2Q) allowed us to give and receive real-time feedback, which allowed us to add features, fix bugs, and get people unstuck quickly.   
-
+- Creating a [Discord](https://discord.gg/njvZZYHj2Q) allowed us to give and receive real-time feedback, which allowed us to add features, fix bugs, and get people unstuck quickly.
 
 ## What Does Being Beta Mean for You?
 
 We believe that our product combines a fantastic developer and content creator experience into a single product. The update from alpha to beta is so large that I wanted to write a short paragraph about each part. Below is a list of each update, feel free to click on it to take you to the long-form update:
 
-
 - [Better Documentation](#better-documentation)
 - [A new initialize command in the CLI](#a-new-initialize-command-in-the-cli)
 - [Improving and adding guides](#improving-and-adding-guides)
 - [Improving our Tina Starter](#improving-our-tina-starter)
-- [Media Manager](#media-manager) 
+- [Media Manager](#media-manager)
 - [Caching improvements](#caching-improvements)
 - [Creating @tinacms/toolkit](#creating-tinacmstoolkit)
 - [Vercel Integration](#vercel-integration)
 - [Dashboard Overhaul](#dashboard-overhaul)
 - [Changes to content modeling](#changes-to-content-modeling)
 
-
 <div class="callout">
 <img className="learnImage" src="/img/tina-laptop.png" alt="" />
   <div>
   <h3>Ready to get started?</h3>
   <p>Get a website running with Tina Cloud in no time!</P>
-  <a href="/guides/tina-cloud/starter/overview/" class="calloutButton">Quick Start Guide <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 448 512" xmlns="http://www.w3.org/2000/svg"><path d="M190.5 66.9l22.2-22.2c9.4-9.4 24.6-9.4 33.9 0L441 239c9.4 9.4 9.4 24.6 0 33.9L246.6 467.3c-9.4 9.4-24.6 9.4-33.9 0l-22.2-22.2c-9.5-9.5-9.3-25 .4-34.3L311.4 296H24c-13.3 0-24-10.7-24-24v-32c0-13.3 10.7-24 24-24h287.4L190.9 101.2c-9.8-9.3-10-24.8-.4-34.3z"></path></svg></a>
+  <a href="/docs/setup-overview/" class="calloutButton">Quick Start Guide <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 448 512" xmlns="http://www.w3.org/2000/svg"><path d="M190.5 66.9l22.2-22.2c9.4-9.4 24.6-9.4 33.9 0L441 239c9.4 9.4 9.4 24.6 0 33.9L246.6 467.3c-9.4 9.4-24.6 9.4-33.9 0l-22.2-22.2c-9.5-9.5-9.3-25 .4-34.3L311.4 296H24c-13.3 0-24-10.7-24-24v-32c0-13.3 10.7-24 24-24h287.4L190.9 101.2c-9.8-9.3-10-24.8-.4-34.3z"></path></svg></a>
   </div>
 </div>
 
@@ -54,15 +52,15 @@ We believe that our product combines a fantastic developer and content creator e
 
 We wanted to speed up getting Tina up and running, whether this was a newly bootstrapped Next.js application or your Production application. We introduced several things to improve this:
 
-* Better documentation
-* A tina init command
-* New and improved guides
+- Better documentation
+- A tina init command
+- New and improved guides
 
 ### Better Documentation
 
-The documentation at Tina has been something that we wanted to improve as much as possible, we found people were unsure of Tina's concepts because we did not clearly explain them in the documentation. We spent time crafting documentation that gives a developer of any experience a better understanding of each part of Tina, how they work together and how to accomplish specific tasks. 
+The documentation at Tina has been something that we wanted to improve as much as possible, we found people were unsure of Tina's concepts because we did not clearly explain them in the documentation. We spent time crafting documentation that gives a developer of any experience a better understanding of each part of Tina, how they work together and how to accomplish specific tasks.
 
-We also moved and created new navigation menus to better convey the intent of a piece of documentation, for example, if you were looking for the Next.js APIs we have a section for that. 
+We also moved and created new navigation menus to better convey the intent of a piece of documentation, for example, if you were looking for the Next.js APIs we have a section for that.
 
 ### A New Initialize Command in the CLI
 
@@ -83,29 +81,27 @@ When we introduced Tina, we had a single guide that got you up and running with 
 
 I went back to the drawing board and created a new guide that takes the [Next.js Starter Blog and adds Tina and Tina Cloud](/guides/tina-cloud/add-tinacms-to-existing-site/overview/) to it while explaining each concept as we went. This feels like a perfect way to show off Tina, learn how to use Tina, with something that many users are familiar with.
 
-We also removed old guides that no longer promote Tina's best practices and moved some of our other guides into our experimental section. Experimental to us means that we can't guarantee that there won't be bugs or issues with the packages used. 
+We also removed old guides that no longer promote Tina's best practices and moved some of our other guides into our experimental section. Experimental to us means that we can't guarantee that there won't be bugs or issues with the packages used.
 
 ## Improving our Tina Starter
 
-
 The Tina Starter was built originally to show "the power of Tina" while it did that, we didn't feel that it showed a real-world example. So we went back to the drawing board and created our new [Tina Starter](/guides/tina-cloud/starter/overview/), which includes a landing page, blog, and about pages. You can edit and rearrange the content and we styled it with TailwindCSS to give it some extra shine! Below is an example of just some of the work you can do:
-
 
 ![Quickstart Example](/img/edit-alongside-content.gif)
 
 ## Media Manager
 
-Media manager was one of the most important features that we needed for Tina Cloud. Our [Cloudinary Media manager](/docs/media-cloudinary/) allows you to change images, upload new images, and delete ones you no longer need without ever leaving the Tina editing experience. 
+Media manager was one of the most important features that we needed for Tina Cloud. Our [Cloudinary Media manager](/docs/media-cloudinary/) allows you to change images, upload new images, and delete ones you no longer need without ever leaving the Tina editing experience.
 
-I wrote a [blog post announcing it](/blog/manage-your-media-with-cloudinary/) and how to implement it into your application. 
+I wrote a [blog post announcing it](/blog/manage-your-media-with-cloudinary/) and how to implement it into your application.
 
 ## Caching Improvements
 
-Speed and performance have been something we have been actively working on. We introduced some improvements behind the scenes to improve the way we retrieve the data for your site. Tina is carefully built with performance in mind and is now faster! 
+Speed and performance have been something we have been actively working on. We introduced some improvements behind the scenes to improve the way we retrieve the data for your site. Tina is carefully built with performance in mind and is now faster!
 
 ## Creating `@tinacms/toolkit`
 
-TinaCMS was built with small modular packages, this meant that we relied heavily on React context. The dependency mismatches from over-modularizing our toolkit,  led to many bugs related to missing context.
+TinaCMS was built with small modular packages, this meant that we relied heavily on React context. The dependency mismatches from over-modularizing our toolkit, led to many bugs related to missing context.
 
 Our open-source team created `@tinacms/toolkit` which incorporates the essentials of Tina all in one place. This simplifies everything for you as a user and Tina as a product.
 
@@ -119,17 +115,18 @@ We wanted to reduce the friction to almost zero when testing TinaCMS, so we work
 
 When using Tina Cloud in alpha our dashboard UX wasn't a first-class experience and at times could be confusing. We completely overhauled the dashboard, making it easier and quicker to add an application to the Cloud, invite users, and find important information such as site URL(s) or Client ID.
 
-If you did use the alpha you will need to sign up again as we made large changes to the way we handle user signup in our backend. 
+If you did use the alpha you will need to sign up again as we made large changes to the way we handle user signup in our backend.
 
-## Changes to Content Modeling 
+## Changes to Content Modeling
 
-Content Modeling is the core of how you interact with TinaCMS and also retrieve your content. We decided to make an important change and be more primitive based in nature. 
+Content Modeling is the core of how you interact with TinaCMS and also retrieve your content. We decided to make an important change and be more primitive based in nature.
 
-This allows for simplistic queries that don't require disambiguation, we believe this will allow you as a developer to craft queries with ease. 
+This allows for simplistic queries that don't require disambiguation, we believe this will allow you as a developer to craft queries with ease.
 
-If you used the alpha of Tina you might want to read this article the team put together to explain all of the [changes and how to migrate](/docs/tina-cloud/migration-overview/). 
+If you used the alpha of Tina you might want to read this article the team put together to explain all of the [changes and how to migrate](/docs/tina-cloud/migration-overview/).
 
 ## Give Us Feedback!
+
 The whole team is truly excited to enter the beta phase and hope you will check it out and give us honest feedback. We want to hear about your projects or, let us know how Tina Cloud can help your team make progress.
 
 To keep up to date with Tina goings-on make sure to follow [@tina_cms](https://twitter.com/tina_cms) and [@james_r_perkins](https://twitter.com/james_r_perkins) on Twitter. Want to chat with the team? Join the [Discord](https://discord.gg/njvZZYHj2Q)

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -14,8 +14,8 @@ next: /docs/setup-overview
 <img className="learnImage" src="../img/tina-laptop.png" alt="" />
 <div>
 <h3>Ready to get started?</h3>
-<p>Get a website running with Tina Cloud in no time!</P>
-<a href="/guides/tina-cloud/starter/overview/" class="calloutButton">Quick Start Guide <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 448 512" xmlns="http://www.w3.org/2000/svg"><path d="M190.5 66.9l22.2-22.2c9.4-9.4 24.6-9.4 33.9 0L441 239c9.4 9.4 9.4 24.6 0 33.9L246.6 467.3c-9.4 9.4-24.6 9.4-33.9 0l-22.2-22.2c-9.5-9.5-9.3-25 .4-34.3L311.4 296H24c-13.3 0-24-10.7-24-24v-32c0-13.3 10.7-24 24-24h287.4L190.9 101.2c-9.8-9.3-10-24.8-.4-34.3z"></path></svg></a>
+<p>Get a website running with Tina Cloud in a few clicks!</P>
+<a href="https://app.tina.io/quickstart" class="calloutButton">Quick Start<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 448 512" xmlns="http://www.w3.org/2000/svg"><path d="M190.5 66.9l22.2-22.2c9.4-9.4 24.6-9.4 33.9 0L441 239c9.4 9.4 9.4 24.6 0 33.9L246.6 467.3c-9.4 9.4-24.6 9.4-33.9 0l-22.2-22.2c-9.5-9.5-9.3-25 .4-34.3L311.4 296H24c-13.3 0-24-10.7-24-24v-32c0-13.3 10.7-24 24-24h287.4L190.9 101.2c-9.8-9.3-10-24.8-.4-34.3z"></path></svg></a>
 </div>
 </div>
 

--- a/content/pages/home.json
+++ b/content/pages/home.json
@@ -13,7 +13,7 @@
           "variant": "orange",
           "label": "Get Started",
           "icon": "",
-          "url": "https://tina.io/docs/setup-overview/"
+          "url": "https://app.tina.io/quickstart"
         }
       ],
       "videoSrc": "v1629294438/tina-io/Beta_Launch_Demo"
@@ -72,9 +72,9 @@
       "actions": [
         {
           "variant": "orange",
-          "label": "Follow our guides",
+          "label": "Check out the docs",
           "icon": "arrowRight",
-          "url": "/guides/"
+          "url": "/docs/setup-overview/"
         }
       ],
       "items": [


### PR DESCRIPTION
- Change our guides CTA's to link to either the main docs setup, or the quickstart
- Change the main hero button to link to the quickstart, now that Vercel has fixed the framework:other issue 