### PR TITLE
docs: index whole document, use snippets in search

### DIFF
--- a/components/search/hitComps.tsx
+++ b/components/search/hitComps.tsx
@@ -1,9 +1,10 @@
-import React from 'react'
-import { Highlight } from 'react-instantsearch-dom'
-import { Hit } from 'react-instantsearch-core'
-import path from 'path'
+import { Highlight, Snippet } from 'react-instantsearch-dom'
+
 import { DynamicLink } from '../ui/DynamicLink'
+import { Hit } from 'react-instantsearch-core'
+import React from 'react'
 import { formatDate } from '../../utils'
+import path from 'path'
 import styled from 'styled-components'
 
 const DocHit = (clickHandler: any) => ({ hit }: { hit: Hit }) => (
@@ -13,7 +14,7 @@ const DocHit = (clickHandler: any) => ({ hit }: { hit: Hit }) => (
         <Highlight attribute="title" hit={hit} tagName="mark" />
       </h4>
       {hit['_highlightResult'].excerpt.matchLevel !== 'none' && (
-        <Highlight attribute="excerpt" hit={hit} tagName="mark" />
+        <Snippet attribute="excerpt" hit={hit} tagName="mark" />
       )}
     </div>
   </DynamicLink>
@@ -31,7 +32,7 @@ const GuideHit = (clickHandler: any) => ({ hit }: { hit: Hit }) => (
         <Highlight attribute="title" hit={hit} tagName="mark" />
       </h4>
       {hit['_highlightResult'].excerpt.matchLevel !== 'none' && (
-        <Highlight attribute="excerpt" hit={hit} tagName="mark" />
+        <Snippet attribute="excerpt" hit={hit} tagName="mark" />
       )}
     </div>
   </DynamicLink>
@@ -54,7 +55,7 @@ const BlogHit = (clickHandler: any) => ({ hit }: { hit: Hit }) => {
           <Highlight attribute="title" hit={hit} tagName="mark" />
         </h4>
         {hit['_highlightResult'].excerpt.matchLevel !== 'none' && (
-          <Highlight attribute="excerpt" hit={hit} tagName="mark" />
+          <Snippet attribute="excerpt" hit={hit} tagName="mark" />
         )}
         <div>{formatDate(hit.date)}</div>
       </div>
@@ -70,7 +71,7 @@ const PackageHit = (clickHandler: any) => ({ hit }: { hit: Hit }) => {
           <Highlight attribute="package" hit={hit} tagName="mark" />
         </h4>
         {hit['_highlightResult'].excerpt.matchLevel !== 'none' && (
-          <Highlight attribute="excerpt" hit={hit} tagName="mark" />
+          <Snippet attribute="excerpt" hit={hit} tagName="mark" />
         )}
       </div>
     </DynamicLink>


### PR DESCRIPTION
Fixes #1044 

Back in #617 a change was made so that we only indexed the first 200 characters of a doc. My best guess is that this was to make things less ugly when searching. 

This change switches things back to index the entire doc, but on the search side of things we use algolia's `<Snippet/>` functionality which I've configured to only display 50 words no matter how long the doc is.
<img width="1651" alt="Screen Shot 2021-12-06 at 11 43 24 AM" src="https://user-images.githubusercontent.com/5082908/144886774-c5b0ef3f-c820-4e47-bc91-febbc2fe0289.png">

Let me know if 50 words is too many or if you remember there being some other reason for the change in #617 

