### PR TITLE
make redirects go to equivalent current docs

### DIFF
--- a/now.json
+++ b/now.json
@@ -131,7 +131,7 @@
     },
     {
       "source": "/docs/nextjs/markdown/",
-      "destination": "/docs/legacy-redirect"
+      "destination": "/docs/editing/markdown/"
     },
     {
       "source": "/teams",
@@ -247,7 +247,7 @@
     },
     {
       "source": "/docs/nextjs/next-tinacms-markdown",
-      "destination": "/docs/legacy-redirect"
+      "destination": "/docs/editing/markdown/"
     },
     {
       "source": "/beta-docs",
@@ -396,7 +396,7 @@
     },
     {
       "source": "/docs/media/",
-      "destination": "/docs/legacy-redirect"
+      "destination": "/docs/media-cloudinary/"
     },
     {
       "source": "/docs/apis/",
@@ -404,19 +404,19 @@
     },
     {
       "source": "/docs/user-interface/",
-      "destination": "/docs/legacy-redirect"
+      "destination": "/docs/advanced/extending-tina/"
     },
     {
       "source": "/docs/sidebar-toolbar/",
-      "destination": "/docs/legacy-redirect"
+      "destination": "/docs/advanced/extending-tina/"
     },
     {
       "source": "/docs/extending-tina/",
-      "destination": "/docs/legacy-redirect"
+      "destination": "/docs/advanced/extending-tina/"
     },
     {
       "source": "/docs/events/",
-      "destination": "/docs/legacy-redirect"
+      "destination": "/docs/advanced/extending-tina/"
     },
     {
       "source": "/docs/plugins(.*)",
@@ -424,11 +424,11 @@
     },
     {
       "source": "/docs/ui/(.*)",
-      "destination": "/docs/legacy-redirect"
+      "destination": "/docs/advanced/extending-tina/"
     },
     {
       "source": "/docs/getting-started/faq/",
-      "destination": "/docs/legacy-redirect"
+      "destination": "/docs/tina-cloud/faq/"
     },
     {
       "source": "/docs/integrations(.*)",
@@ -444,15 +444,15 @@
     },
     {
       "source": "/guides/general(.*)",
-      "destination": "/docs/legacy-redirect"
+      "destination": "/guides/"
     },
     {
       "source": "/guides/nextjs(.*)",
-      "destination": "/docs/legacy-redirect"
+      "destination": "/guides/tina-cloud/add-tinacms-to-existing-site/overview/"
     },
     {
       "source": "/guides/tinacms(.*)",
-      "destination": "/docs/legacy-redirect"
+      "destination": "/guides/"
     },
     {
       "source": "/docs/features/extending-tina/",


### PR DESCRIPTION
All of our content redirects were going to one generic place (https://tina.io/docs/legacy-redirect/). Instead map them to semi-equivalent pages in current docs so users land on relevant and current info. 


### General Contributing:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tinacms.org/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- For non content related updates, or fixing things like typos, you can erase the following section -->

### All New Content Submissions: (To be confirmed by reviewer)

* [ ] Title is short & specific
* [ ] Headers are logically ordered & consistent
* [ ] Purpose of document is explained in the first paragraph
* [ ] Procedures are tested and work
* [ ] Any technical concepts are explained or linked to
* [ ] Document follows structure from templates
* [ ] All links work
* [ ] Spelling and grammer checker has been run
* [ ] Graphics and images are clear and useful
* [ ] Any prerequisites and next steps are defined.
