### PR TITLE
move playgrounds to external links

### DIFF
--- a/content/docs/reference/types/object.md
+++ b/content/docs/reference/types/object.md
@@ -16,7 +16,9 @@ type ObjectField = {
   list?: boolean
   /** See https://tina.io/docs/extending-tina/overview/ for customizing the UI **/
   ui?: {
-   itemProps?(item: Record<string, any>): {
+    itemProps?(
+      item: Record<string, any>
+    ): {
       label?: string
     }
   }
@@ -29,10 +31,10 @@ type ObjectField = {
 
 > Note: you can set `defaultItem` to auto-populate new items as they're added
 
-<iframe width="100%" height="700px" src="https://tina-gql-playground.vercel.app/iframe/object-list-data" />
+<a href="https://tina-gql-playground.vercel.app/object-list-data" target="_blank">See Example</a>
 
 ### With multiple `templates`
 
 If you always want your object to have the same fields, use the `fields` property. But if an object can be one of any different shape, define them as `templates`.
 
-<iframe width="100%" height="700px" src="https://tina-gql-playground.vercel.app/iframe/object-list-templates" />
+<a href="https://tina-gql-playground.vercel.app/object-list-templates" target="_blank">See Example</a>

--- a/content/docs/reference/types/string.md
+++ b/content/docs/reference/types/string.md
@@ -41,46 +41,46 @@ type StringField = {
 
 Specifying an `options` array will provide a selection list
 
-<iframe width="100%" height="450px" src="https://tina-gql-playground.vercel.app/iframe/string-options" />
+<a href="https://tina-gql-playground.vercel.app/string-options" target="_blank">See Example</a>
 
 ### As a `list`
 
 Setting `list: true` will make the value an array
 
-<iframe width="100%" height="450px" src="https://tina-gql-playground.vercel.app/iframe/string-list" />
+<a href="https://tina-gql-playground.vercel.app/string-list" target="_blank">See Example</a>
 
 ### As a `list` with `options`
 
 Setting `list: true` and providing `options` will make the value an array with a selection list
 
-<iframe width="100%" height="450px" src="https://tina-gql-playground.vercel.app/iframe/string-list-options" />
+<a href="https://tina-gql-playground.vercel.app/string-list-options" target="_blank">See Example</a>
 
 ## The `isBody` property
 
 When working with markdown, you can indicate that a given field should repesent the markdown body
 
-<iframe width="100%" height="450px" src="https://tina-gql-playground.vercel.app/iframe/string-body" />
+<a href="https://tina-gql-playground.vercel.app/string-body" target="_blank">See Example</a>
 
 ## Overriding the component
 
 By default, the `text` field is used for strings. To use a different core field plugin, specify it with the `ui.component` property
 
-<iframe width="100%" height="450px" src="https://tina-gql-playground.vercel.app/iframe/string-textarea" />
+<a href="https://tina-gql-playground.vercel.app/iframe/string-textarea" target="_blank">See Example</a>
 
 ## Providing a custom component
 
 You can [create your own components](/docs/extending-tina/custom-field-components/)
 
-<iframe width="100%" height="450px" src="https://tina-gql-playground.vercel.app/string-component" />
+<a href="https://tina-gql-playground.vercel.app/string-component" target="_blank">See Example</a>
 
 ## Providing validation
 
 You can provide a [validation function](/docs/extending-tina/validation/) for frontend validation
 
-<iframe width="100%" height="450px" src="https://tina-gql-playground.vercel.app/validation" />
+<a href="https://tina-gql-playground.vercel.app/validation" target="_blank">See Example</a>
 
 ## Format and parse
 
 You can provide [custom format and parse functions](/docs/extending-tina/format-and-parse/) to a string field
 
-<iframe width="100%" height="450px" src="https://tina-gql-playground.vercel.app/string-format-parse" />
+<a href="https://tina-gql-playground.vercel.app/string-format-parse" target="_blank">See Example</a>

--- a/content/docs/schema.md
+++ b/content/docs/schema.md
@@ -60,7 +60,7 @@ This is my main post body.
 
 Once we've defined a collection, we can edit its fields through the Tina UI, or [query its content](/docs/graphql/overview/) using the Tina Content API.
 
-<iframe width="100%" height="450px" src="https://tina-gql-playground.vercel.app/string-body" />
+<iframe width="100%" height="450px" src="https://tina-gql-playground.vercel.app/iframe/string-body" />
 
 ## "List" fields
 

--- a/content/docs/schema.md
+++ b/content/docs/schema.md
@@ -60,7 +60,7 @@ This is my main post body.
 
 Once we've defined a collection, we can edit its fields through the Tina UI, or [query its content](/docs/graphql/overview/) using the Tina Content API.
 
-<iframe width="100%" height="450px" src="https://tina-gql-playground.vercel.app/iframe/string-body" />
+<iframe width="100%" height="450px" src="https://tina-gql-playground.vercel.app/string-body" />
 
 ## "List" fields
 
@@ -78,7 +78,7 @@ fields: [
 ]
 ```
 
-<iframe width="100%" height="450px" src="https://tina-gql-playground.vercel.app/iframe/string-list" />
+<a href="https://tina-gql-playground.vercel.app/string-list" target="_blank">See Example</a>
 
 ## Limiting values to a set of options
 
@@ -106,7 +106,7 @@ fields: [
 ]
 ```
 
-<iframe width="100%" height="450px" src="https://tina-gql-playground.vercel.app/iframe/string-list-options" />
+<a href="https://tina-gql-playground.vercel.app/string-list-options" target="_blank">See Example</a>
 
 > Omitting `list: true` (or setting it to `false`) would result in a single-select `radio` field.
 
@@ -146,11 +146,11 @@ fields: [
 // ...
 ```
 
-<iframe width="100%" height="700px" src="https://tina-gql-playground.vercel.app/iframe/object" />
+<a href="https://tina-gql-playground.vercel.app/object" target="_blank">See Example</a>
 
 Setting `list: true` would turn the values into an array:
 
-<iframe width="100%" height="700px" src="https://tina-gql-playground.vercel.app/iframe/object-list-data" />
+<a href="https://tina-gql-playground.vercel.app/object-list-data" target="_blank">See Example</a>
 
 > More complex shapes can be built by using the [`templates`](/docs/reference/types/object/#with-multiple-templates) property. This allows your editors to build out pages using predefined blocks.
 
@@ -172,7 +172,7 @@ fields: [
 //
 ```
 
-<iframe width="100%" height="450px" src="https://tina-gql-playground.vercel.app/iframe/reference" />
+<a href="https://tina-gql-playground.vercel.app/reference" target="_blank">See Example</a>
 
 ## Available data types
 


### PR DESCRIPTION
Our playgrounds are pretty heavy browser loads, so pages that feature multiple playgrounds should instead link to external pages