### PR TITLE
Outdated post banner

### DIFF
--- a/content/blog/add-and-delete-files.md
+++ b/content/blog/add-and-delete-files.md
@@ -14,7 +14,7 @@ consumes:
     details: Has image of what the create form looks like
 next: /blog/jamstack-denver-talk
 prev: /blog/dynamic-plugin-system
-outdatedMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
+warningMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
 ---
 
 [Creating](https://tinacms.org/blog/add-and-delete-files/#creating-new-files) and [deleting](https://tinacms.org/blog/add-and-delete-files/#deleting-files) content — two fundamental sides of the CMS coin. This article will cover how to set up this functionality with TinaCMS on a [Gatsby](https://www.gatsbyjs.org/) site. But first, some overview.

--- a/content/blog/add-and-delete-files.md
+++ b/content/blog/add-and-delete-files.md
@@ -14,7 +14,7 @@ consumes:
     details: Has image of what the create form looks like
 next: /blog/jamstack-denver-talk
 prev: /blog/dynamic-plugin-system
-warningMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
+warningMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/setup-overview/) for a solution with less friction.'
 ---
 
 [Creating](https://tinacms.org/blog/add-and-delete-files/#creating-new-files) and [deleting](https://tinacms.org/blog/add-and-delete-files/#deleting-files) content — two fundamental sides of the CMS coin. This article will cover how to set up this functionality with TinaCMS on a [Gatsby](https://www.gatsbyjs.org/) site. But first, some overview.

--- a/content/blog/add-and-delete-files.md
+++ b/content/blog/add-and-delete-files.md
@@ -14,8 +14,8 @@ consumes:
     details: Has image of what the create form looks like
 next: /blog/jamstack-denver-talk
 prev: /blog/dynamic-plugin-system
+outdatedMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
 ---
-{{ WarningCallout text="**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction."}}
 
 [Creating](https://tinacms.org/blog/add-and-delete-files/#creating-new-files) and [deleting](https://tinacms.org/blog/add-and-delete-files/#deleting-files) content — two fundamental sides of the CMS coin. This article will cover how to set up this functionality with TinaCMS on a [Gatsby](https://www.gatsbyjs.org/) site. But first, some overview.
 

--- a/content/blog/creating-markdown-drafts.md
+++ b/content/blog/creating-markdown-drafts.md
@@ -5,8 +5,8 @@ author: Nolan Phillips & Kendall Strautman
 draft: false
 next: /blog/simple-markdown-blog-nextjs
 prev: /blog/announcing-tinacms
+outdatedMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
 ---
-{{ WarningCallout text="**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction."}}
 
 One of the core features of an editorial workflow is to provide writers & editors a safe space for creating and iterating on content without these in-process posts publishing to production — **draft-mode**.
 

--- a/content/blog/creating-markdown-drafts.md
+++ b/content/blog/creating-markdown-drafts.md
@@ -5,7 +5,7 @@ author: Nolan Phillips & Kendall Strautman
 draft: false
 next: /blog/simple-markdown-blog-nextjs
 prev: /blog/announcing-tinacms
-outdatedMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
+warningMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
 ---
 
 One of the core features of an editorial workflow is to provide writers & editors a safe space for creating and iterating on content without these in-process posts publishing to production — **draft-mode**.

--- a/content/blog/creating-markdown-drafts.md
+++ b/content/blog/creating-markdown-drafts.md
@@ -5,7 +5,7 @@ author: Nolan Phillips & Kendall Strautman
 draft: false
 next: /blog/simple-markdown-blog-nextjs
 prev: /blog/announcing-tinacms
-warningMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
+warningMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/setup-overview/) for a solution with less friction.'
 ---
 
 One of the core features of an editorial workflow is to provide writers & editors a safe space for creating and iterating on content without these in-process posts publishing to production — **draft-mode**.

--- a/content/blog/editing-on-the-cloud.md
+++ b/content/blog/editing-on-the-cloud.md
@@ -5,8 +5,8 @@ draft: false
 author: James O'Halloran
 next: /blog/using-tinacms-on-gatsby-cloud
 prev: /blog/what-are-blocks
+outdatedMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
 ---
-{{ WarningCallout text="**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction."}}
 
 TinaCMS allows you to build live-editing functionality directly into your site. Tina differs from other headless CMS's (e.g [Forestry.io](https://Forestry.io), [NetlifyCMS](https://NetlifyCMS.org), [Contentful](https://contentful.com)) which simply allow you to edit your site's content and are relatively detached from your site's code. Having Tina sit in between your content and your site's template gives editors an amazing real-time editing experience where they can navigate to any area of the site, start making changes, and immediately see these changes reflected within the site.
 

--- a/content/blog/editing-on-the-cloud.md
+++ b/content/blog/editing-on-the-cloud.md
@@ -5,7 +5,7 @@ draft: false
 author: James O'Halloran
 next: /blog/using-tinacms-on-gatsby-cloud
 prev: /blog/what-are-blocks
-warningMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
+warningMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/setup-overview/) for a solution with less friction.'
 ---
 
 TinaCMS allows you to build live-editing functionality directly into your site. Tina differs from other headless CMS's (e.g [Forestry.io](https://Forestry.io), [NetlifyCMS](https://NetlifyCMS.org), [Contentful](https://contentful.com)) which simply allow you to edit your site's content and are relatively detached from your site's code. Having Tina sit in between your content and your site's template gives editors an amazing real-time editing experience where they can navigate to any area of the site, start making changes, and immediately see these changes reflected within the site.

--- a/content/blog/editing-on-the-cloud.md
+++ b/content/blog/editing-on-the-cloud.md
@@ -5,7 +5,7 @@ draft: false
 author: James O'Halloran
 next: /blog/using-tinacms-on-gatsby-cloud
 prev: /blog/what-are-blocks
-outdatedMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
+warningMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
 ---
 
 TinaCMS allows you to build live-editing functionality directly into your site. Tina differs from other headless CMS's (e.g [Forestry.io](https://Forestry.io), [NetlifyCMS](https://NetlifyCMS.org), [Contentful](https://contentful.com)) which simply allow you to edit your site's content and are relatively detached from your site's code. Having Tina sit in between your content and your site's template gives editors an amazing real-time editing experience where they can navigate to any area of the site, start making changes, and immediately see these changes reflected within the site.

--- a/content/blog/exporting-wordpress-content-to-gatsby.md
+++ b/content/blog/exporting-wordpress-content-to-gatsby.md
@@ -5,8 +5,8 @@ draft: false
 author: Mitch MacKenzie
 next: /blog/custom-field-components
 prev: /blog/three-ways-to-edit-md
+outdatedMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
 ---
-{{ WarningCallout text="**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction."}}
 
 Say hello to the [WordPress to Gatsby Markdown Exporter](https://github.com/tinacms/wp-gatsby-markdown-exporter)! It's a WordPress plugin to export posts, pages, and other content from WordPress to Markdown.
 

--- a/content/blog/exporting-wordpress-content-to-gatsby.md
+++ b/content/blog/exporting-wordpress-content-to-gatsby.md
@@ -5,7 +5,7 @@ draft: false
 author: Mitch MacKenzie
 next: /blog/custom-field-components
 prev: /blog/three-ways-to-edit-md
-outdatedMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
+warningMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
 ---
 
 Say hello to the [WordPress to Gatsby Markdown Exporter](https://github.com/tinacms/wp-gatsby-markdown-exporter)! It's a WordPress plugin to export posts, pages, and other content from WordPress to Markdown.

--- a/content/blog/exporting-wordpress-content-to-gatsby.md
+++ b/content/blog/exporting-wordpress-content-to-gatsby.md
@@ -5,7 +5,7 @@ draft: false
 author: Mitch MacKenzie
 next: /blog/custom-field-components
 prev: /blog/three-ways-to-edit-md
-warningMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
+warningMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/setup-overview/) for a solution with less friction.'
 ---
 
 Say hello to the [WordPress to Gatsby Markdown Exporter](https://github.com/tinacms/wp-gatsby-markdown-exporter)! It's a WordPress plugin to export posts, pages, and other content from WordPress to Markdown.

--- a/content/blog/gatsby-tina-101.md
+++ b/content/blog/gatsby-tina-101.md
@@ -12,8 +12,8 @@ consumes:
     details: TinaField uses Wysiwyg component for inline editing
 next: /blog/introducing-visual-open-authoring
 prev: /blog/custom-field-plugins
+outdatedMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
 ---
-{{ WarningCallout text="**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction."}}
 
 Static site generators like [Gatsby](https://www.gatsbyjs.org/) are a massive win for developers. They provide us with automated deployments, faster development cycles, and reduced security burden.
 

--- a/content/blog/gatsby-tina-101.md
+++ b/content/blog/gatsby-tina-101.md
@@ -12,7 +12,7 @@ consumes:
     details: TinaField uses Wysiwyg component for inline editing
 next: /blog/introducing-visual-open-authoring
 prev: /blog/custom-field-plugins
-warningMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
+warningMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/setup-overview/) for a solution with less friction.'
 ---
 
 Static site generators like [Gatsby](https://www.gatsbyjs.org/) are a massive win for developers. They provide us with automated deployments, faster development cycles, and reduced security burden.

--- a/content/blog/gatsby-tina-101.md
+++ b/content/blog/gatsby-tina-101.md
@@ -12,7 +12,7 @@ consumes:
     details: TinaField uses Wysiwyg component for inline editing
 next: /blog/introducing-visual-open-authoring
 prev: /blog/custom-field-plugins
-outdatedMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
+warningMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
 ---
 
 Static site generators like [Gatsby](https://www.gatsbyjs.org/) are a massive win for developers. They provide us with automated deployments, faster development cycles, and reduced security burden.

--- a/content/blog/inline-editing-project.md
+++ b/content/blog/inline-editing-project.md
@@ -4,7 +4,7 @@ date: '2020-06-29T11:28:19-03:00'
 author: Kendall Strautman
 next: null
 prev: /blog/upgrade-notice-improved-github-security
-outdatedMessage: '**Update:** Inline editing is evolving and the current version is considered experimental, read more about [the evolution of inline editing](/blog/evolution-of-inline-editing/).'
+warningMessage: '**Update:** Inline editing is evolving and the current version is considered experimental, read more about [the evolution of inline editing](/blog/evolution-of-inline-editing/).'
 ---
 
 6 weeks ago, we embarked on a dedicated project with the goal of improving [Inline Editing](https://tinacms.org/docs/ui/inline-editing). We believe that **this way of creating content is the future**, and we want to be a driver in actualizing that future.

--- a/content/blog/inline-editing-project.md
+++ b/content/blog/inline-editing-project.md
@@ -4,8 +4,8 @@ date: '2020-06-29T11:28:19-03:00'
 author: Kendall Strautman
 next: null
 prev: /blog/upgrade-notice-improved-github-security
+outdatedMessage: '**Update:** Inline editing is evolving and the current version is considered experimental, read more about [the evolution of inline editing](/blog/evolution-of-inline-editing/).'
 ---
-{{ WarningCallout text="**Update:** Inline editing is evolving and the current version is considered experimental, read more about [the evolution of inline editing](/blog/evolution-of-inline-editing/)."}}
 
 6 weeks ago, we embarked on a dedicated project with the goal of improving [Inline Editing](https://tinacms.org/docs/ui/inline-editing). We believe that **this way of creating content is the future**, and we want to be a driver in actualizing that future.
 

--- a/content/blog/introducing-tina-grande.md
+++ b/content/blog/introducing-tina-grande.md
@@ -5,7 +5,7 @@ draft: false
 author: Scott Byrne
 next: /blog/using-tinacms-with-nextjs
 prev: /blog/simple-markdown-blog-nextjs
-warningMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
+warningMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/setup-overview/) for a solution with less friction.'
 ---
 
 [Tina Grande](https://github.com/tinacms/tina-starter-grande 'Tina Grande Repo') is a Gatsby starter with built-in TinaCMS integration. _Grande_ was built to provide a reference implementation of Tina that covers a variety of use cases. Even for those that don’t need a starter, we hope that Grande will prove to be a useful reference for both designers and developers looking to use TinaCMS.

--- a/content/blog/introducing-tina-grande.md
+++ b/content/blog/introducing-tina-grande.md
@@ -5,8 +5,8 @@ draft: false
 author: Scott Byrne
 next: /blog/using-tinacms-with-nextjs
 prev: /blog/simple-markdown-blog-nextjs
+outdatedMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
 ---
-{{ WarningCallout text="**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction."}}
 
 [Tina Grande](https://github.com/tinacms/tina-starter-grande 'Tina Grande Repo') is a Gatsby starter with built-in TinaCMS integration. _Grande_ was built to provide a reference implementation of Tina that covers a variety of use cases. Even for those that don’t need a starter, we hope that Grande will prove to be a useful reference for both designers and developers looking to use TinaCMS.
 

--- a/content/blog/introducing-tina-grande.md
+++ b/content/blog/introducing-tina-grande.md
@@ -5,7 +5,7 @@ draft: false
 author: Scott Byrne
 next: /blog/using-tinacms-with-nextjs
 prev: /blog/simple-markdown-blog-nextjs
-outdatedMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
+warningMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
 ---
 
 [Tina Grande](https://github.com/tinacms/tina-starter-grande 'Tina Grande Repo') is a Gatsby starter with built-in TinaCMS integration. _Grande_ was built to provide a reference implementation of Tina that covers a variety of use cases. Even for those that don’t need a starter, we hope that Grande will prove to be a useful reference for both designers and developers looking to use TinaCMS.

--- a/content/blog/more-changes-coming-to-inline-editing.md
+++ b/content/blog/more-changes-coming-to-inline-editing.md
@@ -3,8 +3,8 @@ title: More Changes Coming to Inline Editing
 date: '2021-01-13T10:16:45-05:00'
 author: DJ
 last_edited: '2021-01-13T15:45:05.411Z'
+outdatedMessage: '**Update:** Inline editing is evolving and the current version is considered experimental, read more about [the evolution of inline editing](/blog/evolution-of-inline-editing/).'
 ---
-{{ WarningCallout text="**Update:** Inline editing is evolving and the current version is considered experimental, read more about [the evolution of inline editing](/blog/evolution-of-inline-editing/)."}}
 
 It was around six months ago that we last dug deep into Tina's inline editing experience. At that time, we introduced new features and improved the UI of inline editing. Since then, there have been a few pain points we've run into from time to time.
 

--- a/content/blog/more-changes-coming-to-inline-editing.md
+++ b/content/blog/more-changes-coming-to-inline-editing.md
@@ -3,7 +3,7 @@ title: More Changes Coming to Inline Editing
 date: '2021-01-13T10:16:45-05:00'
 author: DJ
 last_edited: '2021-01-13T15:45:05.411Z'
-outdatedMessage: '**Update:** Inline editing is evolving and the current version is considered experimental, read more about [the evolution of inline editing](/blog/evolution-of-inline-editing/).'
+warningMessage: '**Update:** Inline editing is evolving and the current version is considered experimental, read more about [the evolution of inline editing](/blog/evolution-of-inline-editing/).'
 ---
 
 It was around six months ago that we last dug deep into Tina's inline editing experience. At that time, we introduced new features and improved the UI of inline editing. Since then, there have been a few pain points we've run into from time to time.

--- a/content/blog/three-ways-to-edit-md.md
+++ b/content/blog/three-ways-to-edit-md.md
@@ -12,7 +12,7 @@ consumes:
     details: Demonstrates useLocalRemarkForm usage
 next: /blog/exporting-wordpress-content-to-gatsby
 prev: /blog/using-tinacms-on-gatsby-cloud
-warningMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
+warningMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/setup-overview/) for a solution with less friction.'
 ---
 
 **Supercharge your static site with real-time content editing!** 🚀

--- a/content/blog/three-ways-to-edit-md.md
+++ b/content/blog/three-ways-to-edit-md.md
@@ -12,8 +12,8 @@ consumes:
     details: Demonstrates useLocalRemarkForm usage
 next: /blog/exporting-wordpress-content-to-gatsby
 prev: /blog/using-tinacms-on-gatsby-cloud
+outdatedMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
 ---
-{{ WarningCallout text="**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction."}}
 
 **Supercharge your static site with real-time content editing!** 🚀
 

--- a/content/blog/three-ways-to-edit-md.md
+++ b/content/blog/three-ways-to-edit-md.md
@@ -12,7 +12,7 @@ consumes:
     details: Demonstrates useLocalRemarkForm usage
 next: /blog/exporting-wordpress-content-to-gatsby
 prev: /blog/using-tinacms-on-gatsby-cloud
-outdatedMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
+warningMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
 ---
 
 **Supercharge your static site with real-time content editing!** 🚀

--- a/content/blog/using-tinacms-on-gatsby-cloud.md
+++ b/content/blog/using-tinacms-on-gatsby-cloud.md
@@ -10,8 +10,8 @@ consumes:
     details: Explains configuring git-specific environment variables to manually set author and ssh-key
 next: /blog/three-ways-to-edit-md
 prev: /blog/editing-on-the-cloud
+outdatedMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
 ---
-{{ WarningCallout text="**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction."}}
 
 We've [recently written](/blog/editing-on-the-cloud/ 'TinaCMS on the cloud') about how TinaCMS will work on the cloud. Gatsby Cloud offers a great way for editors to edit TinaCMS sites, without having to run a local development environment.
 

--- a/content/blog/using-tinacms-on-gatsby-cloud.md
+++ b/content/blog/using-tinacms-on-gatsby-cloud.md
@@ -10,7 +10,7 @@ consumes:
     details: Explains configuring git-specific environment variables to manually set author and ssh-key
 next: /blog/three-ways-to-edit-md
 prev: /blog/editing-on-the-cloud
-warningMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
+warningMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/setup-overview/) for a solution with less friction.'
 ---
 
 We've [recently written](/blog/editing-on-the-cloud/ 'TinaCMS on the cloud') about how TinaCMS will work on the cloud. Gatsby Cloud offers a great way for editors to edit TinaCMS sites, without having to run a local development environment.

--- a/content/blog/using-tinacms-on-gatsby-cloud.md
+++ b/content/blog/using-tinacms-on-gatsby-cloud.md
@@ -10,7 +10,7 @@ consumes:
     details: Explains configuring git-specific environment variables to manually set author and ssh-key
 next: /blog/three-ways-to-edit-md
 prev: /blog/editing-on-the-cloud
-outdatedMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
+warningMessage: '**Update:** The examples in this post reference an outdated Gatsby implementation. We recommend using [Next.js](/docs/integrations/nextjs/) for a solution with less friction.'
 ---
 
 We've [recently written](/blog/editing-on-the-cloud/ 'TinaCMS on the cloud') about how TinaCMS will work on the cloud. Gatsby Cloud offers a great way for editors to edit TinaCMS sites, without having to run a local development environment.

--- a/content/docs/legacy-redirect.md
+++ b/content/docs/legacy-redirect.md
@@ -3,6 +3,6 @@ title: Outdated API reference
 id: legacy-redirect
 ---
 
-Tina's API has been changing over the past year, and it looks like the doc you are looking for is outdated.
+Tina's API has been evolving over the past year, and it looks like the doc you are looking for is outdated.
 
 > You can get started with our new API [here](/docs/), or visit the old docs via the version select dropdown.

--- a/data-api/fetchBlogs.ts
+++ b/data-api/fetchBlogs.ts
@@ -1,4 +1,5 @@
 import matter from 'gray-matter'
+import { isRelevantPost } from 'utils'
 const fg = require('fast-glob')
 var fs = require('fs')
 var path = require('path')
@@ -27,8 +28,5 @@ export async function fetchBlogs() {
 
 export async function fetchRelevantBlogs() {
   const blogs = await fetchBlogs()
-  return blogs.filter(
-    post =>
-      new Date(post.data.date).getTime() >= new Date('2021-04-01').getTime()
-  )
+  return blogs.filter(post => isRelevantPost(post.data))
 }

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 import { NextSeo } from 'next-seo'
 import { GetStaticProps, GetStaticPaths } from 'next'
 import { CloseIcon, EditIcon } from '@tinacms/icons'
-import { formatDate } from '../../utils'
+import { formatDate, isRelevantPost } from '../../utils'
 import {
   Layout,
   Hero,
@@ -24,7 +24,7 @@ import { usePlugin, useCMS } from 'tinacms'
 import { useLastEdited } from 'utils/useLastEdited'
 import { LastEdited, DocsPagination } from 'components/ui'
 import { openGraphImage } from 'utils/open-graph-image'
-
+import { WarningCallout } from '../../utils/shortcodes'
 function BlogTemplate({ file, siteConfig, prevPage, nextPage }) {
   // fallback workaround
   if (!file) {
@@ -40,6 +40,8 @@ function BlogTemplate({ file, siteConfig, prevPage, nextPage }) {
   const frontmatter = data.frontmatter
   const markdownBody = data.markdownBody
   const excerpt = data.excerpt
+
+  const isOutdatedPost = !isRelevantPost(data.frontmatter)
 
   return (
     <InlineGithubForm form={form}>
@@ -76,6 +78,9 @@ function BlogTemplate({ file, siteConfig, prevPage, nextPage }) {
               </MetaWrap>
               <EditLink />
             </BlogMeta>
+            {isOutdatedPost && (
+              <WarningCallout text="**Update:** The Tina API has been changing, and the content in this post is outdated. For help getting started with Tina, we suggest checking out our [getting started doc](/docs/setup-overview/)." />
+            )}
             <InlineWysiwyg
               name="markdownBody"
               imageProps={{

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -41,7 +41,10 @@ function BlogTemplate({ file, siteConfig, prevPage, nextPage }) {
   const markdownBody = data.markdownBody
   const excerpt = data.excerpt
 
-  const isOutdatedPost = !isRelevantPost(data.frontmatter)
+  const warningMessage =
+    data.frontmatter.warningMessage ||
+    (!isRelevantPost(data.frontmatter) &&
+      '**Update:** The Tina API has been evolving, and the content in this post is outdated. For help getting started with Tina, we suggest checking out our [getting started doc](/docs/setup-overview/).')
 
   return (
     <InlineGithubForm form={form}>
@@ -78,14 +81,7 @@ function BlogTemplate({ file, siteConfig, prevPage, nextPage }) {
               </MetaWrap>
               <EditLink />
             </BlogMeta>
-            {isOutdatedPost && (
-              <WarningCallout
-                text={
-                  frontmatter.outdatedMessage ||
-                  '**Update:** The Tina API has been evolving, and the content in this post is outdated. For help getting started with Tina, we suggest checking out our [getting started doc](/docs/setup-overview/).'
-                }
-              />
-            )}
+            {warningMessage && <WarningCallout text={warningMessage} />}
             <InlineWysiwyg
               name="markdownBody"
               imageProps={{

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -79,7 +79,12 @@ function BlogTemplate({ file, siteConfig, prevPage, nextPage }) {
               <EditLink />
             </BlogMeta>
             {isOutdatedPost && (
-              <WarningCallout text="**Update:** The Tina API has been changing, and the content in this post is outdated. For help getting started with Tina, we suggest checking out our [getting started doc](/docs/setup-overview/)." />
+              <WarningCallout
+                text={
+                  frontmatter.outdatedMessage ||
+                  '**Update:** The Tina API has been evolving, and the content in this post is outdated. For help getting started with Tina, we suggest checking out our [getting started doc](/docs/setup-overview/).'
+                }
+              />
             )}
             <InlineWysiwyg
               name="markdownBody"

--- a/utils/blog_helpers.test.ts
+++ b/utils/blog_helpers.test.ts
@@ -1,4 +1,4 @@
-import { stripMarkdown } from './blog_helpers'
+import { isRelevantPost, stripMarkdown } from './blog_helpers'
 
 describe('stripMarkdown', () => {
   describe('with shortcodes', () => {
@@ -10,5 +10,17 @@ describe('stripMarkdown', () => {
       const stripped = await stripMarkdown(testDocument)
       expect(stripped).toEqual(expected)
     })
+  })
+})
+
+describe('isRelevantPost', () => {
+  it('returns false for old post', async () => {
+    const isRelevant = await isRelevantPost({ date: '03-03-2019' })
+    expect(isRelevant).toEqual(false)
+  })
+
+  it('returns true for new post', async () => {
+    const isRelevant = await isRelevantPost({ date: new Date().toString() })
+    expect(isRelevant).toEqual(true)
   })
 })

--- a/utils/blog_helpers.ts
+++ b/utils/blog_helpers.ts
@@ -72,3 +72,7 @@ export function formatDate(fullDate) {
   }
   return date.toLocaleDateString('en-US', dateOptions)
 }
+
+export const isRelevantPost = (post: { date: string }) => {
+  return new Date(post.date).getTime() >= new Date('2021-04-01').getTime()
+}


### PR DESCRIPTION
Show a banner on old posts redirecting to new docs

A few posts had a banner as shortcode, but I moved it to metaData so that we can apply defaults without having to worry about double banners

One very popular post that still gets a lot of traffic is https://tinacms-site-next-git-outdated-post-banner-tinacms.vercel.app/blog/simple-markdown-blog-nextjs so this should mitigate that.

fixes #1054 