### PR TITLE
doc: document init cli options including new --schemaFileTypes

### DIFF
--- a/content/docs/cli-overview.md
+++ b/content/docs/cli-overview.md
@@ -40,6 +40,14 @@ This will,
 4. Create example content in the demo directory.
 5. Edit the `package.json` to have the `dev`, `build`, and `start` scripts run the tina GraphQL API.
 
+#### Optional parameters
+
+| Argument                    | Description                                                                              |
+|-----------------------------|------------------------------------------------------------------------------------------|
+| `--experimentalData`        | Enables the experimental [data layer](/docs/tina-cloud/data-layer/)                      |
+| `--noTelemetry`             | Disables Open Source Telemetry                                                           |
+| `--schemaFileType`          | Overrides default Tina schema file type. Valid values are: `.ts`, `.tsx`, `.js`, `.jsx`  |
+
 ### `tinacms server:start`
 
 > To run this command, you must have a valid `.tina/schema.ts` file.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "A hub for Tina's documentation, blog & general info.",
   "author": "Forestry.io",
   "main": "n/a",
+  "engines": {
+    "node": ">=14"
+  },
   "scripts": {
     "dev-next": "tinacms server:start --noTelemetry -c \"next\" ",
     "dev": "yarn dev-next",


### PR DESCRIPTION
- add optional parameters section to the cli-overview
- add engines >= 14 to the package.json since next-sitemap requires node >= 14