### PR TITLE
Update create-tina-app homepage CTA's

### DIFF
--- a/components/home/Actions.tsx
+++ b/components/home/Actions.tsx
@@ -206,7 +206,7 @@ export const CodeButton = ({ children }) => {
 
   return (
     <>
-      <button className="button" onClick={clickEvent}>
+      <button className="button event-cmd-button" onClick={clickEvent}>
         <span className={`success-message ${copied ? `visible` : ``}`}>
           Copied to clipboard!
         </span>

--- a/components/home/Actions.tsx
+++ b/components/home/Actions.tsx
@@ -1,9 +1,15 @@
 import React from 'react'
 import styled from 'styled-components'
+import { BiCopy } from 'react-icons/bi'
 import { IconRight } from './Icons'
-import { WithCodeStyles } from 'components/layout/MarkdownContent'
+import {
+  copyToClipboard,
+  WithCodeStyles,
+} from 'components/layout/MarkdownContent'
 
 const BashWrapper = styled.div`
+  border: 1px solid black;
+
   code {
     ::before {
       content: '$ ';
@@ -22,11 +28,7 @@ export const Actions = ({ items, align = 'left' }) => {
       >
         {items.map(item => {
           if (item.variant == 'command') {
-            return (
-              <BashWrapper>
-                <WithCodeStyles language="bash,copy" value={item.label} />
-              </BashWrapper>
-            )
+            return <CodeButton>{item.label}</CodeButton>
           }
 
           const { variant, label, icon, url } = item
@@ -184,6 +186,134 @@ export const Actions = ({ items, align = 'left' }) => {
 
           :hover {
             color: var(--color-orange-dark);
+          }
+        }
+      `}</style>
+    </>
+  )
+}
+
+export const CodeButton = ({ children }) => {
+  const [copied, setCopied] = React.useState(false)
+
+  const clickEvent = () => {
+    setCopied(true)
+    copyToClipboard(children)
+    setTimeout(() => {
+      setCopied(false)
+    }, 2000)
+  }
+
+  return (
+    <>
+      <button className="button" onClick={clickEvent}>
+        <span className={`success-message ${copied ? `visible` : ``}`}>
+          Copied to clipboard!
+        </span>
+        <span className="text">
+          <span className="bash">$</span> {children}
+        </span>
+        <span className="icon">
+          <BiCopy />
+        </span>
+      </button>
+      <style jsx>{`
+        .bash {
+          opacity: 0.5;
+          margin-right: 0.25rem;
+        }
+
+        .success-message {
+          position: absolute;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          width: 100%;
+          height: 100%;
+          text-align: center;
+          color: var(--color-orange);
+          font-family: var(--font-tuner);
+          font-weight: regular;
+          font-style: normal;
+          background: white;
+          z-index: 10;
+          transition: opacity 180ms ease-out;
+          opacity: 0;
+        }
+
+        .visible {
+          opacity: 1;
+        }
+
+        .icon {
+          width: 2.75rem;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          background: var(--color-seafoam);
+          border-left: 1px solid #b4f4e0;
+          color: var(--color-orange);
+          align-self: stretch;
+          opacity: 0.5;
+          transition: opacity 180ms ease-out;
+
+          :global(svg) {
+            height: 1.5em;
+            width: auto;
+          }
+        }
+
+        .text {
+          padding: 1rem 1.5rem;
+        }
+
+        .button {
+          display: flex;
+          font-weight: bold;
+          overflow: hidden;
+          font-size: 1rem;
+          border-radius: 0.5rem;
+          cursor: pointer;
+          transition: all 150ms ease-out;
+          width: max-content;
+          transform: translate3d(0px, 0px, 0px);
+          display: flex;
+          align-items: center;
+          background-color: white;
+          color: var(--color-secondary);
+          text-transform: uppercase;
+          font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+          padding: 0;
+          border: 1px solid #b4f4e0;
+          font-weight: regular;
+          font-style: normal;
+          text-decoration: none !important;
+          white-space: nowrap;
+          opacity: 1;
+          line-height: 1;
+
+          &:hover,
+          &:focus {
+            color: var(--color-orange);
+            text-decoration: none;
+            transform: translate3d(-1px, -2px, 0);
+            transition: transform 180ms ease-out;
+
+            .icon {
+              opacity: 1;
+            }
+          }
+          &:focus {
+            box-shadow: rgba(0, 0, 0, 0.08) 0px 0px 0px 1px inset,
+              rgba(236, 72, 21, 0.7) 0px 0px 0px 3px,
+              rgba(0, 0, 0, 0.12) 0px 2px 3px;
+          }
+          &:focus,
+          &:active {
+            outline: none;
+          }
+          &:active {
+            filter: none;
           }
         }
       `}</style>

--- a/components/home/Actions.tsx
+++ b/components/home/Actions.tsx
@@ -1,5 +1,15 @@
 import React from 'react'
+import styled from 'styled-components'
 import { IconRight } from './Icons'
+import { WithCodeStyles } from 'components/layout/MarkdownContent'
+
+const BashWrapper = styled.div`
+  code {
+    ::before {
+      content: '$ ';
+    }
+  }
+`
 
 export const Actions = ({ items, align = 'left' }) => {
   return (
@@ -11,6 +21,14 @@ export const Actions = ({ items, align = 'left' }) => {
         ].join(' ')}
       >
         {items.map(item => {
+          if (item.variant == 'command') {
+            return (
+              <BashWrapper>
+                <WithCodeStyles language="bash,copy" value={item.label} />
+              </BashWrapper>
+            )
+          }
+
           const { variant, label, icon, url } = item
           const externalUrlPattern = /^((http|https|ftp):\/\/)/
           const external = externalUrlPattern.test(url)

--- a/components/home/Features.tsx
+++ b/components/home/Features.tsx
@@ -351,7 +351,7 @@ export const FeatureCLI = () => {
         <code>
           <span
             style={{ display: 'block', marginBottom: '1.25rem' }}
-          >{`$ npx create-tina-app@latest`}</span>
+          >{`$ npx create-next-app@latest`}</span>
           <span
             style={{ display: 'block', marginBottom: '1.25rem' }}
           >{`$ cd <project name>`}</span>

--- a/components/home/Features.tsx
+++ b/components/home/Features.tsx
@@ -155,10 +155,13 @@ export function FeatureBlock({ data, index }) {
           margin-top: 1rem;
 
           :global(a) {
-            text-decoration: none;
+            text-decoration: underline;
             transition: all ease-out 150ms;
+            color: var(--color-tina-blue-dark);
+            text-decoration-color: var(--color-seafoam-dark);
             &:hover {
-              text-decoration: underline;
+              color: var(--color-tina-blue);
+              text-decoration-color: var(--color-tina-blue);
             }
           }
 

--- a/components/home/Features.tsx
+++ b/components/home/Features.tsx
@@ -351,7 +351,7 @@ export const FeatureCLI = () => {
         <code>
           <span
             style={{ display: 'block', marginBottom: '1.25rem' }}
-          >{`$ npx create-tina-app`}</span>
+          >{`$ npx create-tina-app@latest`}</span>
           <span
             style={{ display: 'block', marginBottom: '1.25rem' }}
           >{`$ cd <project name>`}</span>

--- a/components/home/GlobalStyles.tsx
+++ b/components/home/GlobalStyles.tsx
@@ -3,6 +3,9 @@ import css from 'styled-jsx/css'
 
 export const GlobalStyles = css.global`
   :root {
+    --color-tina-blue-light: #2296fe;
+    --color-tina-blue: #2296fe;
+    --color-tina-blue-dark: #0574e4;
     --color-orange: #ec4815;
     --color-orange-light: #eb6337;
     --color-orange-dark: #dc4419;

--- a/components/layout/MarkdownContent.tsx
+++ b/components/layout/MarkdownContent.tsx
@@ -30,7 +30,7 @@ export function WithCodeStyles({ language: tags, value }) {
   )
 }
 
-const copyToClipboard = (text: string) => {
+export const copyToClipboard = (text: string) => {
   const el = document.createElement('textarea')
   el.value = text
   document.body.appendChild(el)

--- a/components/layout/MarkdownContent.tsx
+++ b/components/layout/MarkdownContent.tsx
@@ -17,7 +17,7 @@ interface MarkdownContentProps {
   skipHtml?: boolean
 }
 
-function WithCodeStyles({ language: tags, value }) {
+export function WithCodeStyles({ language: tags, value }) {
   const [language, ...other] = tags?.split(',') || []
   const copy = other.includes('copy') || language === 'copy'
   return (

--- a/content/docs/setup-overview.md
+++ b/content/docs/setup-overview.md
@@ -10,7 +10,7 @@ next: '/docs/using-tina-editor'
 To quickly setup a new Tina starter, from the command line:
 
 ```bash,copy
-npx create-tina-app
+npx create-tina-app@latest
 ```
 
 To run the starter, `cd <your-starter-name>` into its new directory & run:

--- a/content/pages/home.json
+++ b/content/pages/home.json
@@ -17,7 +17,7 @@
         },
         {
           "variant": "command",
-          "label": "npx create-tina-app"
+          "label": "npx create-tina-app@latest"
         }
       ],
       "videoSrc": "v1629294438/tina-io/Beta_Launch_Demo"

--- a/content/pages/home.json
+++ b/content/pages/home.json
@@ -14,6 +14,10 @@
           "label": "Get Started",
           "icon": "",
           "url": "/docs/setup-overview/"
+        },
+        {
+          "variant": "command",
+          "label": "npx create-tina-app"
         }
       ],
       "videoSrc": "v1629294438/tina-io/Beta_Launch_Demo"


### PR DESCRIPTION
Update homepage so that:
- Homepage has CLI CTA on main section
- Fix the "Command Line" section that shows both `create-tina-app` and `@tinacms/cli init`

![Screen Shot 2021-12-06 at 12 58 31 PM](https://user-images.githubusercontent.com/5075484/144888739-6b2d66ef-a15d-40f9-b7fb-0b2ce8ce59f9.png)

A couple things before we merge:

- [x] Could probably use some @spbyrne love
- [x] Give the user extra context from the CLI: https://github.com/tinacms/tinacms/issues/2321
