### PR TITLE
Add stalebot config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,17 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 90
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
Add the config for the ["stale" GitHub bot](https://github.com/marketplace/stale)

Any issue on tinacms/tinacms that has no activity after 90 days, will be marked with wontfix
After 7 more days, if there's been no activity, it will auto-close.
Any updates to the ticket in the 7-day window will cause the 90-day timer to reset
For example, see: https://github.com/tinacms/tinacms/issues/1977#issuecomment-1051248578