### PR TITLE
remove inline tina from homepage

### DIFF
--- a/components/home/Blocks.tsx
+++ b/components/home/Blocks.tsx
@@ -1,29 +1,19 @@
-import {
-  FeaturesBlock,
-  features_template,
-  FlyingBlock,
-  flying_template,
-  HeroBlock,
-  hero_template,
-} from './'
+import * as React from 'react'
+import { FeatureBlock, FeaturesBlock, FlyingBlock, HeroBlock } from './'
 
-export const HOMEPAGE_TEMPLATES = {
-  hero: hero_template,
-  features: features_template,
-  flying: flying_template,
-}
-
-export const HOMEPAGE_BLOCKS = {
-  hero: {
-    Component: HeroBlock,
-    template: hero_template,
-  },
-  features: {
-    Component: FeaturesBlock,
-    template: features_template,
-  },
-  flying: {
-    Component: FlyingBlock,
-    template: flying_template,
-  },
+export const Blocks = ({ blocks }: any) => {
+  return blocks.map((block: any, index) => {
+    switch (block._template) {
+      case 'features':
+        return <FeaturesBlock data={block} index={index} />
+      case 'feature':
+        return <FeatureBlock data={block} index={index} />
+      case 'flying':
+        return <FlyingBlock data={block} index={index} />
+      case 'hero':
+        return <HeroBlock data={block} index={index} />
+      default:
+        return null
+    }
+  })
 }

--- a/components/home/Features.tsx
+++ b/components/home/Features.tsx
@@ -1,12 +1,6 @@
 import React from 'react'
-import {
-  BlocksControls,
-  InlineBlocks,
-  InlineTextarea,
-} from 'react-tinacms-inline'
 import ReactMarkdown from 'react-markdown'
-import { BlockTemplate } from 'tinacms'
-import { ActionFields, Actions } from './Actions'
+import { Actions } from './Actions'
 import { Container } from './Container'
 import BlobOne from '../../public/svg/blob-1.svg'
 import BlobTwo from '../../public/svg/blob-2.svg'
@@ -14,6 +8,7 @@ import BlobThree from '../../public/svg/blob-3.svg'
 import BlobFour from '../../public/svg/blob-4.svg'
 import BlobFive from '../../public/svg/blob-5.svg'
 import BlobSix from '../../public/svg/blob-6.svg'
+import { Blocks } from './Blocks'
 
 const blobSvgOptions = [
   BlobOne,
@@ -24,94 +19,44 @@ const blobSvgOptions = [
   BlobSix,
 ]
 
-export const feature_template: BlockTemplate = {
-  label: 'Feature',
-  defaultItem: {
-    headline: 'New Feature',
-    subline:
-      'Pick from your custom predefined components to build web experiences, blazing fast',
-    media: { src: '/img/io-placeholder.jpg' },
-  },
-  fields: [
-    {
-      label: 'Headline',
-      name: 'headline',
-      component: 'text',
-    },
-    {
-      label: 'Subline',
-      name: 'subline',
-      component: 'text',
-    },
-    ...ActionFields,
-    {
-      label: 'Media',
-      name: 'media',
-      component: 'group',
-      fields: [
-        {
-          label: 'Image Source',
-          name: 'src',
-          component: 'text',
-        },
-        {
-          label: 'Video Source',
-          description: 'Cloudinary ID and file name',
-          name: 'videoSrc',
-          component: 'text',
-        },
-        {
-          label: 'Show CLI Codeblock Instead',
-          name: 'cli',
-          component: 'toggle',
-        },
-      ],
-    },
-  ],
-  itemProps: (item: any) => ({
-    label: item.headline,
-  }),
-}
-
 export function FeatureBlock({ data, index }) {
   const isReversed = index % 2 === 1
   const FeatureBlobSvg = blobSvgOptions[index % blobSvgOptions.length]
 
   return (
     <>
-      <BlocksControls index={index}>
-        <div className={`feature ${isReversed ? 'featureReverse' : ''}`}>
-          <div className="featureText">
-            <h3 className="featureTitle">
-              <InlineTextarea name="headline" />
-            </h3>
-            <hr className="dottedBorder" />
-            <div className="textLarge">
-              <ReactMarkdown source={data.subline} />
-            </div>
-            {data.actions && <Actions items={data.actions} />}
-            <div className="blob">
-              <FeatureBlobSvg />
-            </div>
+      <div
+        key={index}
+        className={`feature ${isReversed ? 'featureReverse' : ''}`}
+      >
+        <div className="featureText">
+          {data.headline && <h3 className="featureTitle">{data.headline}</h3>}
+          <hr className="dottedBorder" />
+          <div className="textLarge">
+            <ReactMarkdown source={data.subline} />
           </div>
-          {data.media.src && (
-            <div className={`featureImage`}>
-              <img
-                src={data.media.src}
-                alt={data.headline}
-                width="1120px"
-                height="800px"
-              />
-            </div>
-          )}
-          {data.media.videoSrc && <FeatureVideo src={data.media.videoSrc} />}
-          {data.media.cli && (
-            <div className={`featureImage`}>
-              <FeatureCLI />
-            </div>
-          )}
+          {data.actions && <Actions items={data.actions} />}
+          <div className="blob">
+            <FeatureBlobSvg />
+          </div>
         </div>
-      </BlocksControls>
+        {data.media.src && (
+          <div className={`featureImage`}>
+            <img
+              src={data.media.src}
+              alt={data.headline}
+              width="1120px"
+              height="800px"
+            />
+          </div>
+        )}
+        {data.media.videoSrc && <FeatureVideo src={data.media.videoSrc} />}
+        {data.media.cli && (
+          <div className={`featureImage`}>
+            <FeatureCLI />
+          </div>
+        )}
+      </div>
       <style jsx>{`
         .feature {
           position: relative;
@@ -221,95 +166,15 @@ export function FeatureBlock({ data, index }) {
   )
 }
 
-export const features_template: BlockTemplate = {
-  label: 'Features',
-  defaultItem: {
-    headline: 'Explore the *Tina ecosystem*',
-    subline:
-      'More than just a headless CMS, Tina has all the tools for building web experiences for interdisciplinary teams.',
-    color: 'white',
-    items: [
-      {
-        _template: 'feature',
-        headline: 'Data Source Plugins',
-        subline:
-          'Data Source plugins allow you to extend Tina to connect to different databases and 3rd Party APIs',
-        actions: [
-          {
-            variant: 'link',
-            label: 'Visit The Docs',
-            icon: 'arrowRight',
-            url: '#',
-          },
-        ],
-        media: { src: '/img/io-placeholder.jpg' },
-      },
-      {
-        _template: 'feature',
-        headline: 'Screen UI Plugins',
-        subline:
-          'Data Source plugins allow you to extend Tina to connect to different databases and 3rd Party AP',
-        actions: [
-          {
-            variant: 'link',
-            label: 'Visit The Docs',
-            icon: 'arrowRight',
-            url: '#',
-          },
-        ],
-        media: { src: '/img/io-placeholder.jpg' },
-      },
-      {
-        _template: 'feature',
-        headline: 'Custom Fields',
-        subline:
-          'Extend primary fields with custom field plugins to completely control the editing experience and functionality.',
-        actions: [
-          {
-            variant: 'link',
-            label: 'Visit The Docs',
-            icon: 'arrowRight',
-            url: '#',
-          },
-        ],
-        media: { src: '/img/io-placeholder.jpg' },
-      },
-    ],
-  },
-  fields: [
-    {
-      label: 'Items',
-      name: 'items',
-      component: 'blocks',
-      //@ts-ignore
-      templates: {
-        feature: feature_template,
-      },
-    },
-  ],
-}
-
 export function FeaturesBlock({ data, index }) {
+  console.log(data)
   return (
-    <BlocksControls
-      index={index}
-      insetControls={true}
-      focusRing={{ offset: -16 }}
-    >
-      <section className={'section white featureSection'}>
-        <Container>
-          <InlineBlocks name="items" blocks={FEATURE_BLOCKS} />
-        </Container>
-      </section>
-    </BlocksControls>
+    <section key={index} className={'section white featureSection'}>
+      <Container>
+        <Blocks blocks={data.items} />
+      </Container>
+    </section>
   )
-}
-
-const FEATURE_BLOCKS = {
-  feature: {
-    Component: FeatureBlock,
-    template: feature_template,
-  },
 }
 
 export const FeatureVideo = ({ src }) => {

--- a/components/home/Flying.tsx
+++ b/components/home/Flying.tsx
@@ -36,20 +36,12 @@ export const flying_template: BlockTemplate = {
 
 export function FlyingBlock({ data, index }) {
   return (
-    <BlocksControls
-      index={index}
-      insetControls={true}
-      focusRing={{ offset: -16 }}
-    >
-      <div className="learnTina">
+    <>
+      <div key={index} className="learnTina">
         <div className="learnContainer">
           <div>
-            <h3 className="title">
-              <InlineTextarea name="headline" />
-            </h3>
-            <p className="text">
-              <InlineTextarea name="subline" />
-            </p>
+            {data.headline && <h3 className="title">{data.headline}</h3>}
+            {data.subline && <p className="text">{data.subline}</p>}
             <Actions items={data.actions} />
           </div>
           <div className="learnImageWrapper">
@@ -193,6 +185,6 @@ export function FlyingBlock({ data, index }) {
           }
         }
       `}</style>
-    </BlocksControls>
+    </>
   )
 }

--- a/components/home/Hero.tsx
+++ b/components/home/Hero.tsx
@@ -1,61 +1,12 @@
 import React from 'react'
-import ReactMarkdown from 'react-markdown'
-import { InlineWysiwyg } from 'react-tinacms-editor'
-import { BlocksControls, InlineTextarea } from 'react-tinacms-inline'
-import { BlockTemplate } from 'tinacms'
-import { ActionFields, Actions } from './Actions'
+import { Actions } from './Actions'
 import { Container } from './Container'
 import HeroBackground from '../../public/svg/hero-background.svg'
 
-export const hero_template: BlockTemplate = {
-  label: 'Hero',
-  defaultItem: {
-    headline: 'Content editing for modern teams',
-    subline: 'Tina is an open-source CMS admin that talks to any API',
-    actions: [
-      {
-        variant: 'button',
-        label: 'Try Demo',
-        icon: 'arrowRight',
-        url: '#',
-      },
-      {
-        variant: 'link',
-        label: 'Learn More',
-        icon: '',
-        url: '#',
-      },
-    ],
-    videoSrc: 'v1571425758/tina-hero-demo-v2',
-  },
-  fields: [
-    {
-      label: 'Headline',
-      name: 'headline',
-      component: 'markdown',
-    },
-    {
-      label: 'Subline',
-      name: 'subline',
-      component: 'text',
-    },
-    ...ActionFields,
-    {
-      label: 'Video Cloudinary Source',
-      name: 'videoSrc',
-      component: 'text',
-    },
-  ],
-}
-
 export function HeroBlock({ data, index }) {
   return (
-    <BlocksControls
-      index={index}
-      insetControls={true}
-      focusRing={{ offset: -16 }}
-    >
-      <section className="hero">
+    <>
+      <section key={index} className="hero">
         <Container width="narrow" center>
           <HeroFeature item={data} />
         </Container>
@@ -91,20 +42,18 @@ export function HeroBlock({ data, index }) {
           }
         }
       `}</style>
-    </BlocksControls>
+    </>
   )
 }
 
 export const HeroFeature = ({ item }) => {
   return (
-    <div className="feature">
-      {item.headline && <h2 className="heading">{item.headline}</h2>}
-      {item.subline && (
-        <p className="textHuge">
-          <InlineTextarea name="subline" />
-        </p>
-      )}
-      {item.actions && <Actions items={item.actions} align="center" />}
+    <>
+      <div className="feature">
+        {item.headline && <h2 className="heading">{item.headline}</h2>}
+        {item.subline && <p className="textHuge">{item.subline}</p>}
+        {item.actions && <Actions items={item.actions} align="center" />}
+      </div>
       <style jsx>{`
         .feature {
           padding: 4rem 0 7rem 0;
@@ -131,7 +80,7 @@ export const HeroFeature = ({ item }) => {
           }
         }
       `}</style>
-    </div>
+    </>
   )
 }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,72 +2,33 @@ import React from 'react'
 import { GetStaticProps } from 'next'
 import { getJsonPreviewProps } from 'utils/getJsonPreviewProps'
 import { Layout } from 'components/layout'
-import { usePlugin } from 'tinacms'
-import { useGithubJsonForm } from 'react-tinacms-github'
-import { InlineGithubForm } from '../components/layout/InlineGithubForm'
 import { NextSeo } from 'next-seo'
-import { InlineBlocks } from 'react-tinacms-inline'
-import {
-  GlobalStyles,
-  HOMEPAGE_BLOCKS,
-  HOMEPAGE_TEMPLATES,
-} from 'components/home'
+import { Blocks, GlobalStyles } from 'components/home'
 
 const HomePage = (props: any) => {
-  //@ts-ignore
-  const [formData, form] = useGithubJsonForm(props.file, HomePageTemplate)
-
-  usePlugin(form)
-
-  const { seo } = formData
+  const data = props.file.data
 
   return (
-    <InlineGithubForm form={form}>
+    <>
       <NextSeo
-        title={seo.title}
-        description={seo.description}
+        title={data.seo.title}
+        description={data.seo.description}
         openGraph={{
-          title: seo.title,
-          description: seo.description,
+          title: data.seo.title,
+          description: data.seo.description,
         }}
       />
       <Layout>
-        <InlineBlocks name="blocks" blocks={HOMEPAGE_BLOCKS} />
+        <Blocks blocks={data.blocks} />
       </Layout>
       <style global jsx>
         {GlobalStyles}
       </style>
-    </InlineGithubForm>
+    </>
   )
 }
 
 export default HomePage
-
-const HomePageTemplate = {
-  label: 'Home Page',
-  defaultItem: {},
-  fields: [
-    {
-      label: 'Page Sections',
-      name: 'blocks',
-      component: 'blocks',
-      templates: HOMEPAGE_TEMPLATES,
-    },
-    {
-      label: 'SEO',
-      name: 'seo',
-      component: 'group',
-      fields: [
-        { name: 'title', label: 'Page Title', component: 'text' },
-        {
-          name: 'description',
-          label: 'Page Description',
-          component: 'textarea',
-        },
-      ],
-    },
-  ],
-}
 
 export const getStaticProps: GetStaticProps = async function({
   preview,


### PR DESCRIPTION
This removes inline components from the homepage and adds a blocks renderer that replaces the `InlineBlocks` component from Tina. 

I'm not really sure how `getJsonPreviewProps` works or what it's doing; if someone would like to assist I'd appreciate it 🙏  

closes #1213