### PR TITLE
Link to "getting started" hub in header

### DIFF
--- a/components/DocumentationNavigation/DocsHeaderNav.tsx
+++ b/components/DocumentationNavigation/DocsHeaderNav.tsx
@@ -33,7 +33,7 @@ export const DocsHeaderNav = styled(
                 Sign In
               </Button>
             </Link>
-            <Link href="https://app.tina.io/quickstart">
+            <Link href="/docs/setup-overview/">
               <Button size="small" color="blue">
                 Get Started
               </Button>


### PR DESCRIPTION
instead of linking to quickstart in header, link to "getting started" hub in header. This page should give all users context on how to make commits, and next steps.