### PR TITLE
add FAQ item for record not found errors

### DIFF
--- a/content/docs/tina-cloud/faq.md
+++ b/content/docs/tina-cloud/faq.md
@@ -61,6 +61,17 @@ Here's an example monorepo structure that works with Tina Cloud:
     /projects/site-c
 ```
 
+## How do I resolve the `Unable to find record '.tina/__generated__/_graphql.json'` error?
+
+Tina Cloud's GraphQL API returns this error when it cannot find a file in your GitHub repository. This may occur under the following circumstances:
+
+- The `.tina` folder (and `__generated__` subfolder) is not in your GitHub repository remote.
+  - If the folder is in your local repository, but not in your remote, make sure there isn't a `.gitignore` file excluding it.
+- Tina is configured with a branch that doesn't exist or a branch that doesn't contain the `.tina` folder.
+  - The referenced branch should be created and should contain the `.tina` folder.
+- The apiURL prop is misconfigured on the TinaCMS component.
+  - Check the apiURL and make sure it looks like `https://content.tinajs.io/content/{tina_client_id}/github/{branch}` where `{tina_client_id}` matches the Client ID on the Project in Tina Cloud and `{branch}` is a valid branch.
+
 ## Tina.io login window doesn't close when logging in from a site
 
 When a user logs in from your site, we will pop open a login window. When login is complete, we will attempt to send a message back to the main window.


### PR DESCRIPTION
This adds an FAQ item for troubleshooting the `Unable to find record '.tina/__generated__/_graphql.json'` errors that have been occurring. It is accompanied by https://github.com/tinacms/tina-cloud/pull/1374 which is should bubble up these errors to the browser to allow the user to understand better what is happening.

<img width="852" alt="Screen Shot 2022-01-31 at 14 53 16" src="https://user-images.githubusercontent.com/370955/151863537-32142934-86d3-420d-b864-bd9d9afedc26.png">

### General Contributing:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tinacms.org/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- For non content related updates, or fixing things like typos, you can erase the following section -->

### All New Content Submissions: (To be confirmed by reviewer)

* [ ] Title is short & specific
* [ ] Headers are logically ordered & consistent
* [ ] Purpose of document is explained in the first paragraph
* [ ] Procedures are tested and work
* [ ] Any technical concepts are explained or linked to
* [ ] Document follows structure from templates
* [ ] All links work
* [ ] Spelling and grammer checker has been run
* [ ] Graphics and images are clear and useful
* [ ] Any prerequisites and next steps are defined.
