### PR TITLE
docs: add blurb constrasting local-mode prod-mode

### DIFF
--- a/content/docs/tina-cloud.md
+++ b/content/docs/tina-cloud.md
@@ -1,29 +1,23 @@
 ---
-title: Tina Cloud
+title: Moving from Local-Mode to Prod-Mode
 id: '/docs/tina-cloud'
 next: '/docs/tina-cloud/dashboard'
 ---
 
-Tina Cloud is a multi-level backend solution for TinaCMS. Included in this solution are our expressive Content API and a Dashboard interface to easily manage projects and users.
+Tina's GraphQL Content API is flexible, in that it can be run locally using the Tina CLI ("Local Mode"), or your site can talk to our hosted content API in a production environment ("Prod Mode"), which persists changes to your GitHub repository.
 
-## Content API
+## Local-Mode
 
-Tina Cloud's Content API unlocks powerful features for the Tina experience.
+When developers are developing locally, it's often convenient to load/save content from their local filesystem rather than connecting to the content on Tina Cloud.
 
-Firstly, Tina's Content API authenticates directly with GitHub removing the need for users to create GitHub accounts. Access is granted through the dashboard, allowing users to login directly through your site and begin editing!
+When in local-mode, you **will not** need to login to enter edit-mode.
 
-Secondly, the Content API provides a powerful GraphQL gateway API. The GraphQL API is important for a variety of reasons:
+{{ WarningCallout text="Note: Local-mode is meant for developing locally, and will not work when your site is hosted on production. When in local-mode, Tina tries to hit `http://localhost:4001`, which isn't available at runtime on your production site (and neither is the underlying filesystem content)." }}
 
-- **Editing Environment Flexibility:**
-  The GraphQL API works regardless of the data-source, allowing for flexibility during development. It can connect to your local filesystem for optional local development, or can be run through a cloud server during production.
-- **Control over Content**:
-  The GraphQL API returns useful data in a way that makes sense for Tina development. It returns both the data for the page as well as the form configuration needed for the Tina editor. As a developer you only need to define your content model once and don't need to worry about mirroring the model between the data source and Tina. The [Tina CLI](/docs/cli-overview/) also has helpful commands to auto-generate the GraphQL queries to be used in API requests as well as TypeScript types which match the data and forms.
-- **Link Resolution**:
-  The Content API leverages the power of GraphQL and thus can return data that is linked to another file, all within one request. You only need to query for what you need and nothing more.
+## Prod-Mode
 
+Once you are ready to host your site in production and put editing behind authentication, it's time to connect Tina Cloud.
 
-## Tina Cloud Dashboard
+Tina's Content API authenticates directly with GitHub removing the need for users to create GitHub accounts. Access is granted through the dashboard, allowing users to login directly through your site and begin editing! Any changes that are saved by your editors will be commited to the configured branch in your GitHub repository.
 
-The Tina Cloud dashboard is used to connect sites with your editors. The dashboard allows creation of TIna Cloud projects. A project connects to your site's GitHub repository and authorizes Tina Cloud to push and pull content directly from it. You can also authorize users to edit your site through the dashboard's user management page. These capabilities allows users to login directly to your site and start editing content with all changes saved in your GitHub repository.
-
-An important distinction here is that unlike traditional CMS dashboards, Tina Cloud's dashboard is not used to edit your content. Instead, content editing capabilities are setup by you, the developer, using the [TinaCMS toolkit](/docs/reference/toolkit/overview/).
+The first step to get started moving from local-mode to prod-mode is to set up a project in the Tina Cloud dashboard.

--- a/content/docs/tina-cloud/dashboard.md
+++ b/content/docs/tina-cloud/dashboard.md
@@ -7,3 +7,7 @@ next: '/docs/tina-cloud/dashboard/registration'
 The **Tina Cloud Dashboard** is the interface for managing the administrative aspects of your content management. The dashboard allows you to create **projects**, and setup your **users**.
 
 ![tina-cloud-dashboard](/img/cloud-dashboard.png)
+
+A **project** connects to your site's GitHub repository and authorizes Tina Cloud to push and pull content directly from it. You can also authorize **users** to edit your site through the dashboard's user management page. Once a user has been added, they will be able to login directly to your site, start editing content, and have their changes saved to your GitHub repository.
+
+An important distinction here is that unlike traditional CMS dashboards, Tina Cloud's dashboard is not used to edit your content. Instead, content editing capabilities are setup by you, the developer, using the TinaCMS toolkit.


### PR DESCRIPTION
Wanted to link from somewhere from the [LocalMode sidebar banner](https://github.com/tinacms/tinacms/pull/2354) where we can compare/constrast local-mode vs prod-mode.

Some of the content in the overview was a bit dated (It talked about the content-api as if it was a separate feature for Tina Cloud compared to tinacms), and a lot of this content has already been covered in the new GraphQL sections