### PR TITLE
Update active-field-indicator hyperlink

### DIFF
--- a/content/docs/editing/active-field-indicator.md
+++ b/content/docs/editing/active-field-indicator.md
@@ -3,7 +3,7 @@ title: Active Field Indicator (Experimental)
 last_edited: '2021-11-06T18:00:00.000Z'
 ---
 
-{{ WarningCallout text="This is an experimental feature, and the API is subject to change. We don't yet suggest using this for production use-cases. Have any thoughts? Let us know in the chat, or through the [GitHub discussion](https://github.com/tinacms/tinacms/discussions/2249)!" }}
+{{ WarningCallout text="This is an experimental feature, and the API is subject to change. We don't yet suggest using this for production use-cases. Have any thoughts? Let us know in the chat, or through the [GitHub discussion](https://github.com/tinacms/tinacms/discussions/2250)!" }}
 
 ## Try it out
 


### PR DESCRIPTION
Current link is directing to the Automated GraphQL SDK #2249 discussion when it should be Active field indicator #2250.

### General Contributing:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tinacms.org/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
