### PR TITLE
[Docs update] Suggest workaround to create a list of references

### DIFF
--- a/content/docs/reference/types/reference.md
+++ b/content/docs/reference/types/reference.md
@@ -9,7 +9,7 @@ The `reference` field allows a "parent" document to connect to another document 
 
 Once defined, the values of the *referenced* document become available to the parent.
 
-> Note: `reference` with `list: true` is not currently supported
+> Note: `reference` with `list: true` is not currently supported. See the "Temporary work around" section of [issue #2056](https://github.com/tinacms/tinacms/issues/2056) for a suggested approach to achieve a similar result
 
 ## Object Definition
 ```ts


### PR DESCRIPTION
## Background

- See the discord discussion here: [Temporary work around](https://discord.com/channels/835168149439643678/991115358796775526/991464165506039981)
- See the original suggestion for the workaround raised by logan-anderson in this pull request: https://github.com/tinacms/tinacms/issues/2056
- See the following error page related to the fact images don't yet support the `list: true` option: https://tina.io/docs/errors/ui-not-supported/
    - that was added via PR #1038 

## Goal

To provide some extra context and a potential solution to the info banner that explains `list: true` is not currently supported on reference fields (at least, not in the frontend form UI)
