### PR TITLE
chore: remove open-graph check

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -39,4 +39,4 @@ jobs:
         uses: chabad360/htmlproofer@master
         with:
           directory: './out'
-          arguments: --only-4xx --assume-extension --check-favicon --check-html --check_opengraph --http-status-ignore "400, 403, 409, 429" --allow-hash-href --timeframe "1w" --file-ignore "/.+\/(blog|404)\/.+/"
+          arguments: --only-4xx --assume-extension --check-favicon --check-html --http-status-ignore "400, 403, 409, 429" --allow-hash-href --timeframe "1w" --file-ignore "/.+\/(blog|404)\/.+/"


### PR DESCRIPTION
htmlproofer fails on newly created pages, because of the URLs with our homepage origin in our SEO checks.