### PR TITLE
Update homepage CTA/hero

### DIFF
--- a/components/home/Features.tsx
+++ b/components/home/Features.tsx
@@ -354,24 +354,8 @@ export const FeatureCLI = () => {
         <code>
           <span
             style={{ display: 'block', marginBottom: '1.25rem' }}
-          >{`$ npx create-next-app@latest`}</span>
-          <span
-            style={{ display: 'block', marginBottom: '1.25rem' }}
-          >{`$ cd <project name>`}</span>
-          <span
-            style={{ display: 'block', marginBottom: '1.25rem' }}
-          >{`$ npx @tinacms/cli init`}</span>
-          <span
-            style={{
-              display: 'block',
-              marginBottom: '1.25rem',
-              fontWeight: 'bold',
-              color: '#49AF25',
-            }}
-          >{`Setting up Tina...`}</span>
-          <span
-            style={{ display: 'block', marginBottom: '1.25rem' }}
-          >{`Installing Tina packages. This might take a moment... ✅`}</span>
+          >{`$ npx create-tina-app@latest`}</span>
+
           <span style={{ display: 'block' }}>
             <span
               style={{
@@ -380,14 +364,32 @@ export const FeatureCLI = () => {
                 color: '#49AF25',
               }}
             >{`?`}</span>
+
             <span
               style={{
                 display: 'inline',
                 fontWeight: 'bold',
               }}
-            >{` Do you want us to override your _app.js`}</span>
-            {`? › (y/N)`}
+            >{` What starter code would you like to use?`}</span>
+            {` 
+› Bare bones starter
+  Tailwind Starter
+  Documentation Starter
+`}
           </span>
+
+          <span
+            style={{
+              display: 'block',
+              marginTop: '1.25rem',
+              marginBottom: '1.25rem',
+              fontWeight: 'bold',
+              color: '#49AF25',
+            }}
+          >{`Setting up Tina...`}</span>
+          <span
+            style={{ display: 'block', marginBottom: '1.25rem' }}
+          >{`Installing Tina packages. This might take a moment... ✅`}</span>
         </code>
       </pre>
       <style jsx>{`

--- a/components/home/Features.tsx
+++ b/components/home/Features.tsx
@@ -389,7 +389,7 @@ export const FeatureCLI = () => {
           >{`Setting up Tina...`}</span>
           <span
             style={{ display: 'block', marginBottom: '1.25rem' }}
-          >{`Installing Tina packages. This might take a moment... ✅`}</span>
+          >{`Installing Tina packages.  This might take a moment... ✅`}</span>
         </code>
       </pre>
       <style jsx>{`

--- a/content/pages/home.json
+++ b/content/pages/home.json
@@ -6,8 +6,8 @@
   "blocks": [
     {
       "_template": "hero",
-      "headline": "The Fastest Way to Edit Next.js Content",
-      "subline": "A visual editing experience for content stored in Markdown and JSON",
+      "headline": "Next Gen Content Management",
+      "subline": "Tina is an open-source, Git-backed CMS with the ability to add visual editing to your NextJS site",
       "actions": [
         {
           "variant": "orange",

--- a/content/pages/home.json
+++ b/content/pages/home.json
@@ -62,7 +62,7 @@
         {
           "_template": "feature",
           "headline": "Command Line Quickstart",
-          "subline": "[Bootstrap your Next.js project with Tina](/guides/tina-cloud/add-tinacms-to-existing-site/overview/) setup and get started in minutes.",
+          "subline": "[Bootstrap your Next.js project with Tina](/docs/setup-overview/) setup and get started in minutes.",
           "media": {
             "cli": true
           }


### PR DESCRIPTION
Change our references from tina init to create-tina-app to keep onboarding consistent. 
<img width="550" alt="Screen Shot 2021-12-20 at 9 57 52 AM" src="https://user-images.githubusercontent.com/3323181/146778514-399595ef-082c-4d0a-89c0-0c8b27ad8d09.png">

Also updated the text in our main header as per @scottgallant 's suggestion 