### PR TITLE
Link to registration page from beta cloud banner

### DIFF
--- a/components/cloud-beta-disclaimer.tsx
+++ b/components/cloud-beta-disclaimer.tsx
@@ -4,6 +4,6 @@ import Link from 'next/link'
 export const CloudDisclaimer = () => (
   <blockquote>
     Tina Cloud is in public beta.{' '}
-    <Link href="https://app.tina.io/quickstart">Get Started</Link>
+    <Link href="https://app.tina.io/register">Get Started</Link>
   </blockquote>
 )


### PR DESCRIPTION
This documentation is fairly far along in the onboarding path. We're also linking to this section from the local Tina sidebar, so it probably makes more sense to funnel the user to import a repo, rather than using the quickstart