### PR TITLE
docs: make ssg agnostic from hugo

### DIFF
--- a/content/guides/tinacms/non-react-based-ssg/guide.md
+++ b/content/guides/tinacms/non-react-based-ssg/guide.md
@@ -9,9 +9,9 @@ Tina's "contextual editing" features require a React-based site, however Tina ca
 
 > ⚠️ **This support is still very much experimental**, and we hope to have a more streamlined onboarding in the future.
 
-While this should work with any Markdown/JSON-based site, this guide specifically refers to a Hugo project.
+This guide should work with any Markdown/JSON-based site: E.g: Hugo, GatsbyJS, Astro, Jekyll, 11ty, Gridsome, etc.
 
-If you don't already have a Hugo site setup, you can [learn how to create one here](https://gohugo.io/getting-started/quick-start/)
+If you don't already have a site setup, you can quicky setup a [Hugo site here](https://gohugo.io/getting-started/quick-start/)
 
 ## Tina Scaffolding Setup
 
@@ -146,7 +146,9 @@ Build the site locally with
 cd tina-admin && yarn build
 ```
 
-This will output Tina's static admin page to the site's static directory.
+This will output Tina's static admin page to the site's `/static` directory.
+
+> Note, the `/static` directory is used by many SSG's to serve static content (e.g Hugo, GatsbyJS, etc), but this output location can be configured via `outDir` in `/tina-admin/vite.config.js`.
 
 Once that is built, **push everything up to git (including the newly built admin)**
 

--- a/content/guides/tinacms/non-react-based-ssg/guide.md
+++ b/content/guides/tinacms/non-react-based-ssg/guide.md
@@ -35,7 +35,7 @@ Enter the following values into the newly generated package.json:
 
 ```json
 {
-  "name": "hugo-site",
+  "name": "my-tina-content-api",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
@@ -46,7 +46,7 @@ Enter the following values into the newly generated package.json:
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@tinacms/cli": "^0.60.15"
+    "@tinacms/cli": "0.60.12"
   }
 }
 ```
@@ -78,7 +78,7 @@ You can try running the following query in altair to confirm that your Tina sche
 
 ```graphql
 {
-  postConnection {
+  getPostList {
     pageInfo {
       hasPreviousPage
       hasNextPage
@@ -87,8 +87,12 @@ You can try running the following query in altair to confirm that your Tina sche
     }
     totalCount
     edges {
+      cursor
       node {
-        title
+        data {
+          title
+          body
+        }
       }
     }
   }


### PR DESCRIPTION
The SSG guide broke recently with the changes to extending tina (where you now have to pass schema into tina). I pinned tina to an older version for now.