### PR TITLE
Create tina app doc

### DIFF
--- a/components/home/Actions.tsx
+++ b/components/home/Actions.tsx
@@ -1,6 +1,15 @@
 import { WithCodeStyles } from 'components/layout/MarkdownContent'
 import React from 'react'
+import styled from 'styled-components'
 import { IconRight } from './Icons'
+
+const BashWrapper = styled.div`
+  code {
+    ::before {
+      content: '$ ';
+    }
+  }
+`
 
 export const Actions = ({ items, align = 'left' }) => {
   return (
@@ -13,7 +22,11 @@ export const Actions = ({ items, align = 'left' }) => {
       >
         {items.map(item => {
           if (item.variant == 'command') {
-            return <WithCodeStyles language="bash,copy" value={item.label} />
+            return (
+              <BashWrapper>
+                <WithCodeStyles language="bash,copy" value={item.label} />
+              </BashWrapper>
+            )
           }
 
           const { variant, label, icon, url } = item

--- a/components/home/Actions.tsx
+++ b/components/home/Actions.tsx
@@ -1,5 +1,5 @@
+import { WithCodeStyles } from 'components/layout/MarkdownContent'
 import React from 'react'
-import { InlineGroup } from 'react-tinacms-inline'
 import { IconRight } from './Icons'
 
 export const Actions = ({ items, align = 'left' }) => {
@@ -12,6 +12,10 @@ export const Actions = ({ items, align = 'left' }) => {
         ].join(' ')}
       >
         {items.map(item => {
+          if (item.variant == 'command') {
+            return <WithCodeStyles language="bash,copy" value={item.label} />
+          }
+
           const { variant, label, icon, url } = item
           const externalUrlPattern = /^((http|https|ftp):\/\/)/
           const external = externalUrlPattern.test(url)

--- a/components/home/Features.tsx
+++ b/components/home/Features.tsx
@@ -351,7 +351,7 @@ export const FeatureCLI = () => {
         <code>
           <span
             style={{ display: 'block', marginBottom: '1.25rem' }}
-          >{`$ npx create-next-app`}</span>
+          >{`$ npx create-tina-app`}</span>
           <span
             style={{ display: 'block', marginBottom: '1.25rem' }}
           >{`$ cd <project name>`}</span>

--- a/components/layout/MarkdownContent.tsx
+++ b/components/layout/MarkdownContent.tsx
@@ -17,7 +17,7 @@ interface MarkdownContentProps {
   skipHtml?: boolean
 }
 
-function WithCodeStyles({ language: tags, value }) {
+export function WithCodeStyles({ language: tags, value }) {
   const [language, ...other] = tags?.split(',') || []
   const copy = other.includes('copy') || language === 'copy'
   return (

--- a/content/docs/setup-overview.md
+++ b/content/docs/setup-overview.md
@@ -10,9 +10,9 @@ next: '/docs/schema'
 To quickly setup a new Tina starter, from the command line, run:
 
 ```bash
-npx create-next-app --example https://github.com/tinacms/tina-cloud-starter
+npx create-tina-app
 # or
-yarn create next-app --example https://github.com/tinacms/tina-cloud-starter
+yarn create tina-app
 ```
 
 To run the starter, `cd <your-starter-name>` into its new directory & run:

--- a/content/pages/home.json
+++ b/content/pages/home.json
@@ -14,6 +14,10 @@
           "label": "Get Started",
           "icon": "",
           "url": "https://app.tina.io/quickstart"
+        },
+        {
+          "variant": "command",
+          "label": "npx create-tina-app"
         }
       ],
       "videoSrc": "v1629294438/tina-io/Beta_Launch_Demo"


### PR DESCRIPTION
- [ ] Once https://github.com/tinacms/tinacms/pull/2312#pullrequestreview-821962390 is deployed,
 we can add create-tina-app references to our site. 

I added a main CTA from the homepage

<img width="660" alt="Screen Shot 2021-12-02 at 4 37 03 PM" src="https://user-images.githubusercontent.com/3323181/144499103-2c58ddff-b50d-4645-8ec6-f1b1b08a34e1.png">

@spbyrne may want to jump in and tweak the styles

