### PR TITLE
Improves reference docs with example

### DIFF
--- a/content/docs/reference/types/reference.md
+++ b/content/docs/reference/types/reference.md
@@ -5,6 +5,10 @@ last_edited: '2021-07-27T15:51:56.737Z'
 
 # `reference`
 
+The `reference` field allows a document to connect to another in another `collection`.  This relationship only needs to be defined on *one side*.
+
+Once defined, the values of the *referenced* document become available to the parent.
+
 ```ts
 type ReferenceField = {
   label: string
@@ -25,6 +29,68 @@ type ReferenceField = {
       meta: any,
       field: UIField<F, Shape>
     ): string | undefined | void
+  }
+}
+```
+
+## Example
+
+Given the following schema:
+
+```ts
+const schema = defineSchema({
+  collections: [
+    {
+      label: "Blog Posts",
+      name: "post",
+      path: "content/posts",
+      format: "md",
+      fields: [
+        {
+          type: "string",
+          label: "Title",
+          name: "title",
+        },
+        {
+          type: "reference",
+          label: "Author",
+          name: "postAuthor",
+          collections: ['author'],
+        },
+      ],
+    },
+    {
+      label: "Authors",
+      names: "author",
+      path: "content/authors",
+      format: "md",
+      fields: [
+        {
+          type: "string",
+          label: "Name",
+          name: "name",
+        }
+      ],
+    }
+  ]
+})
+```
+
+The `post` collection has a `reference` field to the `author` collection.
+
+When editing in Tina, the user will be able to choose a document in the `author` collection for the value of `postAuthor`.
+
+When querying for a `post` document, the `postAuthor` in the response will contain the values of the *referenced* document:
+
+```graphql
+{
+  post(relativePath: "myBlogPost.md") {
+    title
+    postAuthor {
+      ... on Author {
+        name
+      }
+    }
   }
 }
 ```

--- a/content/docs/reference/types/reference.md
+++ b/content/docs/reference/types/reference.md
@@ -74,7 +74,7 @@ The `post` collection has a `reference` field to the `author` collection.
 
 When editing in Tina, the user will be able to choose a document in the `author` collection for the value of `author`.
 
-When querying for a `post` document, the `author` key in the response will contain the values of the *referenced* document:
+When querying for a `post` document, the `author` key in the response will contain the values of the *referenced* `author` document:
 
 ```graphql
 {

--- a/content/docs/reference/types/reference.md
+++ b/content/docs/reference/types/reference.md
@@ -5,7 +5,7 @@ last_edited: '2021-07-27T15:51:56.737Z'
 
 # `reference`
 
-The `reference` field allows a document to connect to another in another collection.  This relationship only needs to be defined on *one side*.
+The `reference` field allows a "parent" document to connect to another document in different collection.  This relationship only needs to be defined on *one side*.
 
 Once defined, the values of the *referenced* document become available to the parent.
 

--- a/content/docs/reference/types/reference.md
+++ b/content/docs/reference/types/reference.md
@@ -36,7 +36,6 @@ type ReferenceField = {
 }
 ```
 
-> Note: `reference` with `list: true` is not currently supported
 
 ## Example
 

--- a/content/docs/reference/types/reference.md
+++ b/content/docs/reference/types/reference.md
@@ -5,7 +5,7 @@ last_edited: '2021-07-27T15:51:56.737Z'
 
 # `reference`
 
-The `reference` field allows a document to connect to another in another `collection`.  This relationship only needs to be defined on *one side*.
+The `reference` field allows a document to connect to another in another collection.  This relationship only needs to be defined on *one side*.
 
 Once defined, the values of the *referenced* document become available to the parent.
 
@@ -33,62 +33,55 @@ type ReferenceField = {
 }
 ```
 
+> Note: `reference` with `list: true` is not currently supported
+
 ## Example
 
 Given the following schema:
 
 ```ts
-const schema = defineSchema({
-  collections: [
-    {
-      label: "Blog Posts",
-      name: "post",
-      path: "content/posts",
-      format: "md",
-      fields: [
-        {
-          type: "string",
-          label: "Title",
-          name: "title",
-        },
-        {
-          type: "reference",
-          label: "Author",
-          name: "postAuthor",
-          collections: ['author'],
-        },
-      ],
-    },
-    {
-      label: "Authors",
-      names: "author",
-      path: "content/authors",
-      format: "md",
-      fields: [
-        {
-          type: "string",
-          label: "Name",
-          name: "name",
-        }
-      ],
-    }
-  ]
+export default defineSchema({
+  collections: [{
+    label: "Post",
+    name: "post",
+    path: "posts",
+    fields: [{
+      label: "Author",
+      name: "author",
+      type: "reference",
+      collections: ["author"]
+    }]
+  }, {
+    label: "Author",
+    name: "author",
+    path: "authors",
+    fields: [{
+      label: "Name",
+      name: "name",
+      type: "string",
+    }, {
+      label: "Avatar",
+      name: "avatar",
+      type: "string",
+    }]
+  }]
 })
 ```
 
 The `post` collection has a `reference` field to the `author` collection.
 
-When editing in Tina, the user will be able to choose a document in the `author` collection for the value of `postAuthor`.
+When editing in Tina, the user will be able to choose a document in the `author` collection for the value of `author`.
 
-When querying for a `post` document, the `postAuthor` in the response will contain the values of the *referenced* document:
+When querying for a `post` document, the `author` key in the response will contain the values of the *referenced* document:
 
 ```graphql
 {
   post(relativePath: "myBlogPost.md") {
     title
-    postAuthor {
+    author {
       ... on Author {
         name
+        avatar
       }
     }
   }
@@ -96,5 +89,3 @@ When querying for a `post` document, the `postAuthor` in the response will conta
 ```
 
 <iframe width="100%" height="450px" src="https://tina-gql-playground.vercel.app/iframe/reference" />
-
-> Note: `reference` with `list: true` is not currently supported

--- a/content/docs/reference/types/reference.md
+++ b/content/docs/reference/types/reference.md
@@ -9,6 +9,9 @@ The `reference` field allows a "parent" document to connect to another document 
 
 Once defined, the values of the *referenced* document become available to the parent.
 
+> Note: `reference` with `list: true` is not currently supported
+
+## Object Definition
 ```ts
 type ReferenceField = {
   label: string


### PR DESCRIPTION
Describes what the `reference` field is and includes an example of how to use it.

Before:
https://tina.io/docs/reference/types/reference/
After:
https://tinacms-site-next-git-feat-1330-improves-reference-docs-tinacms.vercel.app/docs/reference/types/reference/

Closes #1330 