### PR TITLE
2542 - Minors changes to docs around setting up Admin

### DIFF
--- a/content/docs/advanced/edit-state.md
+++ b/content/docs/advanced/edit-state.md
@@ -6,48 +6,45 @@ next: '/docs/tina-cloud'
 
 ## Manually toggling via `useEditState`
 
-You can manually enter and exit edit mode by tapping into the `useEditState` hook. You should **always** have a  [`/pages/admin/[[...tina]].{js,tsx}` file](/docs/tinacms-context/#toggling-edit-mode) but in some cases you may want to go into edit mode without going to the `/admin` or `/admin/logout` routes. 
+You can manually enter and exit edit mode by tapping into the `useEditState` hook. You should **always** have a [`/pages/admin.{js,tsx}` file](/docs/tinacms-context/#toggling-edit-mode) but in some cases you may want to go into edit mode without going to the `/admin` or `/admin#/logout` routes.
 
-In this case you can use the `useEditState` hook. This will enter you into edit mode (and trigger a tina cloud login if applicable). 
+In this case you can use the `useEditState` hook. This will enter you into edit mode (and trigger a tina cloud login if applicable).
 
-
-For example, you may wish to provide your editors with a button to login and logout without having to navigate to `/admin` and `/admin/logout`.
+For example, you may wish to provide your editors with a button to login and logout without having to navigate to `/admin` and `/admin#/logout`.
 
 ```tsx
 import { useEditState } from 'tinacms/dist/edit-state'
 
 const MyEditButton = () => {
-  const { edit, setEdit } = useEditState();
+  const { edit, setEdit } = useEditState()
 
   return (
     <button
       onClick={() => {
-        setEdit((editState) => !editState);
+        setEdit(editState => !editState)
       }}
     >
-      {edit ? "exit exit mode" : "Enter edit mode"}
+      {edit ? 'exit exit mode' : 'Enter edit mode'}
     </button>
-  );
-};
+  )
+}
 ```
 
-Another example is that you may have UI on a page that you only want editors to see. 
+Another example is that you may have UI on a page that you only want editors to see.
 
 ```tsx
 import { useEditState } from 'tinacms/dist/edit-state'
 
 const MyPublicPage = () => {
-  const { edit } = useEditState();
+  const { edit } = useEditState()
 
   return (
     <div>
-       <main>
-          public content....
-       </main>
-       {edit && <EditorOnlyUI/>}
+      <main>public content....</main>
+      {edit && <EditorOnlyUI />}
     </div>
-  );
-};
+  )
+}
 ```
 
 Note that the `tinacms/dist/edit-state (>2kb)` code _will_ be in your production bundle with this pattern.

--- a/content/docs/tinacms-context.md
+++ b/content/docs/tinacms-context.md
@@ -67,11 +67,11 @@ Instead of having the full `tinacms` code in your production site, your main pro
 
 ## Entering / exiting edit-mode
 
-You can log into edit mode by visiting `/admin` and log out of edit mode by visiting `/admin/logout`.
+You can log into edit mode by visiting `/admin` and log out of edit mode by visiting `/admin#/logout`.
 
-> If you setup Tina with [`tinacms init`](/guides/tina-cloud/add-tinacms-to-existing-site/create-app/#adding-tina), this should already be setup for you in the `/pages/admin/[[...tina]].js` page.
+> If you setup Tina with [`tinacms init`](/guides/tina-cloud/add-tinacms-to-existing-site/create-app/#adding-tina), this should already be setup for you in the `/pages/admin.js` page.
 
-If you do not have a `/pages/admin/[[...tina]].js` file, you can create it very easily with two lines:
+If you do not have a `/pages/admin.js` file, you can create it very easily with two lines:
 
 ```
 import { TinaAdmin } from 'tinacms';


### PR DESCRIPTION
Now that Admin is going to use a HashRouter, we can simplify the docs.  The wildcard route is no longer necessary, instead, we can suggest adding just the `admin.{tsx|js}` file.

The route to logout (for non-admin enabled sites) is now `admin#/logout`.

### General Contributing:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tinacms.org/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- For non content related updates, or fixing things like typos, you can erase the following section -->

### All New Content Submissions: (To be confirmed by reviewer)

* [ ] Title is short & specific
* [ ] Headers are logically ordered & consistent
* [ ] Purpose of document is explained in the first paragraph
* [ ] Procedures are tested and work
* [ ] Any technical concepts are explained or linked to
* [ ] Document follows structure from templates
* [ ] All links work
* [ ] Spelling and grammer checker has been run
* [ ] Graphics and images are clear and useful
* [ ] Any prerequisites and next steps are defined.
