### PR TITLE
Adds info about `waitForDB` command to `cli` overview

### DIFF
--- a/content/docs/cli-overview.md
+++ b/content/docs/cli-overview.md
@@ -10,16 +10,17 @@ title: The TinaCMS CLI
 Usage: @tinacms/cli command [options]
 
 Options:
-  -V, --version             output the version number
-  -h, --help                display help for command
+  -V, --version               output the version number
+  -h, --help                  display help for command
 
 Commands:
-  server:start [options]    Start Filesystem Graphql Server
-  schema:compile [options]  Compile schema into static files for the server
-  schema:types [options]    Generate a GraphQL query for your site's schema, (and optionally Typescript types)
-  init [options]            Add Tina Cloud to an existing project
-  audit [options]           Audit your schema and the files to check for errors
-  help [command]            display help for command
+  server:start [options]      Start Filesystem Graphql Server
+  server:waitForDB [options]  Wait for DB to finish indexing, start subprocess
+  schema:compile [options]    Compile schema into static files for the server
+  schema:types [options]      Generate a GraphQL query for your site's schema, (and optionally Typescript types)
+  init [options]              Add Tina Cloud to an existing project
+  audit [options]             Audit your schema and the files to check for errors
+  help [command]              display help for command
 ```
 
 ## Basic Usage:
@@ -42,11 +43,12 @@ This will,
 
 #### Optional parameters
 
-| Argument                    | Description                                                                              |
-|-----------------------------|------------------------------------------------------------------------------------------|
-| `--experimentalData`        | Enables the experimental [data layer](/docs/tina-cloud/data-layer/)                      |
-| `--noTelemetry`             | Disables Open Source Telemetry                                                           |
-| `--schemaFileType`          | Overrides default Tina schema file type. Valid values are: `.ts`, `.tsx`, `.js`, `.jsx`  |
+| Argument             | Description                                                                             |
+| -------------------- | --------------------------------------------------------------------------------------- |
+| `--experimentalData` | Enables the experimental [data layer](/docs/tina-cloud/data-layer/)                     |
+| `--noTelemetry`      | Disables Open Source Telemetry                                                          |
+| `--schemaFileType`   | Overrides default Tina schema file type. Valid values are: `.ts`, `.tsx`, `.js`, `.jsx` |
+| `--dev`              | Sets NODE_ENV=`development`, defaults to `production`                                   |
 
 ### `tinacms server:start`
 
@@ -87,3 +89,9 @@ Takes the following options,
 | Argument  | Description                                                                                                                                                                                                                                                             |
 | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--clean` | When this flag is used, it really submits the Graphql mutations to the file system. This means that it will clean out any fields that are not defined in your `schema.ts`. It is a good practice to do a `git commit` before doing this so one can undo changes easily. |
+
+### `tinacms server:waitForDB` (Experimental)
+
+> To run this command, you must have a valid `.tina/client.ts` file.
+
+For sites with Tina Cloud configured and `--experimentalData` enabled, `server:waitForDB` will block startup until the data layer's indexing process responds with `complete` or `failed`. For `complete`, any subprocess will be run. For `failed`, an error message will be displayed and startup will exit.

--- a/content/docs/cli-overview.md
+++ b/content/docs/cli-overview.md
@@ -92,6 +92,8 @@ Takes the following options,
 
 ### `tinacms server:waitForDB` (Experimental)
 
-> To run this command, you must have a valid `.tina/client.ts` file.
+> To run this command, you must have a valid `.tina/client.ts` file.  [Read here](/docs/graphql/read-only-tokens/#making-requests-with-the-tina-client) to learn how to create one.
 
 For sites with Tina Cloud configured and `--experimentalData` enabled, `server:waitForDB` will block startup until the data layer's indexing process responds with `complete` or `failed`. For `complete`, any subprocess will be run. For `failed`, an error message will be displayed and startup will exit.
+
+> [Read here](https://tina.io/docs/tina-cloud/data-layer/#indexing) to learn more about indexing.

--- a/content/docs/tina-cloud/data-layer.md
+++ b/content/docs/tina-cloud/data-layer.md
@@ -42,8 +42,9 @@ scenarios are:
 
 There are some issues to be aware of when using the data layer: 
 
-- The status of the indexing process is not currently exposed to the end user, so it is possible for an editor to access
-a partially indexed site, in which case any queries may return with incomplete results.
+- We offer a server command to poll for the status of indexing: `server:waitForDB`.  When using `server:start`, `server:waitForDB` is automatically called if you have configured `client.ts`.
+  - You can learn more about `server:waitForDB` [here](/docs/cli-overview/#tinacms-serverwaitfordb-experimental).
+
 - Since the GitHub API currently only allows 5,000 requests per repository per hour, any repositories with large numbers
 of items may not be able to complete indexing before hitting the limit. For this reason, this feature should not be
 activated for repositories with more than 1000-1500 items.


### PR DESCRIPTION
**Needs https://github.com/tinacms/tinacms/pull/2919 is released**

With `waitForDB`, we've added one new command `server:waitForDB` and a new option `--dev`.
https://tinacms-site-next-git-feat-add-info-about-waitfordb-cmd-tinacms.vercel.app/docs/cli-overview/

Closes https://github.com/tinacms/product-roadmap/issues/156

### General Contributing:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/tinacms/tinacms.org/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- For non content related updates, or fixing things like typos, you can erase the following section -->

### All New Content Submissions: (To be confirmed by reviewer)

* [ ] Title is short & specific
* [ ] Headers are logically ordered & consistent
* [ ] Purpose of document is explained in the first paragraph
* [ ] Procedures are tested and work
* [ ] Any technical concepts are explained or linked to
* [ ] Document follows structure from templates
* [ ] All links work
* [ ] Spelling and grammer checker has been run
* [ ] Graphics and images are clear and useful
* [ ] Any prerequisites and next steps are defined.
