### PR TITLE
Add rich-text experimental docs

### DIFF
--- a/content/docs/reference/types/rich-text.md
+++ b/content/docs/reference/types/rich-text.md
@@ -17,3 +17,22 @@ type RichTextField = {
 ```
 
 <iframe width="100%" height="700px" src="https://tina-gql-playground.vercel.app/iframe/rich-text" />
+
+## Experimental update
+
+To enable the experimental version of the rich-text editor, set a feature flag:
+
+```js
+cms.flags.set('rich-text-alt', true)
+```
+
+For a full list of the changes, checkout the [changelog](https://github.com/tinacms/tinacms/blob/main/packages/%40tinacms/toolkit/CHANGELOG.md#05612)
+
+#### Slash commands
+
+To add an embedded template quickly enter `/`, this will present you with the embedable objects,
+filtering them out as you type.
+
+### Give it a try in the playground
+
+<iframe width="100%" height="700px" src="https://tina-gql-playground.vercel.app/iframe/rich-text-experimental" />


### PR DESCRIPTION
Adds a section on how to enable the experimental version, and the playground that uses it https://tinacms-site-next-git-add-rich-text-experimental-tinacms.vercel.app/docs/reference/types/rich-text/#experimental-update