### PR TITLE
doc: explicitly mention cli flag and link to doc on all data layer query pages

### DIFF
--- a/content/docs/graphql/queries/advanced/filter-documents.md
+++ b/content/docs/graphql/queries/advanced/filter-documents.md
@@ -4,7 +4,7 @@ id: /docs/graphql/queries/advanced/filter-documents
 next: /docs/graphql/queries/advanced/sorting
 ---
 
-{{ WarningCallout text="This is an experimental feature, and the API is subject to change. We don't yet suggest using this for production use-cases. Have any thoughts? Let us know in the chat, or through the [GitHub discussion](https://github.com/tinacms/tinacms/discussions/2811)!" }}
+{{ WarningCallout text="This is an experimental feature, and the API is subject to change. We don't yet suggest using this for production use-cases. The `--experimentalData` cli flag must be specified in order to enable this feature. Visit this [page](/docs/tina-cloud/data-layer/#enabling-the-data-layer) for more details. Have any thoughts? Let us know in the chat, or through the [GitHub discussion](https://github.com/tinacms/tinacms/discussions/2811)!" }}
 
 Tina automatically creates filters for collections defined in your schema.
 

--- a/content/docs/graphql/queries/advanced/limitations.md
+++ b/content/docs/graphql/queries/advanced/limitations.md
@@ -3,7 +3,7 @@ title: Query limitations
 id: /docs/graphql/queries/advanced/limitations
 next: /docs/graphql/queries/update-document
 ---
-{{ WarningCallout text="This is an experimental feature, and the API is subject to change. We don't yet suggest using this for production use-cases. Have any thoughts? Let us know in the chat, or through the [GitHub discussion](https://github.com/tinacms/tinacms/discussions/2811)!" }}
+{{ WarningCallout text="This is an experimental feature, and the API is subject to change. We don't yet suggest using this for production use-cases. The `--experimentalData` cli flag must be specified in order to enable this feature. Visit this [page](/docs/tina-cloud/data-layer/#enabling-the-data-layer) for more details. Have any thoughts? Let us know in the chat, or through the [GitHub discussion](https://github.com/tinacms/tinacms/discussions/2811)!" }}
 
 There are a number of limitations to keep in mind when leveraging query functionality with the data layer.
 

--- a/content/docs/graphql/queries/advanced/pagination.md
+++ b/content/docs/graphql/queries/advanced/pagination.md
@@ -4,7 +4,7 @@ id: /docs/graphql/queries/advanced/pagination
 next: /docs/graphql/queries/advanced/performance
 ---
 
-{{ WarningCallout text="This is an experimental feature, and the API is subject to change. We don't yet suggest using this for production use-cases. Have any thoughts? Let us know in the chat, or through the [GitHub discussion](https://github.com/tinacms/tinacms/discussions/2811)!" }}
+{{ WarningCallout text="This is an experimental feature, and the API is subject to change. We don't yet suggest using this for production use-cases. The `--experimentalData` cli flag must be specified in order to enable this feature. Visit this [page](/docs/tina-cloud/data-layer/#enabling-the-data-layer) for more details. Have any thoughts? Let us know in the chat, or through the [GitHub discussion](https://github.com/tinacms/tinacms/discussions/2811)!" }}
 
 Collection queries implement cursor based pagination. The client specifies a result limit parameter (using `first` or `last`) and a corresponding cursor parameter (using `after` or `before`) which is a pointer to the last item on the previous page of results.
 

--- a/content/docs/graphql/queries/advanced/performance.md
+++ b/content/docs/graphql/queries/advanced/performance.md
@@ -3,7 +3,7 @@ title: Query performance
 id: /docs/graphql/queries/advanced/performance
 next: /docs/graphql/queries/advanced/limitations
 ---
-{{ WarningCallout text="This is an experimental feature, and the API is subject to change. We don't yet suggest using this for production use-cases. Have any thoughts? Let us know in the chat, or through the [GitHub discussion](https://github.com/tinacms/tinacms/discussions/2811)!" }}
+{{ WarningCallout text="This is an experimental feature, and the API is subject to change. We don't yet suggest using this for production use-cases. The `--experimentalData` cli flag must be specified in order to enable this feature. Visit this [page](/docs/tina-cloud/data-layer/#enabling-the-data-layer) for more details. Have any thoughts? Let us know in the chat, or through the [GitHub discussion](https://github.com/tinacms/tinacms/discussions/2811)!" }}
 
 The GraphQL API indexes on collection fields to provide sorted results when using the `sort` parameter. If a `filter` is specified, the existence of an index can have a large impact on how quickly a query executes.
 

--- a/content/docs/graphql/queries/advanced/sorting.md
+++ b/content/docs/graphql/queries/advanced/sorting.md
@@ -4,7 +4,7 @@ id: /docs/graphql/queries/advanced/sorting
 next: /docs/graphql/queries/advanced/pagination
 ---
 
-{{ WarningCallout text="This is an experimental feature, and the API is subject to change. We don't yet suggest using this for production use-cases. Have any thoughts? Let us know in the chat, or through the [GitHub discussion](https://github.com/tinacms/tinacms/discussions/2811)!" }}
+{{ WarningCallout text="This is an experimental feature, and the API is subject to change. We don't yet suggest using this for production use-cases. The `--experimentalData` cli flag must be specified in order to enable this feature. Visit this [page](/docs/tina-cloud/data-layer/#enabling-the-data-layer) for more details. Have any thoughts? Let us know in the chat, or through the [GitHub discussion](https://github.com/tinacms/tinacms/discussions/2811)!" }}
 
 To sort collection results by a collection field, pass the `sort` argument to the `<collection>Connection` query, with the value corresponding to the desired collection field to sort by. Results are returned in ascending order.
 

--- a/content/docs/graphql/queries/query-documents.md
+++ b/content/docs/graphql/queries/query-documents.md
@@ -4,9 +4,7 @@ id: /docs/graphql/queries/query-documents
 next: /docs/graphql/queries/advanced/filter-documents
 ---
 
-List queries offer limited functionality for now. Depending on how many items you may have in your collection, the query could be quite slow.
-
-To improve query performance, as well as utilize [filtering](/docs/graphql/queries/advanced/filter-documents), [sorting](/docs/graphql/queries/advanced/sorting), and [pagination](/docs/graphql/queries/advanced/pagination), we recommend [enabling](/docs/tina-cloud/data-layer/#enabling-the-data-layer) the experimental data layer.
+List queries offer limited functionality for now. Depending on how many items you may have in your collection, the query could be quite slow. To improve query performance and enable [filtering](/docs/graphql/queries/advanced/filter-documents), [sorting](/docs/graphql/queries/advanced/sorting), and [pagination](/docs/graphql/queries/advanced/pagination), we recommend activating the experimental data layer with the `--experimentalData` cli flag. Visit this [page](/docs/tina-cloud/data-layer/#enabling-the-data-layer) for more details.
 
 ## Example
 


### PR DESCRIPTION
This makes it more explicit that the data layer cli flag must be enabled for the advanced query capabilities

<img width="852" alt="Screen Shot 2022-05-03 at 09 44 05" src="https://user-images.githubusercontent.com/370955/166464470-af772441-8e1a-4c16-a48e-670d667236bf.png">

