### PR TITLE
remove releases & toolkit content from search

### DIFF
--- a/data-api/fetchDocs.ts
+++ b/data-api/fetchDocs.ts
@@ -6,7 +6,7 @@ var path = require('path')
 export default async function fetchSearchableDocs() {
   const directory = path.resolve('./content/docs')
   const files = await fg(
-    directory + '(?!/reference/toolkit)(?!/releases)/**/*.md'
+    directory + '(?!/reference/toolkit)(?!/releases/)/**/*.md'
   )
 
   return files.map(fileName => {

--- a/data-api/fetchDocs.ts
+++ b/data-api/fetchDocs.ts
@@ -3,9 +3,11 @@ const fg = require('fast-glob')
 var fs = require('fs')
 var path = require('path')
 
-export default async function fetchDocs() {
+export default async function fetchSearchableDocs() {
   const directory = path.resolve('./content/docs')
-  const files = await fg(directory + '/**/*.md')
+  const files = await fg(
+    directory + '(?!/reference/toolkit)(?!/releases)/**/*.md'
+  )
 
   return files.map(fileName => {
     const fullPath = path.resolve(directory, fileName)

--- a/indices/createIndices.ts
+++ b/indices/createIndices.ts
@@ -3,7 +3,7 @@ require('dotenv').config()
 import algoliasearch, { SearchClient, SearchIndex } from 'algoliasearch'
 
 import { fetchRelevantBlogs as fetchBlogs } from '../data-api/fetchBlogs'
-import fetchDocs from '../data-api/fetchDocs'
+import fetchSearchableDocs from '../data-api/fetchDocs'
 import fetchGuides from '../data-api/fetchGuides'
 import { stripMarkdown } from '../utils/blog_helpers'
 
@@ -69,7 +69,7 @@ const createIndices = async () => {
     process.env.ALGOLIA_APP_ID,
     process.env.ALGOLIA_ADMIN_KEY
   )
-  const docs = await fetchDocs()
+  const docs = await fetchSearchableDocs()
   await saveIndex(
     client,
     'Tina-Docs-Next',


### PR DESCRIPTION
Remove any content within toolkit or releases from search.
(I wanted to add some tests around this, but it's tricky to test the fast-glob package). I tested the path locally, and it correctly removed the 17 reference pages