### PR TITLE
Specify "latest" on npx command

### DIFF
--- a/components/home/Features.tsx
+++ b/components/home/Features.tsx
@@ -351,7 +351,7 @@ export const FeatureCLI = () => {
         <code>
           <span
             style={{ display: 'block', marginBottom: '1.25rem' }}
-          >{`$ npx create-tina-app`}</span>
+          >{`$ npx create-tina-app@latest`}</span>
           <span
             style={{ display: 'block', marginBottom: '1.25rem' }}
           >{`$ cd <project name>`}</span>

--- a/content/docs/setup-overview.md
+++ b/content/docs/setup-overview.md
@@ -10,7 +10,7 @@ next: '/docs/using-tina-editor'
 To quickly setup a new Tina starter, from the command line:
 
 ```bash,copy
-npx create-tina-app
+npx create-tina-app@latest
 ```
 
 To run the starter, `cd <your-starter-name>` into its new directory & run:


### PR DESCRIPTION
Ensure npx create-tina-app specifies "latest" since NPM caches will store older versions

cc @jamespohalloran - we've had issues in the past with `npx` commands, we should always specify `npx whatever@latest`