### PR TITLE
Use apiURl prop

### DIFF
--- a/content/docs/tina-cloud/connecting-site.md
+++ b/content/docs/tina-cloud/connecting-site.md
@@ -3,35 +3,63 @@ title: Connecting the site
 next: '/docs/tina-cloud/faq'
 ---
 
-Once you've created a project within the **Tina Cloud**, the next step is to connect your site. Once connected, your project's editors will be able to save content directly to it's GitHub repository, entirely from within your site.
+Once you've created a project within the **Tina Cloud**, the next step is to connect your site. Once connected, your project's editors will be able to save content directly to its GitHub repository, entirely from within your site.
 
 ## Enabling Tina Cloud in TinaCMS
 
 In the [Contextual Editing doc](/docs/tinacms-context/), we showed you how the Tina context is setup on your site.
 
-To now enable Tina Cloud on your site, we just need to tweak a few properties to make the site editable:
+To use Tina Cloud, change the `apiURL` to:
 
-| property        | description                                                                                                                                                                           |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `clientId`      | This identifier associates your site with a Tina Cloud project. You can find your clientId on the [Dashboard](https://app.tina.io/projects) by viewing your project's configuration.  |
-| `isLocalClient` | When this is false, TinaCMS uses Tina Cloud's hosted API instead of a local server to load and save content during editing.                                                           |
-| `branch`        | This is the branch in which we will load/save content to/from while in edit-mode. This can be a dynamic value if you'd like to implement more complex branching, or it can be static. |
+```
+https://content.tinajs.io/content/<myClientId>/github/<myBranch>
+```
 
-### Example
+`<myClientId>` is the value from the Tina Cloud dashboard, and `<myBranch>` is the branch which you wish to communicate with.
+
+We recommend storing this URL in an environment variable so you can switch between `localhost` and Tina Cloud easily. Note that it's safe for this variable to be public so if you're using Next, prefix it with `NEXT_PUBLIC_` for client-side access.
 
 ```tsx
 // pages/_app.js
 import TinaCMS from 'tinacms'
 
+const apiURL = process.env.NEXT_PUBLIC_TINA_API_URL
+
 const App = ({ Component, pageProps }) => {
   return (
     <TinaCMS
-      // ...
-      isLocalClient={false}
-      // Your app identifier when connecting to Tina Cloud
-      clientId="<some-id-from-tina-cloud>"
-      // Specify the git branch
-      branch={process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF || 'main'}
+      apiURL={process.env.NEXT_PUBLIC_TINA_API_URL}
+      // ... other props
+    >
+      {livePageProps => <Component {...livePageProps} />}
+    </TinaCMS>
+  )
+}
+
+export default App
+```
+
+## Using the deployment branch
+
+Typically you'll want to use the branch that you're deploying with your site. This will vary depending on your host, but most will provide an environment variable of some sort that you can use.
+
+```tsx
+// pages/_app.js
+import TinaCMS from 'tinacms'
+
+const clientId = process.env.NEXT_PUBLIC_TINA_CLIENT_ID
+const branch = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF
+
+const apiURL =
+  clientId && branch
+    ? `https://content.tinajs.io/content/${clientId}/github/${branch}`
+    : 'http://localhost:4001/graphql'
+
+const App = ({ Component, pageProps }) => {
+  return (
+    <TinaCMS
+      apiURL={apiURL}
+      // ... other props
     >
       {livePageProps => <Component {...livePageProps} />}
     </TinaCMS>

--- a/content/docs/tina-cloud/connecting-site.md
+++ b/content/docs/tina-cloud/connecting-site.md
@@ -48,9 +48,9 @@ Typically you'll want to use the branch that you're deploying with your site. Th
 import TinaCMS from 'tinacms'
 
 const branch = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF
-
+const clientId = "YOUR-CLIENT-ID-HERE"
 const apiURL = branch
-    ? `https://content.tinajs.io/content/myClientId/github/${branch}`
+    ? `https://content.tinajs.io/content/${clientId}/github/${branch}`
     : 'http://localhost:4001/graphql'
 
 const App = ({ Component, pageProps }) => {

--- a/content/docs/tina-cloud/connecting-site.md
+++ b/content/docs/tina-cloud/connecting-site.md
@@ -48,9 +48,13 @@ import TinaCMS from 'tinacms'
 
 const branch = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF
 const clientId = 'YOUR-CLIENT-ID-HERE'
-const apiURL = branch
-  ? `https://content.tinajs.io/content/${clientId}/github/${branch}`
-  : 'http://localhost:4001/graphql'
+
+// When working locally, hit our local filesystem.
+// On a Vercel deployment, hit the Tina Cloud API
+const apiURL =
+  process.env.NODE_ENV == 'development'
+    ? 'http://localhost:4001/graphql'
+    : `https://content.tinajs.io/content/${clientId}/github/${branch}`
 
 const App = ({ Component, pageProps }) => {
   return (
@@ -67,11 +71,3 @@ export default App
 ```
 
 > `NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF` is a [system environment variable](https://vercel.com/docs/concepts/projects/environment-variables#system-environment-variables) that represents the branch that has made the deployment commit. If not using Vercel, this can replaced with a custom environment variable, or even a hardcoded value.
-
-## Using environment-based API URLs
-
-It may be preferable to test changes against the filesystem in development (local-mode), but use Tina Cloud in production. In these cases, your API URL may look like:
-
-```
-const apiURL = process.env.NODE_ENV == 'development' ? 'http://localhost:4001/graphql' : `https://content.tinajs.io/content/${clientId}/github/${branch}`
-```

--- a/content/docs/tina-cloud/connecting-site.md
+++ b/content/docs/tina-cloud/connecting-site.md
@@ -9,26 +9,23 @@ Once you've created a project within the **Tina Cloud**, the next step is to con
 
 In the [Contextual Editing doc](/docs/tinacms-context/), we showed you how the Tina context is setup on your site.
 
-To use Tina Cloud, change the `apiURL` to:
+To have editing work in production, Change the `apiURL` to:
 
 ```
 https://content.tinajs.io/content/<myClientId>/github/<myBranch>
 ```
 
-`<myClientId>` is the value from the Tina Cloud dashboard, and `<myBranch>` is the branch which you wish to communicate with.
-
-We recommend storing this URL in an environment variable so you can switch between `localhost` and Tina Cloud easily. Note that it's safe for this variable to be public so if you're using Next, prefix it with `NEXT_PUBLIC_` for client-side access.
-
-```tsx
+```diff
 // pages/_app.js
 import TinaCMS from 'tinacms'
 
-const apiURL = process.env.NEXT_PUBLIC_TINA_API_URL
+- const apiURL = `http://localhost:4001/graphql`
++ const apiURL = `https://content.tinajs.io/content/${myClientId}/github/${myBranch}`
 
 const App = ({ Component, pageProps }) => {
   return (
     <TinaCMS
-      apiURL={process.env.NEXT_PUBLIC_TINA_API_URL}
+      apiURL={apiURL}
       // ... other props
     >
       {livePageProps => <Component {...livePageProps} />}
@@ -39,6 +36,8 @@ const App = ({ Component, pageProps }) => {
 export default App
 ```
 
+`<myClientId>` is the value from the Tina Cloud dashboard, and `<myBranch>` is the branch which you wish to communicate with.
+
 ## Using the deployment branch
 
 Typically you'll want to use the branch that you're deploying with your site. This will vary depending on your host, but most will provide an environment variable of some sort that you can use. Note that your client ID isn't a secret and is not likely to change, so hardcoding it is usually ok.
@@ -48,10 +47,10 @@ Typically you'll want to use the branch that you're deploying with your site. Th
 import TinaCMS from 'tinacms'
 
 const branch = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF
-const clientId = "YOUR-CLIENT-ID-HERE"
+const clientId = 'YOUR-CLIENT-ID-HERE'
 const apiURL = branch
-    ? `https://content.tinajs.io/content/${clientId}/github/${branch}`
-    : 'http://localhost:4001/graphql'
+  ? `https://content.tinajs.io/content/${clientId}/github/${branch}`
+  : 'http://localhost:4001/graphql'
 
 const App = ({ Component, pageProps }) => {
   return (
@@ -68,3 +67,11 @@ export default App
 ```
 
 > `NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF` is a [system environment variable](https://vercel.com/docs/concepts/projects/environment-variables#system-environment-variables) that represents the branch that has made the deployment commit. If not using Vercel, this can replaced with a custom environment variable, or even a hardcoded value.
+
+## Using environment-based API URLs
+
+It may be preferable to test changes against the filesystem in development (local-mode), but use Tina Cloud in production. In these cases, your API URL may look like:
+
+```
+const apiURL = process.env.NODE_ENV == 'development' ? 'http://localhost:4001/graphql' : `https://content.tinajs.io/content/${clientId}/github/${branch}`
+```

--- a/content/docs/tina-cloud/connecting-site.md
+++ b/content/docs/tina-cloud/connecting-site.md
@@ -41,18 +41,16 @@ export default App
 
 ## Using the deployment branch
 
-Typically you'll want to use the branch that you're deploying with your site. This will vary depending on your host, but most will provide an environment variable of some sort that you can use.
+Typically you'll want to use the branch that you're deploying with your site. This will vary depending on your host, but most will provide an environment variable of some sort that you can use. Note that your client ID isn't a secret and is not likely to change, so hardcoding it is usually ok.
 
 ```tsx
 // pages/_app.js
 import TinaCMS from 'tinacms'
 
-const clientId = process.env.NEXT_PUBLIC_TINA_CLIENT_ID
 const branch = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF
 
-const apiURL =
-  clientId && branch
-    ? `https://content.tinajs.io/content/${clientId}/github/${branch}`
+const apiURL = branch
+    ? `https://content.tinajs.io/content/myClientId/github/${branch}`
     : 'http://localhost:4001/graphql'
 
 const App = ({ Component, pageProps }) => {

--- a/content/docs/tinacms-context.md
+++ b/content/docs/tinacms-context.md
@@ -23,17 +23,14 @@ const App = ({ Component, pageProps }) => {
       variables={pageProps.variables} // Variables used in your query
       // Required: The data from your `getStaticProps` request
       data={pageProps.data}
-      // Optional: Set to true when working with the local API
-      isLocalClient={process.env.NODE_ENV == 'development'}
-      // Optional: When using Tina Cloud, specify the git branch
-      branch={process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF || 'main'}
-      // Optional: Your identifier when connecting to Tina Cloud
-      clientId="<some-id-from-tina-cloud>"
-      // Optional: A callback for altering the document creator plugin
-      documentCreatorCallback={args => {
-        onNewDocument: args =>
-          window.location.assign('https://my-site.com/my-new-url')
-      }}
+      /**
+       * The URL for the content API.
+       *
+       * When working locally, this should be http://localhost:4001/graphql.
+       *
+       * For Tina Cloud, use https://content.tinajs.io/content/my-client-id/github/my-branch
+       */
+      apiURL="http://localhost:4001/graphql"
     >
       {livePageProps => <Component {...livePageProps} />}
     </TinaCMS>

--- a/content/guides/tina-cloud/add-tinacms-to-existing-site/markdown-plugin.md
+++ b/content/guides/tina-cloud/add-tinacms-to-existing-site/markdown-plugin.md
@@ -38,17 +38,12 @@ const App = ({ Component, pageProps }) => {
       <TinaEditProvider
         editMode={
           <TinaCMS
-            clientId={process.env.NEXT_PUBLIC_TINA_CLIENT_ID}
-            branch={process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF}
-            organization={process.env.NEXT_PUBLIC_ORGANIZATION_NAME}
-            isLocalClient={Boolean(
-              Number(process.env.NEXT_PUBLIC_USE_LOCAL_CLIENT ?? true)
-            )}
-+            cmsCallback={cms => {
-+                import('react-tinacms-editor').then((field)=>{
-+                  cms.plugins.add(field.MarkdownFieldPlugin)
-+                  })
-+            }}
+            apiURL={process.env.NEXT_PUBLIC_TINA_API_URL}
++           cmsCallback={cms => {
++             import('react-tinacms-editor').then((field)=>{
++               cms.plugins.add(field.MarkdownFieldPlugin)
++             })
++           }}
             {...pageProps}
           >
             {(livePageProps) => <Component {...livePageProps} />}


### PR DESCRIPTION
This API definitely feels better, but it's still a bit awkward when using the environment's branch. Did my best to offer some docs [on that](https://tinacms-site-next-git-use-api-url-tinacms.vercel.app/docs/tina-cloud/connecting-site/#using-the-deployment-branch), any insight welcome!

Goes with this PR https://github.com/tinacms/tinacms/pull/2377

EDIT: I've updated things so that the client id isn't stored as an env var. Maybe that helps a bit.

cc @jamespohalloran 