### PR TITLE
doc: update tina-cloud data layer page to latest status

### DIFF
--- a/content/docs/tina-cloud/data-layer.md
+++ b/content/docs/tina-cloud/data-layer.md
@@ -7,12 +7,12 @@ last_edited: '2022-02-15T20:00:00.000Z'
 
 Tina Cloud now supports an optional Data Layer which implements a database layer between the Tina GraphQL API and the
 GitHub REST API. This data layer buffers requests between Tina Cloud and GitHub resulting in improved editing
-performance with TinaCMS. As this feature evolves, it will provide additional capabilities such as:
-- more sophisticated GraphQL queries
+performance with TinaCMS. It also enables additional capabilities such as:
+
+- [sorting](/docs/graphql/queries/advanced/sorting/)
+- [filtering](/docs/graphql/queries/advanced/filter-documents/)
+- [pagination](/docs/graphql/queries/advanced/pagination/)
 - referential integrity
-- sorting
-- filtering
-- pagination 
 
 # Enabling the Data Layer
 


### PR DESCRIPTION
# what

quick update to the tina-cloud data layer doc to remove the "coming soon" verbiage and link to the data query pages